### PR TITLE
Remove comment about unneeded trait bounds

### DIFF
--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -343,7 +343,6 @@ where
     }
 }
 
-// TODO: Trait bound on Clone is not needed after https://github.com/clux/kube-rs/pull/436, see https://github.com/stackabletech/operator-rs/issues/140
 impl<T> ReconciliationContext<T>
 where
     T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,


### PR DESCRIPTION
/closes #140 

I checked and the trait bound on Clone is still needed after all because of 

```
impl<K> Api<K>
where
    K: Clone + DeserializeOwned + Debug,
```

in `core_methods.rs` in `kube-rs`