### PR TITLE
Disable service links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 - BREAKING: kube 0.66 -> 0.68 ([#303]).
 - BREAKING: k8s-openapi 0.13 -> 0.14 ([#303]).
 
+### Removed
+- Auto-generated service link environment variables for built pods ([#305]).
+
 [#303]: https://github.com/stackabletech/operator-rs/pull/303
+[#305]: https://github.com/stackabletech/operator-rs/pull/305
 
 ## [0.9.0] - 2022-01-27
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1093,6 +1093,10 @@ impl PodBuilder {
             security_context: self.security_context.clone(),
             tolerations: self.tolerations.clone(),
             volumes: self.volumes.clone(),
+            // Legacy feature for ancient Docker images
+            // In practice, this just causes a bunch of unused environment variables that may conflict with other uses,
+            // such as https://github.com/stackabletech/spark-operator/pull/256.
+            enable_service_links: Some(false),
             ..PodSpec::default()
         }
     }


### PR DESCRIPTION
## Description
This causes K8s to generate a bunch of environment variables that may break the system being ran, causing issues such as https://github.com/stackabletech/spark-operator/pull/256.

This is technically breaking, but this "feature" is virtually unused anyway.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
