### PR TITLE
The 'ensure_crd_created' method retries on failure.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -- --ignored
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,10 +26,16 @@ jobs:
         with:
           version: 'latest'
       - uses: actions-rs/cargo@v1
+        name: Run tests
+        with:
+          command: test
+      - uses: actions-rs/cargo@v1
+        name: Run ignored-by-default tests
         with:
           command: test
           args: -- --ignored
       - uses: actions-rs/cargo@v1
+        name: Release build
         with:
           command: build
           args: --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,11 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - name: Start K3S
+        uses: debianmaster/actions-k3s@v1.0.1
+        id: k3s
+        with:
+          version: 'latest'
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,23 @@
+= OPERATOR-RS CONTRIBUTING GUIDE
+
+Contributions in any form are welcome and appreciated. The recommended approach for code contributions is to fork this repository and create a pull request.
+
+== CODE
+
+* Use the *stable* branch of Rust, not nightly.
+* Code must be formatted with https://github.com/rust-lang/rustfmt[rustfmt]. Easiest way to install `rustfmt` is to to invoke `cargo install rustfmt` and then format the project with `cargo fmt`.
+* Rustdoc: Structs, functions and all other elements are documented. In general, documentation style follows the https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html[Rustdoc] guide.
+* Tests dependent on Kubernetes runtime are prefixed with `k8s_test_` and ignored.
+
+
+== TESTS
+
+Tests requiring Kubernetes are *disabled* by default, yet enabled in link:.github/workflows/rust.yml[rust.yml] workflow. All others tests are *enabled* by default. This implies `cargo test` won't run Kubernetes-dependent tests by default. To run ignored test(s), invoke `cargo test -- --ignored`.
+
+Kubernetes tests require a `KUBECONFIG` environment variable pointing to a valid kubeconfig file. The kubeconfig must:
+
+* Point to a reachable Kubernetes cluster,
+* Use account with enough permissions to run the tests,
+* Be readable by the user running the tests.
+
+On Linux, a convenient way to install local Kubernetes cluster is https://k3s.io/:[K3S.io]. Invoking `curl -sfL https://get.k3s.io | sh -` installs latest version of K3S and exports a `KUBECONFIG` at `/etc/rancher/k3s/k3s.yaml`. To run Kubernetes-dependent tests with K3S, set the `KUBECONFIG` environment variable using `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml`. Make sure it is readable by user invoking the tests by using `chown`/`chmod`. Running the `cargo test -- --ignored` command afterwards runs all tests, including Kubernetes tests. K3S is also leveraged in link:.github/workflows/rust.yml[rust.yml] workflow.

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,10 @@
-= operator-rs
+= OPERATOR-RS
 
 This is a simple library that includes all kinds of helper methods, structs and enums that can be used to write a Kubernetes Controller/Operator with the https://github.com/clux/kube-rs[kube-rs] crate.
 
-WARNING: This is very new, undocumented and untested!
+WARNING: This is very new, undocumented and partially tested (see the link:CONTRIBUTING.adoc[contributing guide])!
+
+
+== CONTRIBUTING
+
+Contributions are much welcome. A detailed guide on contributing, development and testing is to be found at link:CONTRIBUTING.adoc[CONTRIBUTING].

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,8 +4,8 @@ use crate::label_selector;
 use crate::podutils;
 
 use either::Either;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
 use futures::StreamExt;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
 use k8s_openapi::Resource;
 use kube::api::{DeleteParams, ListParams, Meta, Patch, PatchParams, PostParams};
 use kube::client::{Client as KubeClient, Status};

