### PR TITLE
Don't mandate boxing role configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ All notable changes to this project will be documented in this file.
 - `build_template` to `PodBuilder` ([#259]).
 - `readiness_probe` and `liveness_probe` to `ContainerBuilder` ([#259]).
 - `role_group_selector_labels` to `labels` ([#261]).
+- `Box<T: Configurable>` is now `Configurable` ([#262]).
 
 ### Changed
 - BREAKING: `ObjectMetaBuilder::build` is no longer fallible ([#259]).
 - BREAKING: `PodBuilder::metadata_builder` is no longer fallible ([#259]).
+- `role_utils::transform_all_roles_to_config` now takes any `T: Configurable`, not just `Box<T>` ([#262]).
+- BREAKING: Type-erasing `Role<T>` into `Role<Box<dyn Configurable>>` must now be done using `Role::erase` rather than `Role::into` ([#262]).
 
 [#259]: https://github.com/stackabletech/operator-rs/pull/259
 [#261]: https://github.com/stackabletech/operator-rs/pull/261
+[#262]: https://github.com/stackabletech/operator-rs/pull/262
 
 ## [0.4.0] - 2021-11-05
 

--- a/src/product_config_utils.rs
+++ b/src/product_config_utils.rs
@@ -68,7 +68,7 @@ impl<T: Configuration + ?Sized> Configuration for Box<T> {
         resource: &Self::Configurable,
         role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        T::compute_env(&self, resource, role_name)
+        T::compute_env(self, resource, role_name)
     }
 
     fn compute_cli(
@@ -76,7 +76,7 @@ impl<T: Configuration + ?Sized> Configuration for Box<T> {
         resource: &Self::Configurable,
         role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        T::compute_cli(&self, resource, role_name)
+        T::compute_cli(self, resource, role_name)
     }
 
     fn compute_files(
@@ -85,7 +85,7 @@ impl<T: Configuration + ?Sized> Configuration for Box<T> {
         role_name: &str,
         file: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        T::compute_files(&self, resource, role_name, file)
+        T::compute_files(self, resource, role_name, file)
     }
 }
 

--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -112,18 +112,15 @@ pub struct Role<T: Sized> {
     pub role_groups: HashMap<String, RoleGroup<T>>,
 }
 
-impl<T> From<Role<T>> for Role<Box<dyn Configuration<Configurable = T::Configurable>>>
-where
-    T: Configuration + 'static,
-{
+impl<T: Configuration + 'static> Role<T> {
     /// This casts a generic struct implementing [`crate::product_config_utils::Configuration`]
     /// and used in [`Role`] into a Box of a dynamically dispatched
     /// [`crate::product_config_utils::Configuration`] Trait. This is required to use the generic
     /// [`Role`] with more than a single generic struct. For example different roles most likely
     /// have different structs implementing Configuration.
-    fn from(role: Role<T>) -> Role<Box<dyn Configuration<Configurable = T::Configurable>>> {
+    pub fn erase(self) -> Role<Box<dyn Configuration<Configurable = T::Configurable>>> {
         Role {
-            config: role.config.map(|common| CommonConfiguration {
+            config: self.config.map(|common| CommonConfiguration {
                 config: common.config.map(|cfg| {
                     Box::new(cfg) as Box<dyn Configuration<Configurable = T::Configurable>>
                 }),
@@ -131,7 +128,7 @@ where
                 env_overrides: common.env_overrides,
                 cli_overrides: common.cli_overrides,
             }),
-            role_groups: role
+            role_groups: self
                 .role_groups
                 .into_iter()
                 .map(|(name, group)| {


### PR DESCRIPTION
## Description

For products where all roles take the same `Configuration` this means that you no longer need the `Role::into`. However, products that do have roles with different `Configuration` types you now need to use `Role::erase` instead.

## Review Checklist
- [X] Code contains useful comments
- [X] (Integration-)Test cases added (or not applicable)
- [X] Documentation added (or not applicable)
- [X] Changelog updated (or not applicable)
