### PR TITLE
Adds a compute_hash method

### DIFF
--- a/src/controller_utils.rs
+++ b/src/controller_utils.rs
@@ -1,0 +1,40 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// `compute_hash` returns a hash value calculated from object that is passed in
+/// (which needs to implement [`Hash`]) as well as an optional `collision_count` to
+/// avoid hash collisions.
+///
+/// The resulting hash is intended to be used for naming objects uniquely and should not (due to the
+/// collision count) used in HashMaps or similar structures.
+///
+/// This differs from the Kubernetes hashing algorithms in that it creates 64-bit (8 byte) hashes
+/// and Kubernetes creates 32-bit (4 byte) hashes.
+/// TODO: This could be changed by using an external crate, Rust std library only contains 64-bit hashes
+///
+/// # Example
+///
+/// ```
+/// use stackable_operator::controller_utils;
+///
+/// let hash = controller_utils::compute_hash(123, None);
+/// let hash2 = controller_utils::compute_hash(123, Some(1));
+///
+/// assert_ne!(hash, hash2);
+///
+/// ```
+pub fn compute_hash<T>(resource: T, collision_count: Option<u32>) -> String
+where
+    T: Hash,
+{
+    let mut hasher = DefaultHasher::new();
+    resource.hash(&mut hasher);
+
+    if let Some(collision_count) = collision_count {
+        collision_count.hash(&mut hasher);
+    }
+
+    let hash = hasher.finish();
+
+    format!("{:x}", hash)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod controller;
 pub mod controller_ref;
+pub mod controller_utils;
 pub mod crd;
 pub mod error;
 pub mod finalizer;


### PR DESCRIPTION
This returns a hashed value of the object passed in and includes an optional collision count to avoid collisions for two otherwise same objects.