### PR TITLE
Exclude `cli::Command` doccomment from `--help`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Fixed `cli::Command` including developer-facing docs in `--help` output ([#283])
+
+[#283]: https://github.com/stackabletech/operator-rs/pull/283
+
 ## [0.6.0] - 2021-12-13
 
 ### Changed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,9 @@ pub const AUTHOR: &str = "Stackable GmbH - info@stackable.de";
 /// }
 /// ```
 #[derive(StructOpt)]
+// The enum-level doccomment is intended for developers, not end users
+// so supress it from being included in --help
+#[structopt(long_about = "")]
 pub enum Command {
     /// Print CRD objects
     Crd,


### PR DESCRIPTION
## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