--- a/src/client.rs
+++ b/src/client.rs
@@ -330,7 +330,7 @@ impl Client {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```no_run
     /// use kube::api::ListParams;
     /// use std::time::Duration;
     /// use tokio::time::error::Elapsed;
@@ -358,7 +358,6 @@ impl Client {
     {
         let api: Api<T> = self.get_api(namespace);
         let watcher = kube_runtime::watcher(api, lp).boxed();
-
         kube_runtime::utils::try_flatten_applied(watcher)
             .skip_while(|res| std::future::ready(res.is_err()))
             .next()
@@ -386,7 +385,8 @@ mod tests {
     use tokio::time::error::Elapsed;
 
     #[tokio::test]
-    async fn test_wait_created() {
+    #[ignore = "Tests depending on Kubernetes are not ran by default"]
+    async fn k8s_test_wait_created() {
         let client = super::create_client(None)
             .await
             .expect("KUBECONFIG variable must be configured.");
@@ -463,7 +463,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_created_timeout() {
+    #[ignore = "Tests depending on Kubernetes are not ran by default"]
+    async fn k8s_test_wait_created_timeout() {
         let client = super::create_client(None)
             .await
             .expect("KUBECONFIG variable must be configured.");

--- a/src/client.rs
+++ b/src/client.rs
@@ -426,8 +426,7 @@ mod tests {
             match result {
                 Ok(event) => match event {
                     Event::Applied(pod) => {
-                        panic!("The pod {} should be applied already, as the `wait_ready` function held until the pod is ready.\
-                        Expected Event::Restarted", pod.name())
+                        assert_eq!("test-wait-created-busybox", pod.name());
                     }
                     Event::Restarted(pods) => {
                         assert_eq!(1, pods.len());

--- a/src/client.rs
+++ b/src/client.rs
@@ -313,6 +313,12 @@ impl Client {
         Api::namespaced(self.client.clone(), namespace)
     }
 
+    /// Waits until given resource with metadata is recognized as applied by Kubernetes API
+    ///
+    /// # Arguments
+    ///
+    /// - `namespace` - Optional namespace to look for the resources in.
+    /// - `lp` - Parameters to filter resources in given namespace.
     pub async fn wait_ready<T>(&self, namespace: Option<String>, lp: ListParams)
     where
         T: Meta + Clone + DeserializeOwned + Send + 'static,
@@ -323,10 +329,10 @@ impl Client {
         while let Some(result) = watcher.next().await {
             match result {
                 Ok(event) => match event {
-                    Event::Applied(_) | Event::Deleted(_) => {
+                    Event::Applied(_) | Event::Restarted(_) => {
                         break;
                     }
-                    Event::Restarted(_) => {
+                    Event::Deleted(_) => {
                         continue;
                     }
                 },

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -123,7 +123,7 @@ where
         ..ListParams::default()
     };
     client
-        .wait_ready::<CustomResourceDefinition>(None, lp)
+        .wait_created::<CustomResourceDefinition>(None, lp)
         .await;
     Ok(())
 }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,9 +1,12 @@
-use crate::client::Client;
-use crate::error::{Error, OperatorResult};
+use std::time::Duration;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::error::ErrorResponse;
 use tracing::info;
+
+use crate::client::Client;
+use crate::error::{Error, OperatorResult};
+use kube::api::ListParams;
 
 /// This trait can be implemented to allow automatic handling
 /// (e.g. creation) of `CustomResourceDefinition`s in Kubernetes.
@@ -61,11 +64,16 @@ where
     }
 }
 
-/// This makes sure the CRD is registered in the apiserver.
-/// Currently this does not retry internally.
-/// This means that running it again _might_ work in case of transient errors.
-// TODO: Make sure to wait until it's enabled in the apiserver
-pub async fn ensure_crd_created<T>(client: Client) -> OperatorResult<()>
+/// Makes sure CRD of given type `T` is running and accepted by the Kubernetes apiserver.
+/// If the CRD already exists at the time this method is invoked, this method exits.
+/// If there is no CRD of type `T` yet, it will attempt to create it and verify k8s apiserver
+/// applied the CRD.
+///
+/// # Parameters
+/// - `client`: Client to connect to Kubernetes API and create the CRD with
+/// - `timeout`: If specified, retries creating the CRD for given `Duration`. If not specified,
+///     retries indefinitely.
+pub async fn ensure_crd_created<T>(client: Client, timeout: Option<Duration>) -> OperatorResult<()>
 where
     T: Crd,
 {
@@ -74,8 +82,22 @@ where
         Ok(())
     } else {
         info!("CRD not detected in Kubernetes. Attempting to create it.");
-        create::<T>(client).await
-        // TODO: Maybe retry?
+
+        let crd_created = async {
+            loop {
+                if let Ok(res) = create::<T>(client.clone()).await {
+                    break res;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            wait_ready::<T>(client.clone()).await?;
+            Ok(())
+        };
+        if let Some(timeout) = timeout {
+            tokio::time::timeout(timeout, crd_created).await?
+        } else {
+            crd_created.await
+        }
     }
 }
 
@@ -89,4 +111,18 @@ where
 {
     let crd: CustomResourceDefinition = serde_yaml::from_str(T::CRD_DEFINITION)?;
     client.create(&crd).await.and(Ok(()))
+}
+
+pub async fn wait_ready<T>(client: Client) -> OperatorResult<()>
+where
+    T: Crd,
+{
+    let lp: ListParams = ListParams {
+        field_selector: Some(format!("metadata.name={}", T::RESOURCE_NAME)),
+        ..ListParams::default()
+    };
+    client
+        .wait_ready::<CustomResourceDefinition>(None, lp)
+        .await;
+    Ok(())
 }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -113,6 +113,7 @@ where
     client.create(&crd).await.and(Ok(()))
 }
 
+/// Waits until CRD of given type `T` is applied to Kubernetes.
 pub async fn wait_ready<T>(client: Client) -> OperatorResult<()>
 where
     T: Crd,

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -90,7 +90,7 @@ where
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
-            wait_ready::<T>(client.clone()).await?;
+            wait_created::<T>(client.clone()).await?;
             Ok(())
         };
         if let Some(timeout) = timeout {
@@ -114,7 +114,7 @@ where
 }
 
 /// Waits until CRD of given type `T` is applied to Kubernetes.
-pub async fn wait_ready<T>(client: Client) -> OperatorResult<()>
+pub async fn wait_created<T>(client: Client) -> OperatorResult<()>
 where
     T: Crd,
 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,11 @@ pub enum Error {
 
     #[error("LabelSelector is invalid: {message}")]
     InvalidLabelSelector { message: String },
+    #[error("Operation timed out: {source}")]
+    TimeoutError {
+        #[from]
+        source: tokio::time::error::Elapsed,
+    },
 }
 
 pub type OperatorResult<T> = std::result::Result<T, Error>;

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use kube::api::Meta;
+use stackable_operator::crd::{ensure_crd_created, exists};
+use stackable_operator::{client, Crd};
+
+struct TestCrd {}
+
+impl Crd for TestCrd {
+    const RESOURCE_NAME: &'static str = "tests.stackable.tech";
+    const CRD_DEFINITION: &'static str = r#"
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.stackable.tech
+spec:
+  group: stackable.tech
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+  scope: Namespaced
+  names:
+    plural: tests
+    singular: test
+    kind: Test
+"#;
+}
+
+#[tokio::test]
+async fn test_ensure_crd_created() {
+    let client = client::create_client(None)
+        .await
+        .expect("KUBECONFIG variable must be configured.");
+
+    ensure_crd_created::<TestCrd>(client.clone(), Some(Duration::from_secs(10)))
+        .await
+        .expect("CRD not created in time");
+
+    exists::<TestCrd>(client.clone())
+        .await
+        .expect("CRD should be created");
+    let created_crd: CustomResourceDefinition = client
+        .get(TestCrd::RESOURCE_NAME.as_ref(), None)
+        .await
+        .unwrap();
+    assert_eq!(TestCrd::RESOURCE_NAME, created_crd.name());
+
+    client
+        .delete(&created_crd)
+        .await
+        .expect("TestCrd not deleted");
+    assert!(exists::<TestCrd>(client.clone())
+        .await
+        .expect("CRD should be created"))
+}

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -38,9 +38,13 @@ async fn k8s_test_test_ensure_crd_created() {
         .await
         .expect("KUBECONFIG variable must be configured.");
 
-    ensure_crd_created::<TestCrd>(client.clone(), Some(Duration::from_secs(10)))
-        .await
-        .expect("CRD not created in time");
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        ensure_crd_created::<TestCrd>(client.clone()),
+    )
+    .await
+    .expect("CRD not created in time")
+    .expect("Error while creating CRD");
 
     exists::<TestCrd>(client.clone())
         .await

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -32,7 +32,8 @@ spec:
 }
 
 #[tokio::test]
-async fn test_ensure_crd_created() {
+#[ignore = "Tests depending on Kubernetes are not ran by default"]
+async fn k8s_test_test_ensure_crd_created() {
     let client = client::create_client(None)
         .await
         .expect("KUBECONFIG variable must be configured.");


### PR DESCRIPTION
Attempt to implement CRD creation retry. Added an optional timeout for that. One frequent reason why CRDs fail to be created are permissions - the retry won't help here, it will simply time out, unless permissions are adjusted in time.

## Tests

There is a basic `test_ensure_crd_created` introduced. It is **not** ignored by default and it requires Kubernetes and `KUBECONFIG` environment variable set. Could be ignored by default to make tests runnable locally by anyone. Running Kubernetes cluster in GitHub actions is simple - there is a ready `debianmaster/actions-k3s` available. Exposes the `KUBECONFIG` var automatically, with `clusteradmin` permissions enabled by default (all permissions basically).

If left enabled, anyone who'll do `cargo test` will see tests failed, unles the above mentioned condition is met. This is easy to do, e.g. `https://k3s.io/` is as simple as this on linux:

```bash
curl -sfL https://get.k3s.io | sh -
export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
```
(sometimes, chown or simply `sudo chmod 777 /etc/rancher/k3s/k3s.yaml` on the kubeconfig file is required).

