### PR TITLE
Deprecated functionality based on overall operator rework and changed patterns

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,7 @@
 //!
 use crate::error;
 use crate::error::OperatorResult;
+#[allow(deprecated)]
 use crate::CustomResourceExt;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use std::path::Path;
@@ -180,6 +181,7 @@ fn check_path(
 /// * `name`: Name of the CRD
 ///
 /// returns: App
+#[allow(deprecated)]
 pub fn generate_crd_subcommand<'a, 'b, T>() -> App<'a, 'b>
 where
     T: CustomResourceExt,
@@ -217,6 +219,7 @@ where
 ///
 /// returns: A boolean wrapped in a result indicating whether the this method did handle the argument.
 ///          If it returns `Ok(true)` the program should abort.
+#[allow(deprecated)]
 pub fn handle_crd_subcommand<T>(matches: &ArgMatches) -> OperatorResult<bool>
 where
     T: CustomResourceExt,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, OperatorResult};
+#[allow(deprecated)]
 use crate::finalizer;
 use crate::label_selector;
 use crate::pod_utils;
@@ -344,6 +345,7 @@ impl Client {
     /// Which of the two are returned depends on the API being called.
     /// Take a look at the Kubernetes API reference.
     /// Some `delete` endpoints return the object and others return a `Status` object.
+    #[allow(deprecated)]
     pub async fn delete<T>(&self, resource: &T) -> OperatorResult<Option<Either<T, Status>>>
     where
         T: Clone + Debug + DeserializeOwned + Resource,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -113,7 +113,9 @@
 //!
 use crate::client::Client;
 use crate::error::Error;
+#[allow(deprecated)]
 use crate::reconcile;
+#[allow(deprecated)]
 use crate::reconcile::{ReconcileFunctionAction, ReconciliationContext};
 
 use async_trait::async_trait;
@@ -133,6 +135,7 @@ use uuid::Uuid;
 
 /// Every operator needs to provide an implementation of this trait as it provides the operator specific business logic.
 #[async_trait]
+#[allow(deprecated)]
 pub trait ControllerStrategy {
     type Item;
     type State: ReconciliationState;
@@ -176,6 +179,7 @@ pub trait ReconciliationState {
     //
     /// Returns a Future that - when completed - will either return an `Error` or a `ReconciliationFunctionAction`.
     /// The return result can be used to requeue the same resource for later.
+    #[allow(deprecated)]
     fn reconcile(
         &mut self,
     ) -> Pin<Box<dyn Future<Output = Result<ReconcileFunctionAction, Self::Error>> + Send + '_>>;
@@ -296,6 +300,7 @@ where
     skip(resource, context),
     fields(request_id = %Uuid::new_v4()),
 )]
+#[allow(deprecated)]
 async fn reconcile<S, T>(
     resource: T,
     context: Context<ControllerContext<S>>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use crate::name_utils;
 use crate::product_config_utils;
 use std::collections::{BTreeMap, HashSet};
@@ -66,6 +67,7 @@ pub enum Error {
     },
 
     #[error("NameUtils reported error: {source}")]
+    #[allow(deprecated)]
     NamingError {
         #[from]
         source: name_utils::Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,95 @@
 pub mod builder;
 pub mod cli;
 pub mod client;
+#[deprecated(
+    since = "0.5.0",
+    note = "Start/Stop has been moved to the cluster definition, other commands will be re-added in a different way when needed."
+)]
+#[allow(deprecated)]
 pub mod command;
+#[deprecated(
+    since = "0.5.0",
+    note = "Start/Stop has been moved to the cluster definition, other commands will be re-added in a different way when needed."
+)]
+#[allow(deprecated)]
 pub mod command_controller;
+
+#[deprecated(since = "0.5.0")]
+#[allow(deprecated)]
 pub mod conditions;
+
+#[deprecated(since = "0.5.0")]
+#[allow(deprecated)]
 pub mod configmap;
 pub mod controller;
+
+#[deprecated(since = "0.5.0")]
+#[allow(deprecated)]
 pub mod controller_ref;
