### PR TITLE
Removes the `derive` feature from kube

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,15 @@ async-trait = "0.1"
 either = "1.6"
 futures = "0.3"
 k8s-openapi = { version = "0.11", default-features = false }
-kube = { version = "0.49", default-features = false, features = ["derive"] }
+kube = { version = "0.49", default-features = false }
 kube-runtime = "0.49"
-serde = "1.0"
-serde_json = "1.0"
+lazy_static = "1"
+regex = "1"
+serde = "1"
+serde_json = "1"
 serde_yaml = "0.8"
-thiserror = "1.0"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+thiserror = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ futures = "0.3"
 k8s-openapi = { version = "0.11", default-features = false }
 kube = { version = "0.49", default-features = false }
 kube-runtime = "0.49"
-lazy_static = "1"
-regex = "1"
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 version = "0.1.0"
-authors = ["Lars Francke <lars.francke@gmail.com>"]
+authors = ["Lars Francke <lars.francke@stackable.de>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This is not needed here and can lead to problems because it pulls in kube-derive with default features which doesn't allow downstream users to easily opt-out of the schema feature.