### PR TITLE
Merge test & build step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Run Test Suite
+  build:
+    name: Run tests and create release build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,17 +23,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-
-  build:
-    name: Run Release build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
It probably makes more sense to run the release build only when the tests finished successfully.
Should we want to publish nightly builds this probably makes sense.