### PR TITLE
Add `ClusterRef` as discussed at the last architecture meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Unified `ClusterRef` type for referring to cluster objects ([#307]).
+
 ### Changed
 - BREAKING: kube 0.66 -> 0.68 ([#303]).
 - BREAKING: k8s-openapi 0.13 -> 0.14 ([#303]).
 
 [#303]: https://github.com/stackabletech/operator-rs/pull/303
+[#307]: https://github.com/stackabletech/operator-rs/pull/307
 
 ## [0.9.0] - 2022-01-27
 

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,6 +1,10 @@
+use std::marker::PhantomData;
 use std::time::Duration;
 
+use derivative::Derivative;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
 use crate::client::Client;
@@ -13,6 +17,55 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+
+/// A reference to a product cluster (for example, a `ZookeeperCluster`)
+///
+/// `namespace`'s defaulting only applies when retrieved via [`ClusterRef::namespace_relative_from`]
+#[derive(Deserialize, Serialize, JsonSchema, Derivative)]
+#[derivative(
+    Default(bound = ""),
+    Clone(bound = ""),
+    Debug(bound = ""),
+    PartialEq(bound = "")
+)]
+pub struct ClusterRef<K> {
+    /// The name of the cluster
+    pub name: Option<String>,
+    /// The namespace of the cluster
+    ///
+    /// This field is optional, and will default to the namespace of the referring object.
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(skip)]
+    _kind: PhantomData<K>,
+}
+
+impl<K: kube::Resource> ClusterRef<K> {
+    pub fn to_named(name: &str, namespace: Option<&str>) -> Self {
+        Self {
+            name: Some(name.into()),
+            namespace: namespace.map(|ns| ns.into()),
+            _kind: PhantomData,
+        }
+    }
+
+    pub fn to_object(obj: &K) -> Self {
+        Self {
+            name: obj.meta().name.clone(),
+            namespace: obj.meta().namespace.clone(),
+            _kind: PhantomData,
+        }
+    }
+
+    pub fn namespace_relative_from<'a, K2: kube::Resource>(
+        &'a self,
+        container: &'a K2,
+    ) -> Option<&'a str> {
+        self.namespace
+            .as_deref()
+            .or_else(|| container.meta().namespace.as_deref())
+    }
+}
 
 /// Retrieve the custom resource name (e.g. simple-test-cluster).
 pub trait HasInstance {
@@ -245,4 +298,41 @@ where
         .wait_created::<CustomResourceDefinition>(None, lp)
         .await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use k8s_openapi::api::core::v1::ConfigMap;
+    use kube::core::ObjectMeta;
+
+    use super::ClusterRef;
+
+    #[test]
+    fn cluster_ref_should_default_namespace() {
+        let relative_ref = ClusterRef::<ConfigMap>::to_named("foo", None);
+        let absolute_ref = ClusterRef::<ConfigMap>::to_named("foo", Some("bar"));
+
+        let nsless_obj = ConfigMap::default();
+        let namespaced_obj = ConfigMap {
+            metadata: ObjectMeta {
+                namespace: Some("baz".to_string()),
+                ..ObjectMeta::default()
+            },
+            ..ConfigMap::default()
+        };
+
+        assert_eq!(relative_ref.namespace_relative_from(&nsless_obj), None);
+        assert_eq!(
+            absolute_ref.namespace_relative_from(&nsless_obj),
+            Some("bar")
+        );
+        assert_eq!(
+            relative_ref.namespace_relative_from(&namespaced_obj),
+            Some("baz")
+        );
+        assert_eq!(
+            absolute_ref.namespace_relative_from(&namespaced_obj),
+            Some("bar")
+        );
+    }
 }


### PR DESCRIPTION
## Description
Inspired by `ZookeeperClusterRef` (including https://github.com/stackabletech/zookeeper-operator/pull/382), but generalized and added some convenience methods.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
