### PR TITLE
Require a context for fieldManager when using Server-Side Apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Bugfix: when scheduling a pod, `GroupAntiAffinityStrategy` should not skip nodes that are mapped by other pods from different role+group. ([#222])
+- BREAKING: `Client::apply_patch` and `Client::apply_patch_status` now take a `context` argument that scopes their fieldManager ([#225])
+- Bugfix: `Client::set_condition` now scopes its fieldManager to the condition being applied ([#225])
 
 ### Added
 - `command.rs` module to handle common command operations ([#184]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 [#184]: https://github.com/stackabletech/operator-rs/pull/184
 [#222]: https://github.com/stackabletech/operator-rs/pull/222
+[#225]: https://github.com/stackabletech/operator-rs/pull/225
 
 ## [0.2.2] - 2021-09-21
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,7 +58,7 @@ impl Client {
     /// since it will revert changes that are owned by the `field_manager` but not part of the Apply request.
     fn apply_patch_params(&self, field_manager_scope: impl Display) -> PatchParams {
         let mut params = self.patch_params.clone();
-        // TODO: According to https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller we should always force conflicts in controllers.
+        // According to https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller we should always force conflicts in controllers.
         params.force = true;
         if let Some(manager) = &mut params.field_manager {
             *manager = format!("{}/{}", manager, field_manager_scope);

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use kube::{Api, Config};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::convert::TryFrom;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use tracing::{error, info, trace};
 
 /// This `Client` can be used to access Kubernetes.
@@ -24,8 +24,8 @@ use tracing::{error, info, trace};
 #[derive(Clone)]
 pub struct Client {
     client: KubeClient,
+    field_manager: Option<String>,
     patch_params: PatchParams,
-    force_patch_params: PatchParams,
     post_params: PostParams,
     delete_params: DeleteParams,
     /// Default namespace as defined in the kubeconfig this client has been created from.
@@ -40,25 +40,30 @@ impl Client {
     ) -> Self {
         Client {
             client,
+            field_manager: field_manager.clone(),
             post_params: PostParams {
                 field_manager: field_manager.clone(),
                 ..PostParams::default()
             },
             patch_params: PatchParams {
-                field_manager: field_manager.clone(),
-                ..PatchParams::default()
-            },
-            // TODO: According to https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller we should always force conflicts in controllers.
-            //  we currently consider this a workaround until we can properly implement patching
-            //  (see https://github.com/stackabletech/operator-rs/issues/113)
-            force_patch_params: PatchParams {
                 field_manager,
-                force: true,
                 ..PatchParams::default()
             },
             delete_params: DeleteParams::default(),
             default_namespace,
         }
+    }
+
+    /// Server-side apply requires a `field_manager` that uniquely identifies a single usage site,
+    /// since it will revert changes that are owned by the `field_manager` but not part of the Apply request.
+    fn apply_patch_params(&self, context: impl Display) -> PatchParams {
+        let mut params = self.patch_params.clone();
+        // TODO: According to https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller we should always force conflicts in controllers.
+        params.force = true;
+        if let Some(manager) = &mut params.field_manager {
+            *manager = format!("{}/{}", manager, context);
+        }
+        params
     }
 
     /// Returns a [kube::client::Client]] that can be freely used.
@@ -172,14 +177,23 @@ impl Client {
     /// and the merge strategy can differ from field to field and will be defined by the
     /// schema of the resource in question.
     /// This will _create_ or _update_ existing resources.
-    pub async fn apply_patch<T, P>(&self, resource: &T, patch: P) -> OperatorResult<T>
+    pub async fn apply_patch<T, P>(
+        &self,
+        context: &str,
+        resource: &T,
+        patch: P,
+    ) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
         P: Debug + Serialize,
     {
-        self.patch(resource, Patch::Apply(patch), &self.patch_params)
-            .await
+        self.patch(
+            resource,
+            Patch::Apply(patch),
+            &self.apply_patch_params(context),
+        )
+        .await
     }
 
     /// Patches a resource using the `JSON` patch strategy described in [JavaScript Object Notation (JSON) Patch](https://tools.ietf.org/html/rfc6902).
@@ -216,7 +230,12 @@ impl Client {
 
     /// Patches subresource status in a given Resource using apply strategy.
     /// The subresource status must be defined beforehand in the Crd.
-    pub async fn apply_patch_status<T, S>(&self, resource: &T, status: &S) -> OperatorResult<T>
+    pub async fn apply_patch_status<T, S>(
+        &self,
+        context: &str,
+        resource: &T,
+        status: &S,
+    ) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,
         <T as Resource>::DynamicType: Default,
@@ -229,7 +248,7 @@ impl Client {
         }));
 
         Ok(self
-            .patch_status(resource, new_status, &self.force_patch_params)
+            .patch_status(resource, new_status, &self.apply_patch_params(context))
             .await?)
     }
 
@@ -401,6 +420,7 @@ impl Client {
     where
         T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,
     {
+        let patch_params = self.apply_patch_params(format_args!("condition-{}", condition.type_));
         let new_status = Patch::Apply(serde_json::json!({
             "apiVersion": T::api_version(&()),
             "kind": T::kind(&()),
@@ -410,7 +430,7 @@ impl Client {
         }));
 
         Ok(self
-            .patch_status(resource, new_status, &self.force_patch_params)
+            .patch_status(resource, new_status, &patch_params)
             .await?)
     }
 


### PR DESCRIPTION
## Description
This is required so that different applies don't revert each other. For example, `set_condition` would trample on other conditions set by the same operator (actually, it still does that for another reason, #226).

This is technically breaking (adding a param to the public API), but no Stackable repos currently use the affected methods.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
