### PR TITLE
fix: object_to_owner_reference now sets the controller flag.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ use crate::error::OperatorResult;
 
 pub use crd::Crd;
 use k8s_openapi::api::core::v1::{ConfigMap, Toleration};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{Meta, ObjectMeta};
 use std::collections::BTreeMap;
 use tracing_subscriber::EnvFilter;
@@ -92,10 +91,9 @@ where
         metadata: ObjectMeta {
             name: Some(String::from(cm_name)),
             namespace: Meta::namespace(resource),
-            owner_references: Some(vec![OwnerReference {
-                controller: Some(true),
-                ..metadata::object_to_owner_reference::<T>(resource.meta().clone())?
-            }]),
+            owner_references: Some(vec![metadata::object_to_owner_reference::<T>(
+                resource.meta().clone(),
+            )?]),
             ..ObjectMeta::default()
         },
         ..ConfigMap::default()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -31,6 +31,8 @@ where
     })
 }
 
+/// Creates an OwnerReference pointing to the resource type and `metadata` being passed in.
+/// The created OwnerReference has it's `controller` flag set to `true`
 pub fn object_to_owner_reference<K: Resource>(meta: ObjectMeta) -> OperatorResult<OwnerReference> {
     Ok(OwnerReference {
         api_version: K::API_VERSION.to_string(),
@@ -41,6 +43,7 @@ pub fn object_to_owner_reference<K: Resource>(meta: ObjectMeta) -> OperatorResul
         uid: meta.uid.ok_or(Error::MissingObjectKey {
             key: ".metadata.uid",
         })?,
+        controller: Some(true),
         ..OwnerReference::default()
     })
 }


### PR DESCRIPTION
This was set to false by default which was a bit surprising. We're only using it in a context where we're the controller as well. If we ever need to we can introduce a parameter to say whether it should be set or not but for now we'll just change the default.