### PR TITLE
Fix command controller

### DIFF
--- a/src/command_controller.rs
+++ b/src/command_controller.rs
@@ -69,6 +69,7 @@
 //! }
 //! ```
 //!
+use crate::builder::OwnerReferenceBuilder;
 use crate::client::Client;
 use crate::controller::{Controller, ControllerStrategy, ReconciliationState};
 use crate::error::{Error, OperatorResult};

--- a/src/command_controller.rs
+++ b/src/command_controller.rs
@@ -72,9 +72,9 @@
 use crate::builder::OwnerReferenceBuilder;
 use crate::client::Client;
 use crate::controller::{Controller, ControllerStrategy, ReconciliationState};
+use crate::controller_ref;
 use crate::error::{Error, OperatorResult};
 use crate::reconcile::{ReconcileFunctionAction, ReconcileResult, ReconciliationContext};
-use crate::{builder::ObjectMetaBuilder, controller_ref};
 use async_trait::async_trait;
 use json_patch::{AddOperation, PatchOperation};
 use kube::api::ListParams;

--- a/src/command_controller.rs
+++ b/src/command_controller.rs
@@ -148,8 +148,10 @@ where
     /// If the owner (main controller custom resource), we set its owner reference
     /// to our command custom resource.
     async fn set_owner_reference(&self) -> ReconcileResult<Error> {
-        let owner_reference = ObjectMetaBuilder::new()
-            .ownerreference_from_resource(self.owner.as_ref().unwrap(), Some(true), Some(true))?
+        let owner_reference = OwnerReferenceBuilder::new()
+            .initialize_from_resource(self.owner.as_ref().unwrap())
+            .block_owner_deletion(true)
+            .controller(true)
             .build()?;
 
         let owner_references_path = "/metadata/ownerReferences".to_string();


### PR DESCRIPTION
I made a mistake when introducing the builder patterns and created a ObjectMeta instead of an OwnerReference by accident.