### PR TITLE
Add create config maps with labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_yaml = "0.8"
 strum = "0.21"
 strum_macros = "0.21"
 thiserror = "1.0"
-tokio = { version = "1.6", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -400,6 +400,7 @@ impl NodeBuilder {
 #[derive(Clone, Default)]
 pub struct ObjectMetaBuilder {
     name: Option<String>,
+    generate_name: Option<String>,
     namespace: Option<String>,
     ownerreference: Option<OwnerReference>,
     labels: BTreeMap<String, String>,
@@ -425,6 +426,19 @@ impl ObjectMetaBuilder {
 
     pub fn name<VALUE: Into<String>>(&mut self, name: VALUE) -> &mut Self {
         self.name = Some(name.into());
+        self
+    }
+
+    pub fn generate_name<VALUE: Into<String>>(&mut self, generate_name: VALUE) -> &mut Self {
+        self.generate_name = Some(generate_name.into());
+        self
+    }
+
+    pub fn generate_name_opt<VALUE: Into<Option<String>>>(
+        &mut self,
+        generate_name: VALUE,
+    ) -> &mut Self {
+        self.generate_name = generate_name.into();
         self
     }
 
@@ -543,6 +557,7 @@ impl ObjectMetaBuilder {
 
     pub fn build(&self) -> OperatorResult<ObjectMeta> {
         Ok(ObjectMeta {
+            generate_name: self.generate_name.clone(),
             name: self.name.clone(),
             namespace: self.namespace.clone(),
             owner_references: match self.ownerreference {
@@ -551,7 +566,6 @@ impl ObjectMetaBuilder {
             },
             labels: self.labels.clone(),
             annotations: self.annotations.clone(),
-
             ..ObjectMeta::default()
         })
     }
@@ -922,6 +936,7 @@ mod tests {
         pod.metadata.uid = Some("uid".to_string());
 
         let meta = ObjectMetaBuilder::new()
+            .generate_name("generate_foo")
             .name("foo")
             .namespace("bar")
             .ownerreference_from_resource(&pod, Some(true), Some(false))
@@ -931,6 +946,7 @@ mod tests {
             .build()
             .unwrap();
 
+        assert_eq!(meta.generate_name, Some("generate_foo".to_string()));
         assert_eq!(meta.name, Some("foo".to_string()));
         assert_eq!(meta.owner_references.len(), 1);
         assert!(

--- a/src/config_map_utils.rs
+++ b/src/config_map_utils.rs
@@ -1,0 +1,84 @@
+use crate::builder::{ConfigMapBuilder, ObjectMetaBuilder};
+use crate::client::Client;
+use crate::error::{Error, OperatorResult};
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use kube::Resource;
+use std::collections::BTreeMap;
+use tracing::{debug, info};
+
+pub fn build_config_map<T>(
+    cluster: &T,
+    name: &str,
+    namespace: &str,
+    labels: BTreeMap<String, String>,
+    data: BTreeMap<String, String>,
+) -> OperatorResult<ConfigMap>
+where
+    T: Resource<DynamicType = ()>,
+{
+    ConfigMapBuilder::new()
+        .metadata(
+            ObjectMetaBuilder::new()
+                .name(name.clone())
+                .ownerreference_from_resource(cluster, Some(true), Some(true))?
+                .namespace(namespace)
+                .with_labels(labels)
+                .build()?,
+        )
+        .data(data)
+        .build()
+}
+
+/// This method can be used to ensure a ConfigMap exists and has the specified content.
+///
+/// If a ConfigMap with the specified name does not exist it will be created.
+///
+/// Should a ConfigMap with the specified name already exist the content is retrieved and
+/// compared with the content from `config_map`, if content differs the existing ConfigMap is
+/// updated.
+///
+/// Returns `Ok(true)` if a change was made and `Ok(false}` if no change was necessary.
+pub async fn create_config_map(client: &Client, config_map: ConfigMap) -> OperatorResult<()> {
+    let existing_config_maps: Vec<ConfigMap> = client
+        .list_with_label_selector(
+            Some(&client.default_namespace),
+            &LabelSelector {
+                match_labels: config_map.metadata.labels.clone(),
+                ..LabelSelector::default()
+            },
+        )
+        .await?;
+
+    info!(
+        "Found {} configmap(s) with matching labels: {:?}",
+        existing_config_maps.len(),
+        config_map.metadata.labels
+    );
+
+    let cm_name = match config_map.metadata.name.as_deref() {
+        None => return Err(Error::InvalidName { errors: vec![] }),
+        Some(name) => name,
+    };
+
+    if existing_config_maps.is_empty() {
+        // nothing there yet, we need to create
+        info!("ConfigMap [{}] not existing, creating it.", cm_name);
+        client.create(&config_map).await?;
+    } else if existing_config_maps.len() == 1 {
+        if existing_config_maps.get(0).unwrap().data == config_map.data {
+            info!(
+                "ConfigMap [{}] already exists with identical data, skipping creation!",
+                cm_name
+            );
+        } else {
+            info!(
+                "ConfigMap [{}] already exists, but differs, updating it!",
+                cm_name
+            );
+            client.update(&config_map).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/config_map_utils.rs
+++ b/src/config_map_utils.rs
@@ -1,24 +1,46 @@
 use crate::builder::{ConfigMapBuilder, ObjectMetaBuilder};
 use crate::client::Client;
 use crate::error::{Error, OperatorResult};
+use crate::labels;
 use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::Resource;
+use lazy_static::lazy_static;
 use std::collections::BTreeMap;
-use tracing::{debug, info};
+use tracing::info;
 
-/// This method can be used to build a config map.
-///
-/// The labels must contain:
-/// *
+/// This is a required label to set in the configmaps to differentiate config maps for e.g.
+/// config, ids etc.
+pub const CM_TYPE_LABEL: &str = "configmap.stackable.tech/type";
+
+lazy_static! {
+    static ref REQUIRED_LABELS: Vec<&'static str> = {
+        vec![
+            labels::APP_NAME_LABEL,
+            labels::APP_INSTANCE_LABEL,
+            labels::APP_COMPONENT_LABEL,
+            labels::APP_MANAGED_BY_LABEL,
+            CM_TYPE_LABEL,
+        ]
+    };
+}
+
+/// This method can be used to build a config map. In order to create, update or delete a config
+/// map, it has to be uniquely identifiable via a LabelSelector. That is why the `labels` must
+/// contain at least the following labels:
+/// * `labels::APP_NAME_LABEL`
+/// * `labels::APP_INSTANCE_LABEL`
+/// * `labels::APP_COMPONENT_LABEL`
+/// * `labels::APP_MANAGED_BY_LABEL`
+/// * `config_map_utils::CM_TYPE_LABEL`
 ///
 /// # Arguments
 ///
 /// - `cluster` - The Kubernetes client.
-/// - `name` - The config map to create or update.
-/// - `namespace` - The config map to create or update.
-/// - `labels` - The config map to create or update.
-/// - `data` - The config map to create or update.
+/// - `name` - The config map name (generate_name).
+/// - `namespace` - The config map namespace.
+/// - `labels` - The config map labels.
+/// - `data` - The config map data.
 ///
 pub fn build_config_map<T>(
     cluster: &T,
@@ -30,6 +52,8 @@ pub fn build_config_map<T>(
 where
     T: Resource<DynamicType = ()>,
 {
+    check_labels(name, &labels)?;
+
     ConfigMapBuilder::new()
         .metadata(
             ObjectMetaBuilder::new()
@@ -41,6 +65,34 @@ where
         )
         .data(data)
         .build()
+}
+
+/// Checks if the labels contain the following:
+/// * `labels::APP_NAME_LABEL`
+/// * `labels::APP_INSTANCE_LABEL`
+/// * `labels::APP_COMPONENT_LABEL`
+/// * `labels::APP_MANAGED_BY_LABEL`
+/// * `config_map_utils::CM_TYPE_LABEL`
+///
+/// This is required to uniquely identify the config map.
+///
+fn check_labels(cm_name: &str, labels: &BTreeMap<String, String>) -> Result<(), Error> {
+    let mut missing_labels = vec![];
+
+    for label in REQUIRED_LABELS.to_vec() {
+        if !labels.contains_key(label) {
+            missing_labels.push(label);
+        }
+    }
+
+    return if missing_labels.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::ConfigMapMissingLabels {
+            name: cm_name.to_string(),
+            labels: missing_labels,
+        })
+    };
 }
 
 /// This method can be used to ensure a ConfigMap exists and has the specified content.
@@ -59,8 +111,8 @@ where
 /// - `config_map` - The config map to create or update.
 ///
 pub async fn create_config_map(client: &Client, config_map: ConfigMap) -> OperatorResult<()> {
-    let existing_config_maps: Vec<ConfigMap> = client
-        .list_with_label_selector(
+    let existing_config_maps = client
+        .list_with_label_selector::<ConfigMap>(
             Some(&client.default_namespace),
             &LabelSelector {
                 match_labels: config_map.metadata.labels.clone(),
@@ -75,8 +127,8 @@ pub async fn create_config_map(client: &Client, config_map: ConfigMap) -> Operat
         config_map.metadata.labels
     );
 
-    let cm_name = match config_map.metadata.name.as_deref() {
-        None => return Err(Error::InvalidName { errors: vec![] }),
+    let cm_name = match config_map.metadata.generate_name.as_deref() {
+        None => return Err(Error::ConfigMapMissingGenerateName),
         Some(name) => name,
     };
 

--- a/src/config_map_utils.rs
+++ b/src/config_map_utils.rs
@@ -7,6 +7,19 @@ use kube::Resource;
 use std::collections::BTreeMap;
 use tracing::{debug, info};
 
+/// This method can be used to build a config map.
+///
+/// The labels must contain:
+/// *
+///
+/// # Arguments
+///
+/// - `cluster` - The Kubernetes client.
+/// - `name` - The config map to create or update.
+/// - `namespace` - The config map to create or update.
+/// - `labels` - The config map to create or update.
+/// - `data` - The config map to create or update.
+///
 pub fn build_config_map<T>(
     cluster: &T,
     name: &str,
@@ -20,7 +33,7 @@ where
     ConfigMapBuilder::new()
         .metadata(
             ObjectMetaBuilder::new()
-                .name(name.clone())
+                .generate_name(name.clone())
                 .ownerreference_from_resource(cluster, Some(true), Some(true))?
                 .namespace(namespace)
                 .with_labels(labels)
@@ -38,7 +51,13 @@ where
 /// compared with the content from `config_map`, if content differs the existing ConfigMap is
 /// updated.
 ///
-/// Returns `Ok(true)` if a change was made and `Ok(false}` if no change was necessary.
+/// Returns `Ok(())` if created or updated. Otherwise error.
+///
+/// # Arguments
+///
+/// - `client` - The Kubernetes client.
+/// - `config_map` - The config map to create or update.
+///
 pub async fn create_config_map(client: &Client, config_map: ConfigMap) -> OperatorResult<()> {
     let existing_config_maps: Vec<ConfigMap> = client
         .list_with_label_selector(

--- a/src/configmap.rs
+++ b/src/configmap.rs
@@ -1,3 +1,20 @@
+//! This module offers methods to build and create/update configmaps.
+//!
+//! ConfigMaps using this module are required to implement certain labels to be identifiable via
+//! a LabelSelector:
+//! * `labels::APP_NAME_LABEL`
+//! * `labels::APP_INSTANCE_LABEL`
+//! * `labels::APP_COMPONENT_LABEL`
+//! * `labels::APP_ROLE_GROUP_LABEL`
+//! * `labels::APP_MANAGED_BY_LABEL`
+//! * `configmap::CONFIGMAP_TYPE_LABEL`
+//!
+//! ConfigMap names should be created via `name_utils::build_resource_name`. The name represents
+//! the metadata.generate_name.
+//!
+//! To have the 'full' name the config maps have to be created before mounting them into pods.
+//! The generate_name from `name_utils::build_resource_name` cannot be used as mount name.   
+//!
 use crate::builder::{ConfigMapBuilder, ObjectMetaBuilder};
 use crate::client::Client;
 use crate::error::{Error, OperatorResult};

--- a/src/configmap.rs
+++ b/src/configmap.rs
@@ -295,6 +295,7 @@ mod tests {
     #[test]
     fn test_filter_config_maps_multiple() {
         let time_old = Time(Utc::now());
+        let time_old_2 = Time(Utc::now() + Duration::minutes(10));
         let time_new = Time(Utc::now() + Duration::days(1));
 
         let config_maps = vec![
@@ -308,6 +309,13 @@ mod tests {
             ConfigMap {
                 metadata: ObjectMeta {
                     creation_timestamp: Some(time_new.clone()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ConfigMap {
+                metadata: ObjectMeta {
+                    creation_timestamp: Some(time_old_2),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/src/configmap.rs
+++ b/src/configmap.rs
@@ -6,12 +6,15 @@ use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::Resource;
 use lazy_static::lazy_static;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
-use tracing::{info, warn};
+use std::hash::{Hash, Hasher};
+use tracing::{debug, info, warn};
 
 /// This is a required label to set in the configmaps to differentiate config maps for e.g.
 /// config, data, ids etc.
-pub const CM_TYPE_LABEL: &str = "configmap.stackable.tech/type";
+pub const CONFIGMAP_TYPE_LABEL: &str = "configmap.stackable.tech/type";
+pub const CONFIGMAP_HASH_LABEL: &str = "configmap.stackable.tech/hash";
 
 lazy_static! {
     static ref REQUIRED_LABELS: Vec<&'static str> = {
@@ -21,20 +24,22 @@ lazy_static! {
             labels::APP_COMPONENT_LABEL,
             labels::APP_ROLE_GROUP_LABEL,
             labels::APP_MANAGED_BY_LABEL,
-            CM_TYPE_LABEL,
+            CONFIGMAP_TYPE_LABEL,
         ]
     };
 }
 
 /// This method can be used to build a config map. In order to create, update or delete a config
-/// map, it has to be uniquely identifiable via a LabelSelector. That is why the `labels` must
-/// contain at least the following labels:
+/// map, it has to be uniquely identifiable via a LabelSelector.
+/// That is why the `labels` must contain at least the following labels:
 /// * `labels::APP_NAME_LABEL`
 /// * `labels::APP_INSTANCE_LABEL`
 /// * `labels::APP_COMPONENT_LABEL`
 /// * `labels::APP_ROLE_GROUP_LABEL`
 /// * `labels::APP_MANAGED_BY_LABEL`
-/// * `config_map_utils::CM_TYPE_LABEL`
+/// * `configmap::CONFIGMAP_TYPE_LABEL`
+///
+/// The labels and data are hashed and added as configmap::CONFIGMAP_HASH_LABEL.
 ///
 /// # Arguments
 ///
@@ -59,7 +64,7 @@ where
     ConfigMapBuilder::new()
         .metadata(
             ObjectMetaBuilder::new()
-                .generate_name(name.clone())
+                .generate_name(name)
                 .ownerreference_from_resource(cluster, Some(true), Some(true))?
                 .namespace(namespace)
                 .with_labels(labels)
@@ -86,71 +91,64 @@ where
 ///
 pub async fn create_config_map(
     client: &Client,
-    config_map: ConfigMap,
+    mut config_map: ConfigMap,
 ) -> OperatorResult<ConfigMap> {
-    return if let Some(mut cm) = list_config_map(client, &config_map).await? {
-        info!(
-            "Found a configmap [{}] with matching labels: {:?}",
-            name(&config_map),
+    let hash = hash_config_map(&config_map);
+
+    return if let Some(mut existing_config_map) = find_config_map(client, &config_map).await? {
+        debug!(
+            "Found an existing configmap [{}] with matching labels: {:?}",
+            name(&existing_config_map),
             config_map.metadata.labels
         );
 
-        if cm.data != config_map.data {
-            cm = client.update(&config_map).await?;
+        // compare hashes and check for changes
+        if Some(&hash.to_string())
+            != existing_config_map
+                .metadata
+                .labels
+                .get(CONFIGMAP_HASH_LABEL)
+        {
             info!(
                 "ConfigMap [{}] already exists, but differs, updating it!",
-                name(&config_map),
+                name(&existing_config_map),
             );
+
+            merge_config_maps(&mut existing_config_map, config_map, hash);
+            existing_config_map = client.update(&existing_config_map).await?;
         }
 
-        Ok(cm)
+        Ok(existing_config_map)
     } else {
-        info!(
+        debug!(
             "ConfigMap [{}] not existing, creating it.",
             name(&config_map),
         );
+
+        config_map
+            .metadata
+            .labels
+            .insert(CONFIGMAP_HASH_LABEL.to_string(), hash.to_string());
+
         Ok(client.create(&config_map).await?)
-    };
-}
-
-/// Checks if the labels contain the following:
-/// * `labels::APP_NAME_LABEL`
-/// * `labels::APP_INSTANCE_LABEL`
-/// * `labels::APP_COMPONENT_LABEL`
-/// * `labels::APP_ROLE_GROUP_LABEL`
-/// * `labels::APP_MANAGED_BY_LABEL`
-/// * `config_map_utils::CM_TYPE_LABEL`
-///
-/// This is required to uniquely identify the config map.
-///
-fn check_labels(cm_name: &str, labels: &BTreeMap<String, String>) -> Result<(), Error> {
-    let mut missing_labels = vec![];
-
-    for label in REQUIRED_LABELS.to_vec() {
-        if !labels.contains_key(label) {
-            missing_labels.push(label);
-        }
-    }
-
-    return if missing_labels.is_empty() {
-        Ok(())
-    } else {
-        Err(Error::ConfigMapMissingLabels {
-            name: cm_name.to_string(),
-            labels: missing_labels,
-        })
     };
 }
 
 /// Returns `Ok(Some(ConfigMap))` if created or updated. Otherwise Ok(None). Returns Err if
 /// anything with listing the configmaps went wrong.
 ///
+/// For now we assume that the config map labels are unique. That means we will return only
+/// one matching config map.
+///
+/// If for some reason multiple config maps match the label selector, we log a warning and
+/// return the 'newest' config map, meaning the youngest creation timestamp.
+///
 /// # Arguments
 ///
 /// - `client` - The Kubernetes client.
 /// - `config_map` - The config map to create or update.
 ///
-async fn list_config_map(
+async fn find_config_map(
     client: &Client,
     config_map: &ConfigMap,
 ) -> OperatorResult<Option<ConfigMap>> {
@@ -187,6 +185,35 @@ async fn list_config_map(
     };
 }
 
+/// Checks if the labels contain the following:
+/// * `labels::APP_NAME_LABEL`
+/// * `labels::APP_INSTANCE_LABEL`
+/// * `labels::APP_COMPONENT_LABEL`
+/// * `labels::APP_ROLE_GROUP_LABEL`
+/// * `labels::APP_MANAGED_BY_LABEL`
+/// * `configmap::CONFIGMAP_TYPE_LABEL`
+///
+/// This is required to uniquely identify the config map.
+///
+fn check_labels(cm_name: &str, labels: &BTreeMap<String, String>) -> Result<(), Error> {
+    let mut missing_labels = vec![];
+
+    for label in REQUIRED_LABELS.to_vec() {
+        if !labels.contains_key(label) {
+            missing_labels.push(label);
+        }
+    }
+
+    if missing_labels.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::ConfigMapMissingLabels {
+            name: cm_name.to_string(),
+            labels: missing_labels,
+        })
+    }
+}
+
 /// Extract the metadata.name or alternatively metadata.generate_name.
 ///
 /// # Arguments
@@ -202,4 +229,35 @@ fn name(config_map: &ConfigMap) -> &str {
         (None, Some(generate_name)) => generate_name,
         _ => "<no-name-found>",
     };
+}
+
+/// Provides a hash of relevant parts of the config map in order to react on any changes.
+///
+/// # Arguments
+///
+/// - `config_map` - The ConfigMap to hash.
+///
+fn hash_config_map(config_map: &ConfigMap) -> u64 {
+    let mut s = DefaultHasher::new();
+    config_map.metadata.labels.hash(&mut s);
+    config_map.data.hash(&mut s);
+    s.finish()
+}
+
+/// Merges the data of the created with the existing config map.
+///
+/// # Arguments
+///
+/// - `existing` - The existing config map.
+/// - `created` - The created config map.
+/// - `hash` - The hash of the created config map.
+///
+fn merge_config_maps(existing: &mut ConfigMap, created: ConfigMap, hash: u64) {
+    existing.data = created.data;
+    existing.metadata.labels = created.metadata.labels;
+    // update hash
+    existing
+        .metadata
+        .labels
+        .insert(CONFIGMAP_HASH_LABEL.to_string(), hash.to_string());
 }

--- a/src/configmap.rs
+++ b/src/configmap.rs
@@ -14,6 +14,7 @@ use tracing::{debug, info, warn};
 /// This is a required label to set in the configmaps to differentiate config maps for e.g.
 /// config, data, ids etc.
 pub const CONFIGMAP_TYPE_LABEL: &str = "configmap.stackable.tech/type";
+/// This label will be set automatically to track the content of the config map.
 pub const CONFIGMAP_HASH_LABEL: &str = "configmap.stackable.tech/hash";
 
 lazy_static! {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,19 @@ use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error(
+    "The configmap is missing a generated name. This is a programming error. Please open a ticket."
+    )]
+    ConfigMapMissingGenerateName,
+
+    #[error(
+    "The config map [{name}] is missing labels [:?labels]. This is a programming error. Please open a ticket."
+    )]
+    ConfigMapMissingLabels {
+        name: String,
+        labels: Vec<&'static str>,
+    },
+
     #[error("Failed to serialize template to JSON: {source}")]
     JsonSerializationError {
         #[from]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod client;
 pub mod command_controller;
 pub mod conditions;
+pub mod config_map_utils;
 pub mod controller;
 pub mod controller_ref;
 pub mod controller_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod cli;
 pub mod client;
 pub mod command_controller;
 pub mod conditions;
-pub mod config_map_utils;
+pub mod configmap;
 pub mod controller;
 pub mod controller_ref;
 pub mod controller_utils;


### PR DESCRIPTION
- Added generate_name to ObjectMetaBuilder
- Added methods to build and create config maps via labels
- Added hash label to track the content and/or differences in the config map
- Bumped tokio to 1.10