### PR TITLE
Kube: 0.66 -> 0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- BREAKING: kube 0.66 -> 0.68.
-- BREAKING: k8s-openapi 0.13 -> 0.14.
+- BREAKING: kube 0.66 -> 0.68 ([#303]).
+- BREAKING: k8s-openapi 0.13 -> 0.14 ([#303]).
+
+[#303]: https://github.com/stackabletech/operator-rs/pull/303
 
 ## [0.9.0] - 2022-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- BREAKING: kube 0.66 -> 0.68.
+- BREAKING: k8s-openapi 0.13 -> 0.14.
+
 ## [0.9.0] - 2022-01-27
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ const_format = "0.2.22"
 either = "1.6.1"
 futures = "0.3.17"
 json-patch = "0.2.6"
-k8s-openapi = { version = "0.13.1", default-features = false, features = ["schemars", "v1_22"] }
-kube = { version = "0.66.0", features = ["jsonpatch", "runtime", "derive"] }
+k8s-openapi = { version = "0.14.0", default-features = false, features = ["schemars", "v1_22"] }
+kube = { version = "0.68.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.3.0" }
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ version = "0.10.0-nightly"
 repository = "https://github.com/stackabletech/operator-rs"
 
 [dependencies]
-async-trait = "0.1.51"
+async-trait = "0.1.52"
 chrono = "0.4.19"
-clap = { version = "3.0.4", features = ["derive", "cargo"] }
+clap = { version = "3.0.13", features = ["derive", "cargo"] }
 const_format = "0.2.22"
 either = "1.6.1"
-futures = "0.3.17"
+futures = "0.3.19"
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["schemars", "v1_22"] }
 kube = { version = "0.68.0", features = ["jsonpatch", "runtime", "derive"] }
@@ -21,17 +21,17 @@ lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.3.0" }
 rand = "0.8.4"
 regex = "1.5.4"
-schemars = "0.8.7"
-serde = "1.0.130"
-serde_json = "1.0.68"
-serde_yaml = "0.8.21"
+schemars = "0.8.8"
+serde = "1.0.136"
+serde_json = "1.0.78"
+serde_yaml = "0.8.23"
 strum = "0.23.0"
 strum_macros = "0.23.1"
 thiserror = "1.0.30"
-tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
-tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 backoff = "0.4.0"
 derivative = "2.2.0"
@@ -39,7 +39,7 @@ derivative = "2.2.0"
 [dev-dependencies]
 rstest = "0.12.0"
 serial_test = "0.5.1"
-tempfile = "3.2.0"
+tempfile = "3.3.0"
 
 [features]
 default = ["native-tls"]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -129,6 +129,7 @@ use std::fmt::{Debug, Display};
 use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, trace, warn, Instrument};
 use uuid::Uuid;
@@ -302,7 +303,7 @@ where
 )]
 #[allow(deprecated)]
 async fn reconcile<S, T>(
-    resource: T,
+    resource: Arc<T>,
     context: Context<ControllerContext<S>>,
 ) -> Result<ReconcilerAction, Error>
 where
@@ -316,7 +317,7 @@ where
 
     let rc = ReconciliationContext::new(
         context.client.clone(),
-        resource.clone(),
+        T::clone(&resource),
         context.requeue_timeout,
     );
 


### PR DESCRIPTION
## Description

### Features

Kube-rs now supports user impersonation! Run your operators with the environment variable `KUBE_RS_DEBUG_IMPERSONATE_USER=system:serviceaccount:default:my-operator` to run the operator with the same RBAC rules as the ServiceAccount `my-operator` in `default`.

### Breakage

Operator reconcile function signatures will have to change from `async fn reconcile(obj: K, ...)` to `async fn reconcile(obj: Arc<K>, ...)`.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
