### PR TITLE
Optionally set the block_owner_deletion flag in OwnerReferences for automatic cleanup

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -79,6 +79,7 @@ where
             namespace: Meta::namespace(parent),
             owner_references: Some(vec![metadata::object_to_owner_reference::<T>(
                 parent.meta().clone(),
+                true,
             )?]),
             ..ObjectMeta::default()
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,9 @@ pub fn create_tolerations() -> Vec<Toleration> {
     ]
 }
 
-/// Creates a ConfigMap
+/// Creates a ConfigMap.
+/// This ConfigMap has its `block_owner_deletion` flag set to true.
+/// That means it'll be deleted if its owner is being deleted.
 pub fn create_config_map<T>(
     resource: &T,
     cm_name: &str,
@@ -93,6 +95,7 @@ where
             namespace: Meta::namespace(resource),
             owner_references: Some(vec![metadata::object_to_owner_reference::<T>(
                 resource.meta().clone(),
+                true,
             )?]),
             ..ObjectMeta::default()
         },

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,6 +16,7 @@ pub fn build_metadata<T>(
     name: String,
     labels: Option<BTreeMap<String, String>>,
     resource: &T,
+    block_owner_deletion: bool,
 ) -> OperatorResult<ObjectMeta>
 where
     T: Meta,
@@ -26,6 +27,7 @@ where
         namespace: Meta::namespace(resource),
         owner_references: Some(vec![object_to_owner_reference::<T>(
             resource.meta().clone(),
+            block_owner_deletion,
         )?]),
         ..ObjectMeta::default()
     })
@@ -33,7 +35,10 @@ where
 
 /// Creates an OwnerReference pointing to the resource type and `metadata` being passed in.
 /// The created OwnerReference has it's `controller` flag set to `true`
-pub fn object_to_owner_reference<K: Resource>(meta: ObjectMeta) -> OperatorResult<OwnerReference> {
+pub fn object_to_owner_reference<K: Resource>(
+    meta: ObjectMeta,
+    block_owner_deletion: bool,
+) -> OperatorResult<OwnerReference> {
     Ok(OwnerReference {
         api_version: K::API_VERSION.to_string(),
         kind: K::KIND.to_string(),
@@ -44,7 +49,7 @@ pub fn object_to_owner_reference<K: Resource>(meta: ObjectMeta) -> OperatorResul
             key: ".metadata.uid",
         })?,
         controller: Some(true),
-        ..OwnerReference::default()
+        block_owner_deletion: Some(block_owner_deletion),
     })
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -78,7 +78,7 @@ mod tests {
             ..Pod::default()
         };
 
-        let meta = build_metadata(name.to_string(), Some(labels), &pod)?;
+        let meta = build_metadata(name.to_string(), Some(labels), &pod, true)?;
 
         assert_eq!(meta.name, Some(name.to_string()));
         assert_eq!(meta.namespace, namespace);


### PR DESCRIPTION
This only works when the garbage collector is also running otherwise the object will never be cleaned up.
The garbage collector does not run as part of the apiserver itself. It's probably controller-manager or something.