### PR TITLE
Checks for collisions on revision count and try with a new hash

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -93,12 +93,11 @@ where
         cr.metadata.name = Some(name);
 
         let result = client.create(&cr).await;
-        match k8s_errors::is_already_exists(&result) {
-            true => {
-                collision_count += 1;
-                continue;
-            }
-            false => return result,
+        if k8s_errors::is_already_exists(&result) {
+            collision_count += 1;
+            continue;
+        } else {
+            return result;
         }
     }
 }

--- a/src/k8s_errors.rs
+++ b/src/k8s_errors.rs
@@ -1,0 +1,102 @@
+use crate::error;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum StatusReason {
+    /// AlreadyExists means the resource you are creating already exists.
+    /// Details (optional):
+    ///   "kind" string - the kind attribute of the conflicting resource
+    ///   "id"   string - the identifier of the conflicting resource
+    /// Status code 409
+    AlreadyExists,
+}
+
+impl FromStr for StatusReason {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AlreadyExists" => Ok(StatusReason::AlreadyExists),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Returns a reason for an error if there is one.
+/// The error may occur for any status reasons that are unknown.
+pub fn reason_for_error<T>(result: &Result<T, error::Error>) -> Option<StatusReason> {
+    match result {
+        Err(error::Error::KubeError {
+            source: kube::Error::Api(error),
+        }) => match error.reason.parse() {
+            Ok(reason) => Some(reason),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns true if the passed result indicates an API error with the reason `AlreadyExists`
+pub fn is_already_exists<T>(result: &Result<T, error::Error>) -> bool {
+    matches!(reason_for_error(result), Some(StatusReason::AlreadyExists))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error;
+    use crate::k8s_errors::{is_already_exists, reason_for_error, StatusReason};
+    use kube::error::ErrorResponse;
+
+    #[test]
+    fn test_reason_for_error() {
+        let result = Ok(123);
+        assert_eq!(true, matches!(reason_for_error(&result), None));
+
+        let result: Result<(), error::Error> = Err(error::Error::KubeError {
+            source: kube::error::Error::RequestSend,
+        });
+        assert_eq!(true, matches!(reason_for_error(&result), None));
+
+        let result: Result<(), error::Error> = Err(error::Error::KubeError {
+            source: kube::error::Error::Api(ErrorResponse {
+                status: "".to_string(),
+                message: "".to_string(),
+                reason: "Foobar".to_string(),
+                code: 0,
+            }),
+        });
+        let result_2 = reason_for_error(&result);
+        assert_eq!(true, matches!(result_2, None), "Got: [{:?}]", result_2);
+
+        let result: Result<(), error::Error> = Err(error::Error::KubeError {
+            source: kube::error::Error::Api(ErrorResponse {
+                status: "".to_string(),
+                message: "".to_string(),
+                reason: "AlreadyExists".to_string(),
+                code: 0,
+            }),
+        });
+        let result_2 = reason_for_error(&result);
+        assert_eq!(
+            true,
+            matches!(result_2, Some(StatusReason::AlreadyExists)),
+            "Got: [{:?}]",
+            result_2
+        );
+    }
+
+    #[test]
+    fn test_is_already_exists() {
+        assert_eq!(is_already_exists(&Ok(123)), false);
+
+        let result: Result<(), error::Error> = Err(error::Error::KubeError {
+            source: kube::error::Error::Api(ErrorResponse {
+                status: "".to_string(),
+                message: "".to_string(),
+                reason: "AlreadyExists".to_string(),
+                code: 0,
+            }),
+        });
+        assert_eq!(is_already_exists(&result), true);
+    }
+}

--- a/src/k8s_errors.rs
+++ b/src/k8s_errors.rs
@@ -50,12 +50,12 @@ mod tests {
     #[test]
     fn test_reason_for_error() {
         let result = Ok(123);
-        assert_eq!(true, matches!(reason_for_error(&result), None));
+        assert!(matches!(reason_for_error(&result), None));
 
         let result: Result<(), error::Error> = Err(error::Error::KubeError {
             source: kube::error::Error::RequestSend,
         });
-        assert_eq!(true, matches!(reason_for_error(&result), None));
+        assert!(matches!(reason_for_error(&result), None));
 
         let result: Result<(), error::Error> = Err(error::Error::KubeError {
             source: kube::error::Error::Api(ErrorResponse {
@@ -66,7 +66,11 @@ mod tests {
             }),
         });
         let result_2 = reason_for_error(&result);
-        assert_eq!(true, matches!(result_2, None), "Got: [{:?}]", result_2);
+        assert!(
+            matches!(result_2, None),
+            "Got [{:?}] expected [None]",
+            result_2
+        );
 
         let result: Result<(), error::Error> = Err(error::Error::KubeError {
             source: kube::error::Error::Api(ErrorResponse {
@@ -77,17 +81,16 @@ mod tests {
             }),
         });
         let result_2 = reason_for_error(&result);
-        assert_eq!(
-            true,
+        assert!(
             matches!(result_2, Some(StatusReason::AlreadyExists)),
-            "Got: [{:?}]",
+            "Got [{:?}] expected [Some(StatusReason::AlreadyExists)]",
             result_2
         );
     }
 
     #[test]
     fn test_is_already_exists() {
-        assert_eq!(is_already_exists(&Ok(123)), false);
+        assert!(!is_already_exists(&Ok(123)));
 
         let result: Result<(), error::Error> = Err(error::Error::KubeError {
             source: kube::error::Error::Api(ErrorResponse {
@@ -97,6 +100,6 @@ mod tests {
                 code: 0,
             }),
         });
-        assert_eq!(is_already_exists(&result), true);
+        assert!(is_already_exists(&result));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod crd;
 pub mod error;
 pub mod finalizer;
 pub mod history;
+pub mod k8s_errors;
 pub mod podutils;
 
 use crate::client::Client;


### PR DESCRIPTION
So far the same "spec" would lead to the same hash which would lead to the same K8S object name which in turn would lead to an "AlreadyExists" error.

This can easily happen if someone changes a spec option and then later reverts that change.

This introduces a collision count which is added to the hash. The idea here is from how StatefulSets operate but I'm sure I don't implement it 100% compatible, I don't think I need to either.