### PR TITLE
Update kube-rs from 0.65.0 to 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- BREAKING: kube-rs 0.65.0 -> 0.66.0 ([#295])
+
+[#295]: https://github.com/stackabletech/operator-rs/pull/295
+
 ## [0.7.0] - 2021-12-22
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ either = "1.6.1"
 futures = "0.3.17"
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.13.1", default-features = false, features = ["schemars", "v1_22"] }
-kube = { version = "0.65.0", features = ["jsonpatch", "runtime", "derive"] }
+kube = { version = "0.66.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.3.0" }
 rand = "0.8.4"


### PR DESCRIPTION
Update kube-rs dependency


**Changelog 0.66.0 / 2022-01-15**

Tons of ergonomics improvements, and 3 new contributors.
Highlighted first is the 3 **most discussed** changes:

### [Support for auto-generating schemas for enums in `kube-derive`](https://github.com/kube-rs/kube-rs/issues/779)

It is now possible to **embed complex enums** inside structs that use `#[derive(CustomResource)]`.

This has been a [highly requested feature](https://github.com/kube-rs/kube-rs/issues/648) since the inception of auto-generated schemas. It does [not work for all cases](https://docs.rs/kube/latest/kube/derive.CustomResource.html#enums), and has [certain ergonomics caveats](https://docs.rs/kube/0.66.0/kube/core/schema/struct.StructuralSchemaRewriter.html#method.visit_schema_object), but represents a huge step forwards.

Note that **if** you depend on `kube-derive` directly rather than via `kube` then you **must** now add the `schema` feature to `kube-core`

### [New `StreamBackoff` mechanism in `kube-runtime`](https://github.com/kube-rs/kube-rs/issues/703)

To avoid spamming the apiserver when on certain watch errors cases, it's now possible to [stream wrap](https://docs.rs/kube/0.66.0/kube/runtime/utils/struct.StreamBackoff.html) the `watcher` to set backoffs. The new [`default_backoff`](https://docs.rs/kube/0.66.0/kube/runtime/watcher/fn.default_backoff.html) follows existing `client-go` conventions of being kind to the apiserver.

Initially, this is **default-enabled** in `Controller` watches (configurable via [`Controller::trigger_backoff`](https://docs.rs/kube/latest/kube/runtime/struct.Controller.html#method.trigger_backoff)) and avoids spam errors when crds are not installed.

### [New version priority parser in `kube-core`](https://github.com/kube-rs/kube-rs/issues/764)

To aid users picking the most appropriate version of a `kind` from [api discovery](https://docs.rs/kube/0.66.0/kube/discovery/index.html) or [through a CRD](https://github.com/kube-rs/kopium/), two new sort orders have been exposed on the new [`kube_core::Version`](https://docs.rs/kube/latest/kube/core/enum.Version.html)

- [`Version::priority`](https://docs.rs/kube/0.66.0/kube/core/enum.Version.html#method.priority) implementing [kubernetes version priority](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority)
- [`Version::generation`](https://docs.rs/kube/0.66.0/kube/core/enum.Version.html#method.generation) implementing a more traditional; generational sort (highest version)

## Changes
Merged PRs from [github release](https://github.com/kube-rs/kube-rs/releases/tag/0.66.0).
### Added
* Add `DeleteParams` constructors for easily setting `PropagationPolicy` by @kate-goldenring in https://github.com/kube-rs/kube-rs/pull/757
* Add Serialize to ObjecList and add field-selector and jsonpath example by @ChinYing-Li in https://github.com/kube-rs/kube-rs/pull/760
* Implement cordon/uncordon for Node by @ChinYing-Li in https://github.com/kube-rs/kube-rs/pull/762
* Export Version priority parser with Ord impls in kube_core by @clux in https://github.com/kube-rs/kube-rs/pull/764
* Add Api fns for arbitrary subresources and approval subresource for CertificateSigningRequest by @ChinYing-Li in https://github.com/kube-rs/kube-rs/pull/773

### Changed
* Add backoff handling for watcher and Controller by @clux in https://github.com/kube-rs/kube-rs/pull/703
* Remove crate private `identity_pem` field from `Config` by @kazk in https://github.com/kube-rs/kube-rs/pull/771
* Use SecretString in AuthInfo to avoid credential leaking by @ChinYing-Li in https://github.com/kube-rs/kube-rs/pull/766

Signed-off-by: Sönke Liebau <soenke.liebau@stackable.de>

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
