### PR TITLE
Addresses build problems

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
 
   build:
     runs-on: ubuntu-latest

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -30,9 +30,19 @@ pub trait CRD {
 /// # Example
 ///
 /// ```no_run
+/// # use stackable_operator::{CRD, create_client};
+/// #
+/// # struct Test;
+/// # impl CRD for Test {
+/// #    const RESOURCE_NAME: &'static str = "foo.bar.com";
+/// #    const CRD_DEFINITION: &'static str = "mycrdhere";
+/// # }
+/// #
+/// # async {
+/// # let client = create_client().await.unwrap();
 /// use stackable_operator::crd::exists;
-///
-/// exists::<Test>(client);
+/// exists::<Test>(client).await;
+/// # };
 /// ```
 pub async fn exists<T>(client: Client) -> Result<bool, error::Error>
 where

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,5 +20,4 @@ pub enum Error {
 
     #[error("Object is missing key: {key}")]
     MissingObjectKey { key: &'static str },
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub fn object_to_owner_reference<K: Meta>(meta: ObjectMeta) -> Result<OwnerRefer
 
 pub async fn patch_resource<T>(
     api: &Api<T>,
-    resource_name: &String,
+    resource_name: &str,
     resource: &T,
     field_manager: &str,
 ) -> Result<T, Error>


### PR DESCRIPTION
Github Actions fails because of duplicate features in clippy check and a bad doc test.

This happened because the first commit only added the Github Actions definition.