### PR TITLE
Upgrade Clap to 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- BREAKING: clap 2.33.3 -> 3.0.4 ([#289]).
+
+[#289]: https://github.com/stackabletech/operator-rs/pull/289
+
 ## [0.7.0] - 2021-12-22
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/stackabletech/operator-rs"
 [dependencies]
 async-trait = "0.1.51"
 chrono = "0.4.19"
-clap = { version = "3.0.4", features = ["derive"] }
+clap = { version = "3.0.4", features = ["derive", "cargo"] }
 const_format = "0.2.22"
 either = "1.6.1"
 futures = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/stackabletech/operator-rs"
 [dependencies]
 async-trait = "0.1.51"
 chrono = "0.4.19"
-clap = "2.33.3"
+clap = { version = "3.0.4", features = ["derive"] }
 const_format = "0.2.22"
 either = "1.6.1"
 futures = "0.3.17"
@@ -35,7 +35,6 @@ tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 backoff = "0.4.0"
 derivative = "2.2.0"
-structopt = "0.3.25"
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,13 +94,12 @@ use crate::error;
 use crate::error::OperatorResult;
 #[allow(deprecated)]
 use crate::CustomResourceExt;
-use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches};
 use product_config::ProductConfigManager;
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 pub const AUTHOR: &str = "Stackable GmbH - info@stackable.de";
 
@@ -116,19 +115,19 @@ pub const AUTHOR: &str = "Stackable GmbH - info@stackable.de";
 ///     Framework(stackable_operator::cli::Command)
 /// }
 /// ```
-#[derive(StructOpt)]
+#[derive(clap::Parser)]
 // The enum-level doccomment is intended for developers, not end users
 // so supress it from being included in --help
-#[structopt(long_about = "")]
+#[clap(long_about = "")]
 pub enum Command {
     /// Print CRD objects
     Crd,
     /// Run operator
     Run {
         /// Provides the path to a product-config file
-        #[structopt(
+        #[clap(
             long,
-            short = "p",
+            short = 'p',
             value_name = "FILE",
             default_value = "",
             parse(from_os_str)
@@ -200,9 +199,9 @@ const PRODUCT_CONFIG_ARG: &str = "product-config";
 ///
 /// See the module level documentation for a complete example.
 #[deprecated(note = "use ProductConfigPath (or Command) instead")]
-pub fn generate_productconfig_arg<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name(PRODUCT_CONFIG_ARG)
-        .short("p")
+pub fn generate_productconfig_arg() -> Arg<'static> {
+    Arg::new(PRODUCT_CONFIG_ARG)
+        .short('p')
         .long(PRODUCT_CONFIG_ARG)
         .value_name("FILE")
         .help("Provides the path to a product-config file")
@@ -248,23 +247,23 @@ pub fn handle_productconfig_arg(
 /// returns: App
 #[deprecated(note = "use Command instead")]
 #[allow(deprecated)]
-pub fn generate_crd_subcommand<'a, 'b, T>() -> App<'a, 'b>
+pub fn generate_crd_subcommand<T>() -> App<'static>
 where
     T: CustomResourceExt,
 {
     let kind = T::api_resource().kind;
 
-    SubCommand::with_name(&kind.to_lowercase())
+    App::new(&kind.to_lowercase())
         .setting(AppSettings::ArgRequiredElseHelp)
         .arg(
             Arg::with_name("print")
-                .short("p")
+                .short('p')
                 .long("print")
                 .help("Will print the CRD schema in YAML format to stdout"),
         )
         .arg(
             Arg::with_name("save")
-                .short("s")
+                .short('s')
                 .long("save")
                 .takes_value(true)
                 .value_name("FILE")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! This module provides helper methods to deal with common CLI options using the `clap` crate.
 //!
 //! In particular it currently supports handling two kinds of options:
-//! * CRD handling (printing & saving to a file)
+//! * CRD printing
 //! * Product config location
 //!
 //! # Example
@@ -10,8 +10,7 @@
 //!
 //! ```
 //! // Handle CLI arguments
-//! use clap::{crate_version, SubCommand};
-//! use clap::App;
+//! use clap::{crate_version, App};
 //! use stackable_operator::cli;
 //! use stackable_operator::error::OperatorResult;
 //! use kube::CustomResource;
@@ -46,13 +45,13 @@
 //!     .about("Stackable Operator for Foobar")
 //!     .version(crate_version!())
 //!     .subcommand(
-//!         SubCommand::with_name("crd")
+//!         App::new("crd")
 //!             .subcommand(cli::generate_crd_subcommand::<FooCluster>())
 //!             .subcommand(cli::generate_crd_subcommand::<BarCluster>())
 //!     )
 //!     .get_matches();
 //!
-//! if let ("crd", Some(subcommand)) = matches.subcommand() {
+//! if let Some(("crd", subcommand)) = matches.subcommand() {
 //!     if cli::handle_crd_subcommand::<FooCluster>(subcommand)? {
 //!         return Ok(());
 //!     };
@@ -67,10 +66,9 @@
 //! Product config handling works similarly:
 //!
 //! ```no_run
-//! use clap::{crate_version, SubCommand};
+//! use clap::{crate_version, App};
 //! use stackable_operator::cli;
 //! use stackable_operator::error::OperatorResult;
-//! use clap::App;
 //!
 //! # fn main() -> OperatorResult<()> {
 //! let matches = App::new("Spark Operator")
@@ -107,7 +105,7 @@ pub const AUTHOR: &str = "Stackable GmbH - info@stackable.de";
 ///
 /// If you need operator-specific commands then you can flatten [`Command`] into your own command enum. For example:
 /// ```rust
-/// #[derive(structopt::StructOpt)]
+/// #[derive(clap::Parser)]
 /// enum Command {
 ///     /// Print hello world message
 ///     Hello,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,7 @@
 //!
 //! #[derive(clap::Parser)]
 //! #[clap(
-//!     name = "Spark Operator",
+//!     name = "Foobar Operator",
 //!     author,
 //!     version,
 //!     about = "Stackable Operator for Foobar"
@@ -77,7 +77,7 @@
 //!
 //! #[derive(clap::Parser)]
 //! #[clap(
-//!     name = "Spark Operator",
+//!     name = "Foobar Operator",
 //!     author,
 //!     version,
 //!     about = "Stackable Operator for Foobar"


### PR DESCRIPTION
## Description
This requires some manual work (compared to #288), since Clap is a breaking update. In particular, `structopt::StructOpt` has now been upstreamed as `clap::Parser`.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
