### PR TITLE
Remove duplicate resource identity from reconciler span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Bugfix: when scheduling a pod, `GroupAntiAffinityStrategy` should not skip nodes that are mapped by other pods from different role+group. ([#222])
+- Bugfix: removed duplicate object identity from reconciler. ([#228])
 
 ### Added
 - `command.rs` module to handle common command operations ([#184]).
@@ -27,6 +28,7 @@ All notable changes to this project will be documented in this file.
 
 [#184]: https://github.com/stackabletech/operator-rs/pull/184
 [#222]: https://github.com/stackabletech/operator-rs/pull/222
+[#228]: https://github.com/stackabletech/operator-rs/pull/228
 
 ## [0.2.2] - 2021-09-21
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -300,11 +300,7 @@ where
 /// This method contains the logic of reconciling an object (the desired state) we received with the actual state.
 #[tracing::instrument(
     skip(resource, context),
-    fields(
-        resource.name = ?resource.meta().name,
-        resource.namespace = ?resource.meta().namespace,
-        request_id = %Uuid::new_v4()
-    )
+    fields(request_id = %Uuid::new_v4()),
 )]
 async fn reconcile<S, T>(
     resource: T,


### PR DESCRIPTION
## Description

This is already provided by kube_runtime::Controller's span (https://github.com/kube-rs/kube-rs/blob/b13c619e699311788bc7cdbb0fdf18176ebd02ef/kube-runtime/src/controller/mod.rs#L274-L277). Maybe we should also move `request_id` upstream?

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
