### PR TITLE
[89] - list_with_label_selector namespace as a ref + tests

### DIFF
--- a/src/command_controller.rs
+++ b/src/command_controller.rs
@@ -181,7 +181,7 @@ where
             .client
             .get(
                 &self.context.resource.get_owner_name(),
-                self.context.resource.namespace(),
+                self.context.resource.namespace().as_deref(),
             )
             .await?;
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -22,7 +22,7 @@ where
     T: Meta,
 {
     let revisions = client
-        .list(Meta::namespace(resource), &ListParams::default())
+        .list(Meta::namespace(resource).as_deref(), &ListParams::default())
         .await?;
     let owner_uid = resource.meta().uid.as_ref().unwrap(); // TODO: Error handling
     let mut owned = vec![];

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -158,7 +158,7 @@ where
         };
 
         self.client
-            .list_with_label_selector(self.resource.namespace(), &label_selector)
+            .list_with_label_selector(self.resource.namespace().as_deref(), &label_selector)
             .await
             .map(|pods| {
                 pods.into_iter()

--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -106,7 +106,7 @@ pub async fn find_nodes_that_fit_selectors(
     for role_group in role_groups {
         let selector = krustlet::add_stackable_selector(&role_group.selector);
         let nodes = client
-            .list_with_label_selector(namespace.clone(), &selector)
+            .list_with_label_selector(namespace.clone().as_deref(), &selector)
             .await?;
         debug!(
             "Found [{}] nodes for role group [{}]: [{:?}]",


### PR DESCRIPTION
Originally added namespaces support to `list_with_label_selector` method. This has been implemented in the meantime already and merged to main. Therefore, this PR adds the following:

1. Namespaces are passed as string slices, therefore no strings are moved or even cloned anymore.
2. Tests