### PR TITLE
Introduce result type

### DIFF
--- a/src/crd.rs
+++ b/src/crd.rs
@@ -83,7 +83,7 @@ where
 /// It will return an error if the CRD already exists.
 /// If it returns successfully it does not mean that the CRD is fully established yet,
 /// just that it has been accepted by the apiserver.
-async fn create<T>(client: Client) -> Result<(), error::Error>
+async fn create<T>(client: Client) -> OperatorResult<()>
 where
     T: CRD,
 {

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,6 +1,7 @@
 use crate::error;
 
 use crate::client::Client;
+use crate::error::OperatorResult;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::error::ErrorResponse;
 use tracing::info;
@@ -44,7 +45,7 @@ pub trait CRD {
 /// exists::<Test>(client).await;
 /// # };
 /// ```
-pub async fn exists<T>(client: Client) -> Result<bool, error::Error>
+pub async fn exists<T>(client: Client) -> OperatorResult<bool>
 where
     T: CRD,
 {
@@ -64,7 +65,7 @@ where
 /// Currently this does not retry internally.
 /// This means that running it again _might_ work in case of transient errors.
 // TODO: Make sure to wait until it's enabled in the apiserver
-pub async fn ensure_crd_created<T>(client: Client) -> Result<(), error::Error>
+pub async fn ensure_crd_created<T>(client: Client) -> OperatorResult<()>
 where
     T: CRD,
 {

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -39,7 +39,7 @@ pub trait CRD {
 /// # }
 /// #
 /// # async {
-/// # let client = create_client().await.unwrap();
+/// # let client = create_client(Some("foo".to_string())).await.unwrap();
 /// use stackable_operator::crd::exists;
 /// exists::<Test>(client).await;
 /// # };

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,3 +21,5 @@ pub enum Error {
     #[error("Object is missing key: {key}")]
     MissingObjectKey { key: &'static str },
 }
+
+pub type OperatorResult<T> = std::result::Result<T, Error>;

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -26,7 +26,7 @@ where
             "finalizers": [finalizer.to_string()]
         }
     }))?;
-    client.patch(resource, new_metadata).await
+    client.merge_patch(resource, new_metadata).await
 }
 
 /// Removes our finalizer from a resource object.
@@ -66,7 +66,7 @@ where
                     }
                 }))?;
 
-                client.patch(resource, new_metadata).await
+                client.merge_patch(resource, new_metadata).await
             } else {
                 Err(Error::MissingObjectKey {
                     key: ".metadata.finalizers",

--- a/src/finalizer.rs
+++ b/src/finalizer.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, OperatorResult};
 
 use crate::client::Client;
 use kube::api::Meta;
@@ -17,7 +17,7 @@ where
 }
 
 /// Adds our finalizer to the list of finalizers.
-pub async fn add_finalizer<T>(client: Client, resource: &T, finalizer: &str) -> Result<T, Error>
+pub async fn add_finalizer<T>(client: Client, resource: &T, finalizer: &str) -> OperatorResult<T>
 where
     T: k8s_openapi::Resource + Clone + Meta + DeserializeOwned,
 {
@@ -34,7 +34,7 @@ where
 /// # Arguments
 /// `name` - is the name of the resource we want to patch
 /// `namespace` is the namespace of where the resource to patch lives
-pub async fn remove_finalizer<T>(client: Client, resource: &T, finalizer: &str) -> Result<T, Error>
+pub async fn remove_finalizer<T>(client: Client, resource: &T, finalizer: &str) -> OperatorResult<T>
 where
     T: Clone + DeserializeOwned + Meta,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ pub fn initialize_logging(level: tracing::Level) {
     tracing_subscriber::fmt().with_max_level(level).init();
 }
 
-pub async fn create_client() -> Result<client::Client, error::Error> {
-    Ok(client::Client::new(kube::Client::try_default().await?))
+pub async fn create_client(field_manager: Option<String>) -> Result<client::Client, error::Error> {
+    Ok(client::Client::new(
+        kube::Client::try_default().await?,
+        field_manager,
+    ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod finalizer;
 pub mod util;
 
 use crate::client::Client;
-use crate::error::Error;
+use crate::error::{Error, OperatorResult};
 pub use crd::CRD;
 use k8s_openapi::api::core::v1::{ConfigMap, Toleration};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
@@ -98,7 +98,7 @@ pub fn create_tolerations() -> Vec<Toleration> {
     ]
 }
 
-pub fn object_to_owner_reference<K: Meta>(meta: ObjectMeta) -> Result<OwnerReference, Error> {
+pub fn object_to_owner_reference<K: Meta>(meta: ObjectMeta) -> OperatorResult<OwnerReference> {
     Ok(OwnerReference {
         api_version: K::API_VERSION.to_string(),
         kind: K::KIND.to_string(),
@@ -117,7 +117,7 @@ pub async fn patch_resource<T>(
     resource_name: &str,
     resource: &T,
     field_manager: &str,
-) -> Result<T, Error>
+) -> OperatorResult<T>
 where
     T: Clone + Meta + DeserializeOwned + Serialize,
 {
@@ -139,7 +139,7 @@ pub fn create_config_map<T>(
     resource: &T,
     cm_name: &str,
     data: BTreeMap<String, String>,
-) -> Result<ConfigMap, Error>
+) -> OperatorResult<ConfigMap>
 where
     T: Meta,
 {
@@ -162,7 +162,7 @@ pub fn initialize_logging(level: tracing::Level) {
     tracing_subscriber::fmt().with_max_level(level).init();
 }
 
-pub async fn create_client(field_manager: Option<String>) -> Result<client::Client, error::Error> {
+pub async fn create_client(field_manager: Option<String>) -> OperatorResult<client::Client> {
     Ok(client::Client::new(
         kube::Client::try_default().await?,
         field_manager,


### PR DESCRIPTION
This introduces a "OperatorResult" type which uses our own Error type.
I decided to name it `OperatorResult` instead of reusing the `Result` name.
Personally, I find it confusing to have `Result` mean different things in different places and I tend to get confused.

This also replaces `map_err` with a different way to returning our errors.

This PR depends on #7 so that needs to be merged in first!