### PR TITLE
Adds a simple method to print startup diagnostic information

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod product_config_utils;
 pub mod reconcile;
 pub mod role_utils;
 pub mod status;
+pub mod utils;
 pub mod validation;
 
 pub use crate::crd::CustomResourceExt;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,32 @@
 use tracing::info;
 
+/// Prints helpful and standardized diagnostic messages.
+///
+/// This method is meant to be called first thing in the `main` method of an Operator.
+///
+/// # Usage
+///
+/// Use the [`built`](https://crates.io/crates/built) crate and include it in your `main.rs` like this:
+///
+/// ```ignore
+/// mod built_info {
+///     // The file has been placed there by the build script.
+///     include!(concat!(env!("OUT_DIR"), "/built.rs"));
+/// }
+/// ```
+///
+/// Then call this method in your `main` method:
+///
+/// ```ignore
+/// stackable_operator::utils::print_startup_string(
+///      built_info::PKG_DESCRIPTION,
+///      built_info::PKG_VERSION,
+///      built_info::GIT_VERSION,
+///      built_info::TARGET,
+///      built_info::BUILT_TIME_UTC,
+///      built_info::RUSTC_VERSION,
+/// );
+/// ```
 pub fn print_startup_string(
     pkg_description: &str,
     pkg_version: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use tracing::info;
+
 pub fn print_startup_string(
     pkg_description: &str,
     pkg_version: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,18 @@
+pub fn print_startup_string(
+    pkg_description: &str,
+    pkg_version: &str,
+    git_version: Option<&str>,
+    target: &str,
+    built_time: &str,
+    rustc_version: &str,
+) {
+    let git_information = match git_version {
+        None => "".to_string(),
+        Some(git) => format!(" (Git information: {})", git),
+    };
+    info!("Starting {}", pkg_description);
+    info!(
+        "This is version {}{}, built for {} by {} at {}",
+        pkg_version, git_information, target, rustc_version, built_time
+    )
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use tracing::info;
 ///
 /// Use the [`built`](https://crates.io/crates/built) crate and include it in your `main.rs` like this:
 ///
-/// ```ignore
+/// ```text
 /// mod built_info {
 ///     // The file has been placed there by the build script.
 ///     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -17,7 +17,7 @@ use tracing::info;
 ///
 /// Then call this method in your `main` method:
 ///
-/// ```ignore
+/// ```text
 /// stackable_operator::utils::print_startup_string(
 ///      built_info::PKG_DESCRIPTION,
 ///      built_info::PKG_VERSION,


### PR DESCRIPTION
This is related to https://github.com/stackabletech/issues/issues/19

I don't think we can include the full `bult` in `operator-rs` because it auto-generates a file at build time (using a `build.rs` script) and if we include this in operator-rs we'd get the information of `operator-rs` and not of the using library.

See https://github.com/stackabletech/spark-operator/pull/118 for an example on how to use it.