### PR TITLE
Add label role_selector_label for selecting objects belonging to any rolegroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - `build_template` to `PodBuilder` ([#259]).
 - `readiness_probe` and `liveness_probe` to `ContainerBuilder` ([#259]).
 - `role_group_selector_labels` to `labels` ([#261]).
+- `role_selector_labels` to `labels` ([#270]).
 - `Box<T: Configurable>` is now `Configurable` ([#262]).
 - `node_selector` to `PodBuilder` ([#267]).
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#263]: https://github.com/stackabletech/operator-rs/pull/263
 [#267]: https://github.com/stackabletech/operator-rs/pull/267
 [#269]: https://github.com/stackabletech/operator-rs/pull/269
+[#270]: https://github.com/stackabletech/operator-rs/pull/270
 
 ## [0.4.0] - 2021-11-05
 

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -50,9 +50,20 @@ pub fn role_group_selector_labels<T: Resource>(
     app_role: &str,
     app_role_group: &str,
 ) -> BTreeMap<String, String> {
+    let mut labels = role_selector_labels(resource, app_name, app_role);
+    labels.insert(APP_ROLE_GROUP_LABEL.to_string(), app_role_group.to_string());
+    labels
+}
+
+/// The labels required to match against objects of a certain role group, assuming that those objects
+/// are defined using [`get_recommended_labels`]
+pub fn role_selector_labels<T: Resource>(
+    resource: &T,
+    app_name: &str,
+    app_role: &str,
+) -> BTreeMap<String, String> {
     let mut labels = build_common_labels_for_all_managed_resources(app_name, &resource.name());
     labels.insert(APP_COMPONENT_LABEL.to_string(), app_role.to_string());
-    labels.insert(APP_ROLE_GROUP_LABEL.to_string(), app_role_group.to_string());
     labels
 }
 


### PR DESCRIPTION
## Description

`role_group_selector_label` isn't helpful for role-level services where we want to LB across all rolegroups.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
