### PR TITLE
This filters pods by owner reference of the current object.

### DIFF
--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -127,10 +127,7 @@ where
 /// If however the `uid` exists and matches we return `true`.
 fn pod_owned_by(pod: &Pod, owner_uid: &str) -> bool {
     let controller = controller_ref::get_controller_of(pod);
-    match controller {
-        Some(OwnerReference { uid, .. }) if uid == owner_uid => true,
-        _ => false,
-    }
+    matches!(controller, Some(OwnerReference { uid, .. }) if uid == owner_uid)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is related to #55 which talks about using labels.
That, however, requires everyone to actually set labels so this is a first leightweight approach that fixes the issue itself but not the performance implications of fetching all pods and then filtering on the client side.