### PR TITLE
Change all instances of &Option<T> to Option<&T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ All notable changes to this project will be documented in this file.
 - BREAKING: `PodBuilder::metadata_builder` is no longer fallible ([#259]).
 - `role_utils::transform_all_roles_to_config` now takes any `T: Configurable`, not just `Box<T>` ([#262]).
 - BREAKING: Type-erasing `Role<T>` into `Role<Box<dyn Configurable>>` must now be done using `Role::erase` rather than `Role::into` ([#262]).
+- BREAKING: Changed all `&Option<T>` into `Option<&T>`, some code will need to be rewritten to use `Option::as_ref` rather than `&foo` ([#263]).
 
 [#259]: https://github.com/stackabletech/operator-rs/pull/259
 [#261]: https://github.com/stackabletech/operator-rs/pull/261
 [#262]: https://github.com/stackabletech/operator-rs/pull/262
+[#263]: https://github.com/stackabletech/operator-rs/pull/263
 
 ## [0.4.0] - 2021-11-05
 

--- a/src/configmap.rs
+++ b/src/configmap.rs
@@ -175,7 +175,7 @@ async fn find_config_map(
 
     Ok(filter_config_map(
         existing_config_maps,
-        &config_map.metadata.labels,
+        config_map.metadata.labels.as_ref(),
     ))
 }
 
@@ -191,7 +191,7 @@ async fn find_config_map(
 ///
 fn filter_config_map(
     mut config_maps: Vec<ConfigMap>,
-    labels: &Option<BTreeMap<String, String>>,
+    labels: Option<&BTreeMap<String, String>>,
 ) -> Option<ConfigMap> {
     match config_maps.len() {
         0 => None,
@@ -334,7 +334,7 @@ mod tests {
             },
         ];
 
-        let filtered = filter_config_map(config_maps, &Some(BTreeMap::new())).unwrap();
+        let filtered = filter_config_map(config_maps, Some(&BTreeMap::new())).unwrap();
         assert_eq!(filtered.metadata.creation_timestamp, Some(time_new));
     }
 
@@ -342,7 +342,7 @@ mod tests {
     #[case(vec![], false)]
     #[case(vec![ConfigMap::default()], true)]
     fn test_filter_config_maps_single(#[case] config_maps: Vec<ConfigMap>, #[case] expected: bool) {
-        let filtered = filter_config_map(config_maps, &Some(BTreeMap::new()));
+        let filtered = filter_config_map(config_maps, Some(&BTreeMap::new()));
         assert_eq!(filtered.is_some(), expected);
     }
 

--- a/src/product_config_utils.rs
+++ b/src/product_config_utils.rs
@@ -347,13 +347,18 @@ where
 {
     let mut result = HashMap::new();
 
-    let role_properties = parse_role_config(resource, role_name, &role.config, property_kinds);
+    let role_properties =
+        parse_role_config(resource, role_name, role.config.as_ref(), property_kinds);
 
     // for each role group ...
     for (role_group_name, role_group) in &role.role_groups {
         // ... compute the group properties ...
-        let role_group_properties =
-            parse_role_config(resource, role_name, &role_group.config, property_kinds);
+        let role_group_properties = parse_role_config(
+            resource,
+            role_name,
+            role_group.config.as_ref(),
+            property_kinds,
+        );
 
         // ... and merge them with the role properties.
         let mut role_properties_copy = role_properties.clone();
@@ -383,7 +388,7 @@ where
 fn parse_role_config<T>(
     resource: &<T as Configuration>::Configurable,
     role_name: &str,
-    config: &Option<CommonConfiguration<T>>,
+    config: Option<&CommonConfiguration<T>>,
     property_kinds: &[PropertyNameKind],
 ) -> HashMap<PropertyNameKind, BTreeMap<String, Option<String>>>
 where
@@ -413,7 +418,7 @@ where
 fn parse_cli_properties<T>(
     resource: &<T as Configuration>::Configurable,
     role_name: &str,
-    config: &Option<CommonConfiguration<T>>,
+    config: Option<&CommonConfiguration<T>>,
 ) -> BTreeMap<String, Option<String>>
 where
     T: Configuration,
@@ -446,7 +451,7 @@ where
 fn parse_env_properties<T>(
     resource: &<T as Configuration>::Configurable,
     role_name: &str,
-    config: &Option<CommonConfiguration<T>>,
+    config: Option<&CommonConfiguration<T>>,
 ) -> BTreeMap<String, Option<String>>
 where
     T: Configuration,
@@ -479,7 +484,7 @@ where
 fn parse_file_properties<T>(
     resource: &<T as Configuration>::Configurable,
     role_name: &str,
-    config: &Option<CommonConfiguration<T>>,
+    config: Option<&CommonConfiguration<T>>,
     file: &str,
 ) -> BTreeMap<String, Option<String>>
 where

--- a/src/status.rs
+++ b/src/status.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 
 /// Provides access to the custom resource status.
 pub trait Status<T> {
-    fn status(&self) -> &Option<T>;
+    fn status(&self) -> Option<&T>;
     fn status_mut(&mut self) -> &mut Option<T>;
 }
 
@@ -34,7 +34,7 @@ pub trait HasCurrentCommand {
 
 /// Provides access to the custom resource status version for up or downgrades.
 pub trait Versioned<V> {
-    fn version(&self) -> &Option<ProductVersion<V>>;
+    fn version(&self) -> Option<&ProductVersion<V>>;
     fn version_mut(&mut self) -> &mut Option<ProductVersion<V>>;
 }
 

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -200,7 +200,7 @@ where
 ///
 fn build_version_and_condition<T, V>(
     resource: &T,
-    product_version: &Option<ProductVersion<V>>,
+    product_version: Option<&ProductVersion<V>>,
     spec_version: V,
     conditions: &[Condition],
 ) -> OperatorResult<(Option<ProductVersion<V>>, Option<Condition>)>
@@ -399,8 +399,8 @@ mod tests {
     }
 
     impl Status<TestClusterStatus> for TestCluster {
-        fn status(&self) -> &Option<TestClusterStatus> {
-            &self.status
+        fn status(&self) -> Option<&TestClusterStatus> {
+            self.status.as_ref()
         }
         fn status_mut(&mut self) -> &mut Option<TestClusterStatus> {
             &mut self.status
@@ -414,8 +414,8 @@ mod tests {
     }
 
     impl Versioned<TestVersion> for TestClusterStatus {
-        fn version(&self) -> &Option<ProductVersion<TestVersion>> {
-            &self.version
+        fn version(&self) -> Option<&ProductVersion<TestVersion>> {
+            self.version.as_ref()
         }
         fn version_mut(&mut self) -> &mut Option<ProductVersion<TestVersion>> {
             &mut self.version
@@ -514,7 +514,7 @@ mod tests {
 
         let (version, condition) = build_version_and_condition(
             &cluster,
-            &product_version,
+            product_version.as_ref(),
             spec_version,
             vec![].as_slice(),
         )
@@ -546,7 +546,12 @@ mod tests {
         let cluster: TestCluster =
             serde_yaml::from_str(TEST_CLUSTER_YAML).expect("Invalid test cluster definition!");
 
-        build_version_and_condition(&cluster, &product_version, spec_version, vec![].as_slice())
-            .unwrap_err();
+        build_version_and_condition(
+            &cluster,
+            product_version.as_ref(),
+            spec_version,
+            vec![].as_slice(),
+        )
+        .unwrap_err();
     }
 }


### PR DESCRIPTION
## Description

`Option<&T>` carries the same expressive power, is slightly more efficient, and
makes it easier to express some code with fewer clones.

In general code that provides provides these parameters will need to change from
`&foo` to `foo.as_ref()`, and from `&Some(foo)` to `Some(&foo)`. Rustc has a
specific lint for `as_ref`.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
