### PR TITLE
Updated kube and kube-runtime to 0.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ either = "1.6"
 futures = "0.3"
 json-patch = "0.2"
 k8s-openapi = { version = "0.12", default-features = false }
-kube = { version = "0.57", default-features = false, features = ["jsonpatch"] }
-kube-runtime = "0.57"
+kube = { version = "0.58", default-features = false, features = ["jsonpatch"] }
+kube-runtime = "0.58"
 lazy_static = "1.4"
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ backoff = "0.3"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.12", default-features = false, features = ["v1_21"] }
-kube = { version = "0.57", default-features = false, features = ["derive"] }
+kube = { version = "0.58", default-features = false, features = ["derive"] }
 rstest = "0.11"
 serial_test = "0.5"
 tempfile = "3.2"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -229,8 +229,7 @@ where
     /// You need to make sure to add this `OwnerReference` yourself.
     pub fn owns<Child>(mut self, api: Api<Child>, lp: ListParams) -> Self
     where
-        Child: Clone + Debug + Resource + DeserializeOwned + Send + 'static,
-        <Child as Resource>::DynamicType: Clone + Debug + Eq + Hash,
+        Child: Clone + Resource<DynamicType = ()> + DeserializeOwned + Debug + Send + 'static,
     {
         self.kube_controller = self.kube_controller.owns(api, lp);
         self


### PR DESCRIPTION
Due to https://github.com/kube-rs/kube-rs/pull/575 we had to change the type bounds on the owns function, as this doesn't support DynamicTypes anymore.

This _should_ not require any changes in the operators themselves, as we don't currently use DynamicTypes. Might break for people who do though.