### PR TITLE
Adds a `delete` method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Lars Francke <lars.francke@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+either = "1.6"
 futures = "0.3"
 k8s-openapi = { version = "0.9.0", default-features = false, features = ["v1_18"] } # 1.19 and k8s-openapi 0.10 are not supported in kube 0.43 yet, they will be in the next released version
 kube = { version = "0.43", default-features = false, features = ["derive"] }


### PR DESCRIPTION
There are some things (like Pods) that return the object itself when delete is called, others return a `Status` object instead.
So we have to return an `Either` here and the client will have to know what to expect.