### PR TITLE
Error policy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ pub async fn create_client(field_manager: Option<String>) -> OperatorResult<clie
 /// We just log the error and requeue the event after a configurable amount of time
 ///
 /// # Example
-/// ```no_run
+/// ```ignore
 /// use std::time::Duration;
 /// use stackable_operator::requeueing_error_policy;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ pub async fn create_client(field_manager: Option<String>) -> OperatorResult<clie
 /// We just log the error and requeue the event after a configurable amount of time
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// use std::time::Duration;
 /// use stackable_operator::requeueing_error_policy;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,9 @@ pub async fn create_client(field_manager: Option<String>) -> OperatorResult<clie
     ))
 }
 
-/// This method returns a closure which can be used as an `error_policy`  is being called by the Controller whenever there's an error during reconciliation.
-/// We just log the error and requeue the event after a configurable amount of time
+/// This method returns a closure which can be used as an `error_policy` by the [Controller](kube_runtime::Controller).
+/// The returned method will be called whenever there's an error during reconciliation.
+/// It just logs the error and requeues the event after a configurable amount of time
 ///
 /// # Example
 /// ```ignore


### PR DESCRIPTION
The kube controller class requires an error_policy function that handles andy errors during reconciliations.
This adds a very simple requeueing error policy.