+
+#[deprecated(since = "0.5.0")]
+#[allow(deprecated)]
 pub mod controller_utils;
+
+#[deprecated(
+    since = "0.5.0",
+    note = "Waiting for resources to be present has been upstreamed to kube.rs in 0.58"
+)]
+#[allow(deprecated)]
 pub mod crd;
 pub mod error;
+
+#[deprecated(
+    since = "0.5.0",
+    note = "Finalizer handling has been introduced in kube.rs 0.58"
+)]
+#[allow(deprecated)]
 pub mod finalizer;
+
+#[deprecated(since = "0.5.0", note = "Only needed for the sticky scheduler")]
+#[allow(deprecated)]
 pub mod identity;
+
+#[deprecated(since = "0.5.0")]
 pub mod k8s_errors;
+
+#[deprecated(since = "0.5.0", note = "Unneeded due move to statefulsets")]
+#[allow(deprecated)]
 pub mod k8s_utils;
 pub mod label_selector;
 pub mod labels;
 pub mod logging;
+
+#[deprecated(
+    since = "0.5.0",
+    note = "Functionality to be moved to RoleGroupRef (go talk to Teo if what you need is not yet supported)"
+)]
+#[allow(deprecated)]
 pub mod name_utils;
 pub mod namespace;
 pub mod pod_utils;
 pub mod product_config_utils;
+
+#[deprecated(since = "0.5.0", note = "Unneeded due move to statefulsets")]
+#[allow(deprecated)]
 pub mod reconcile;
 pub mod role_utils;
+
+#[deprecated(since = "0.5.0", note = "Unneeded due move to statefulsets")]
+#[allow(deprecated)]
 pub mod scheduler;
+
+#[deprecated(since = "0.5.0", note = "Unneeded after changed command handling")]
+#[allow(deprecated)]
 pub mod status;
 pub mod utils;
 pub mod validation;
+
+#[deprecated(since = "0.5.0", note = "Unneeded due move to statefulsets")]
+#[allow(deprecated)]
 pub mod versioning;
 
+#[allow(deprecated)]
 pub use crate::crd::CustomResourceExt;
 
 pub use ::k8s_openapi;

--- a/src/pod_utils.rs
+++ b/src/pod_utils.rs
@@ -1,7 +1,14 @@
+/*
+We consider the functions in this module to be somewhat useful.
+Not necessarily these exact functions, but things in here will probably stick around in some
+shape or form.
+ */
+
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::result::Result;
 
+#[allow(deprecated)]
 use crate::k8s_utils::LabelOptionalValueMap;
 use k8s_openapi::api::core::v1::{Node, Pod, PodCondition, PodSpec, PodStatus};
 use kube::api::{Resource, ResourceExt};
@@ -198,6 +205,7 @@ pub fn is_pod_assigned_to_node(pod: &Pod, node: &Node) -> bool {
 ///
 /// assert!(!pod_utils::pod_matches_labels(&pod, &required_labels));
 /// ```
+#[allow(deprecated)]
 pub fn pod_matches_labels(pod: &Pod, required_labels: &LabelOptionalValueMap) -> bool {
     // We convert the `required_labels` into a form that can be understood by `pod_matches_multiple_label_values`
     let converted = required_labels

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,3 +1,11 @@
+/*
+   Keep this around for now, it could be useful, because it allows performing Kubernetes checks
+   before actually sending a request and waiting for it to fail.
+
+   Warning: You should be sure that Kubernetes enforces these rules for the request you are trying
+   to validate.
+*/
+
 // This is adapted from Kubernetes.
 // See apimachinery/pkg/util/validation/validation.go, apimachinery/pkg/api/validation/generic.go and pkg/apis/core/validation/validation.go in the Kubernetes source
 


### PR DESCRIPTION
A lot of the functionality in the operator framework has become unnecessary over time.

This PR deprecates these functions to make developing new operators easier and ensure that no "old" functionality is used by accident.

Based on https://github.com/stackabletech/operator-rs/issues/257

Signed-off-by: Sönke Liebau <soenke.liebau@stackable.de>

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
