### PR TITLE
Adds function to check by name if all required CRDs have been registered in Kubernetes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         name: Run ignored-by-default tests
         with:
           command: test
-          args: -- --ignored
+          args: -- --ignored --test-threads=1
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: clean

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
 uuid = { version = "0.8", features = ["v4"] }
+backoff = "0.3"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ uuid = { version = "0.8", features = ["v4"] }
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 kube = { version = "0.56", default-features = false, features = ["derive"] }
 rstest = "0.10"
-serial_test = "0.5"
 
 [features]
 default = ["native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { version = "0.8", features = ["v4"] }
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 kube = { version = "0.56", default-features = false, features = ["derive"] }
 rstest = "0.10"
+serial_test = "0.5"
 
 [features]
 default = ["native-tls"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -337,7 +337,10 @@ impl Client {
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
-        let mut backoff_strategy = ExponentialBackoff::default();
+        let mut backoff_strategy = ExponentialBackoff {
+            max_elapsed_time: None,
+            ..ExponentialBackoff::default()
+        };
 
         self.delete(&resource).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,8 @@ use crate::finalizer;
 use crate::label_selector;
 use crate::pod_utils;
 
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
 use either::Either;
 use futures::StreamExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
@@ -15,8 +17,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::fmt::Debug;
-use std::time::Duration;
-use tracing::trace;
+use tracing::{error, info, trace};
 
 /// This `Client` can be used to access Kubernetes.
 /// It wraps an underlying [kube::client::Client] and provides some common functionality.
@@ -336,6 +337,8 @@ impl Client {
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
+        let mut backoff_strategy = ExponentialBackoff::default();
+
         self.delete(&resource).await?;
 
         loop {
@@ -345,7 +348,26 @@ impl Client {
             {
                 return Ok(());
             }
-            tokio::time::sleep(Duration::from_secs(5)).await;
+
+            // When backoff returns `None` the timeout has expired
+            match backoff_strategy.next_backoff() {
+                Some(backoff) => {
+                    info!(
+                        "Waiting [{}] seconds before trying again..",
+                        backoff.as_secs()
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+                None => {
+                    // We offer no way of specifying a timeout, so this shouldn't happen,
+                    // if it does we'll log an error for now and continue iterating and wait for
+                    // the last interval we saw
+                    error!(
+                        "Waiting for deletion timed out, but no timeout was specified, this is an error and should not happen!"
+                    );
+                    tokio::time::sleep(backoff_strategy.current_interval).await;
+                }
+            }
         }
     }
 

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -83,7 +83,7 @@ pub async fn wait_until_crds_present(
     delay: Option<Duration>,
     timeout: Option<Duration>,
 ) -> OperatorResult<()> {
-    let delay = delay.unwrap_or(Duration::from_secs(60));
+    let delay = delay.unwrap_or_else(|| Duration::from_secs(60));
     let start = Instant::now();
 
     // The loop will continue running until either all CRDs are present or a configured

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -137,7 +137,10 @@ pub async fn wait_until_crds_present(
                 );
                 if let Some(timeout_value) = &timeout {
                     if timeout.is_some() && start.elapsed() >= *timeout_value {
-                        info!("Timeout of [{}] seconds reached, returning.", timeout_value.as_secs());
+                        info!(
+                            "Timeout of [{}] seconds reached, returning.",
+                            timeout_value.as_secs()
+                        );
                         return Err(err);
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to serialize template to JSON: {source}")]
@@ -44,6 +46,9 @@ pub enum Error {
 
     #[error("Invalid name for resource: {errors:?}")]
     InvalidName { errors: Vec<String> },
+
+    #[error("The following required CRDs are missing from Kubernetes: {names:?}")]
+    RequiredCrdsMissing { names: HashSet<String>}
 }
 
 pub type OperatorResult<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ pub enum Error {
     InvalidName { errors: Vec<String> },
 
     #[error("The following required CRDs are missing from Kubernetes: {names:?}")]
-    RequiredCrdsMissing { names: HashSet<String>}
+    RequiredCrdsMissing { names: HashSet<String> },
 }
 
 pub type OperatorResult<T> = std::result::Result<T, Error>;

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -57,7 +57,7 @@ spec:
 "#;
 }
 
-/*#[tokio::test]
+#[tokio::test]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_test_ensure_crd_created() {
     let client = client::create_client(None)
@@ -91,7 +91,6 @@ async fn k8s_test_test_ensure_crd_created() {
         .await
         .expect("CRD should be created"))
 }
-*/
 
 #[tokio::test]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -2,10 +2,10 @@ use std::time::Duration;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::core::ResourceExt;
+use serial_test::serial;
 use stackable_operator::client::Client;
 use stackable_operator::crd::{ensure_crd_created, wait_until_crds_present};
 use stackable_operator::{client, Crd};
-use serial_test::serial;
 
 struct TestCrd {}
 

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -59,41 +59,6 @@ spec:
 
 #[tokio::test]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
-async fn k8s_test_test_ensure_crd_created() {
-    let client = client::create_client(None)
-        .await
-        .expect("KUBECONFIG variable must be configured.");
-
-    tokio::time::timeout(
-        Duration::from_secs(30),
-        ensure_crd_created::<TestCrd>(&client),
-    )
-    .await
-    .expect("CRD not created in time")
-    .expect("Error while creating CRD");
-
-    client
-        .exists::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
-        .await
-        .expect("CRD should be created");
-    let created_crd: CustomResourceDefinition = client
-        .get(TestCrd::RESOURCE_NAME.as_ref(), None)
-        .await
-        .unwrap();
-    assert_eq!(TestCrd::RESOURCE_NAME, created_crd.name());
-
-    client
-        .delete(&created_crd)
-        .await
-        .expect("TestCrd not deleted");
-    assert!(client
-        .exists::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
-        .await
-        .expect("CRD should be created"))
-}
-
-#[tokio::test]
-#[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_wait_for_crds() {
     // TODO: Switch this to using TemporaryResource from the integration-test-commons crate
     let client = client::create_client(None)
@@ -243,4 +208,39 @@ async fn k8s_test_wait_for_crds() {
                 .unwrap_or_else(|_| panic!("Unable to delete CRD [{}]", crd_name));
         }
     }
+}
+
+#[tokio::test]
+#[ignore = "Tests depending on Kubernetes are not ran by default"]
+async fn k8s_test_test_ensure_crd_created() {
+    let client = client::create_client(None)
+        .await
+        .expect("KUBECONFIG variable must be configured.");
+
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        ensure_crd_created::<TestCrd>(&client),
+    )
+        .await
+        .expect("CRD not created in time")
+        .expect("Error while creating CRD");
+
+    client
+        .exists::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
+        .await
+        .expect("CRD should be created");
+    let created_crd: CustomResourceDefinition = client
+        .get(TestCrd::RESOURCE_NAME.as_ref(), None)
+        .await
+        .unwrap();
+    assert_eq!(TestCrd::RESOURCE_NAME, created_crd.name());
+
+    client
+        .delete(&created_crd)
+        .await
+        .expect("TestCrd not deleted");
+    assert!(client
+        .exists::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
+        .await
+        .expect("CRD should be created"))
 }

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::core::ResourceExt;
-use serial_test::serial;
 use stackable_operator::crd::{ensure_crd_created, wait_until_crds_present};
 use stackable_operator::{client, Crd};
 
@@ -58,8 +57,7 @@ spec:
 "#;
 }
 
-#[tokio::test]
-#[serial]
+/*#[tokio::test]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_test_ensure_crd_created() {
     let client = client::create_client(None)
@@ -93,9 +91,9 @@ async fn k8s_test_test_ensure_crd_created() {
         .await
         .expect("CRD should be created"))
 }
+*/
 
 #[tokio::test]
-#[serial]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_wait_for_crds() {
     // TODO: Switch this to using TemporaryResource from the integration-test-commons crate

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::core::ResourceExt;
-use stackable_operator::crd::ensure_crd_created;
+use stackable_operator::crd::{ensure_crd_created, wait_until_crds_present};
 use stackable_operator::{client, Crd};
 
 struct TestCrd {}
@@ -64,4 +64,98 @@ async fn k8s_test_test_ensure_crd_created() {
         .exists::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
         .await
         .expect("CRD should be created"))
+}
+
+#[tokio::test]
+#[ignore = "Tests depending on Kubernetes are not ran by default"]
+async fn k8s_test_wait_for_crds() {
+    // TODO: Switch this to using TemporaryResource from the integration-test-commons crate
+    let client = client::create_client(None)
+        .await
+        .expect("KUBECONFIG variable must be configured.");
+
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        ensure_crd_created::<TestCrd>(&client),
+    )
+    .await
+    .expect("CRD not created in time")
+    .expect("Error while creating CRD");
+
+    // Give k8s some time to perform the deletion
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Test waiting honors timeout
+    let await_result = tokio::time::timeout(
+        Duration::from_secs(30),
+        wait_until_crds_present(
+            &client,
+            vec!["non_existing_crd_name"],
+            Some(Duration::from_secs(1)),
+            Some(Duration::from_secs(10)),
+        ),
+    )
+    .await
+    .expect("Waiting for CRDs did not return within the configured timeout!");
+
+    match await_result {
+        Err(stackable_operator::error::Error::RequiredCrdsMissing { names }) => {
+            assert_eq!(
+                names,
+                vec!["non_existing_crd_name".to_string()].into_iter().collect()
+            )
+        }
+        _ => panic!("Did not get the expected error!"),
+    }
+
+    // Check that waiting returns promptly when all CRDs exist
+    let await_result = tokio::time::timeout(
+        Duration::from_secs(30),
+        wait_until_crds_present(
+            &client,
+            vec![TestCrd::RESOURCE_NAME],
+            Some(Duration::from_secs(1)),
+            Some(Duration::from_secs(10)),
+        ),
+    )
+    .await
+    .expect("Checking for an existing CRD should have returned before the timeout!");
+
+    match await_result {
+        Ok(()) => {}
+        Err(e) => panic!("Got error instead of expected Ok(()): [{:?}]", e),
+    }
+
+    // Check await returns an error when one of multiple expected CRDs is missing
+    let await_result = tokio::time::timeout(
+        Duration::from_secs(30),
+        wait_until_crds_present(
+            &client,
+            vec![TestCrd::RESOURCE_NAME, "MissingCrdName"],
+            Some(Duration::from_secs(1)),
+            Some(Duration::from_secs(10)),
+        ),
+    )
+    .await
+    .expect("Waiting for CRDs did not return within the configured timeout!");
+
+    match await_result {
+        Err(stackable_operator::error::Error::RequiredCrdsMissing { names }) => {
+            assert_eq!(
+                names,
+                vec!["MissingCrdName".to_string()].into_iter().collect()
+            )
+        }
+        _ => panic!("Did not get the expected error!"),
+    }
+
+    // Cleanup
+    if let Ok(crd) = client
+        .get::<CustomResourceDefinition>(TestCrd::RESOURCE_NAME, None)
+        .await
+    {
+        // Ensure CRD is not present
+        println!("deleting");
+        client.delete(&crd).await.expect("TestCrd not deleted");
+    }
 }

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -4,6 +4,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomRe
 use kube::core::ResourceExt;
 use stackable_operator::crd::{ensure_crd_created, wait_until_crds_present};
 use stackable_operator::{client, Crd};
+use serial_test::serial;
 
 struct TestCrd {}
 
@@ -58,6 +59,7 @@ spec:
 }
 
 #[tokio::test]
+#[serial]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_test_ensure_crd_created() {
     let client = client::create_client(None)
@@ -93,6 +95,7 @@ async fn k8s_test_test_ensure_crd_created() {
 }
 
 #[tokio::test]
+#[serial]
 #[ignore = "Tests depending on Kubernetes are not ran by default"]
 async fn k8s_test_wait_for_crds() {
     // TODO: Switch this to using TemporaryResource from the integration-test-commons crate

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -120,7 +120,6 @@ async fn k8s_test_wait_for_crds() {
         wait_until_crds_present(
             &client,
             vec!["non_existing_crd_name"],
-            Some(Duration::from_secs(1)),
             Some(Duration::from_secs(10)),
         ),
     )
@@ -145,7 +144,6 @@ async fn k8s_test_wait_for_crds() {
         wait_until_crds_present(
             &client,
             vec![TestCrd::RESOURCE_NAME],
-            Some(Duration::from_secs(1)),
             Some(Duration::from_secs(10)),
         ),
     )
@@ -163,7 +161,6 @@ async fn k8s_test_wait_for_crds() {
         wait_until_crds_present(
             &client,
             vec![TestCrd::RESOURCE_NAME, "MissingCrdName"],
-            Some(Duration::from_secs(1)),
             Some(Duration::from_secs(10)),
         ),
     )
@@ -186,7 +183,6 @@ async fn k8s_test_wait_for_crds() {
         wait_until_crds_present(
             &client,
             vec![TestCrd::RESOURCE_NAME, TestCrd2::RESOURCE_NAME],
-            Some(Duration::from_secs(1)),
             Some(Duration::from_secs(10)),
         ),
     )
@@ -209,7 +205,6 @@ async fn k8s_test_wait_for_crds() {
                 "missing1",
                 "missing2",
             ],
-            Some(Duration::from_secs(1)),
             Some(Duration::from_secs(10)),
         ),
     )

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -102,7 +102,9 @@ async fn k8s_test_wait_for_crds() {
         Err(stackable_operator::error::Error::RequiredCrdsMissing { names }) => {
             assert_eq!(
                 names,
-                vec!["non_existing_crd_name".to_string()].into_iter().collect()
+                vec!["non_existing_crd_name".to_string()]
+                    .into_iter()
+                    .collect()
             )
         }
         _ => panic!("Did not get the expected error!"),

--- a/tests/test_crd.rs
+++ b/tests/test_crd.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::core::ResourceExt;
+use serial_test::serial;
 use stackable_operator::crd::{ensure_crd_created, wait_until_crds_present};
 use stackable_operator::{client, Crd};
-use serial_test::serial;
 
 struct TestCrd {}
 


### PR DESCRIPTION
The function also allows specifying a timeout and delay between retries to optionally allow operators to wait until CRDs have been created and then continue their startup.

partially fixes https://github.com/stackabletech/issues/issues/27

follow up PRs are needed in all operators for to fully fix the issue.