### PR TITLE
Truncate K8s event message if it is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Reported K8s events are now limited to 1024 bytes ([#327]).
+
 ### Removed
 - `Client::set_condition` ([#326]).
 - `Error` variants that are no longer used ([#326]).
 
 [#326]: https://github.com/stackabletech/operator-rs/pull/326
+[#327]: https://github.com/stackabletech/operator-rs/pull/327
 
 ## [0.11.0] - 2022-02-17
 

--- a/src/logging/k8s_events.rs
+++ b/src/logging/k8s_events.rs
@@ -87,8 +87,10 @@ mod message {
         const ELLIPSIS_LEN: usize = ELLIPSIS.len_utf8();
         let len = msg.len();
         if len > max_len {
-            msg.truncate(find_start_of_char(msg, len - ELLIPSIS_LEN));
-            msg.push(ELLIPSIS);
+            msg.truncate(find_start_of_char(msg, len.saturating_sub(ELLIPSIS_LEN)));
+            if ELLIPSIS_LEN <= max_len {
+                msg.push(ELLIPSIS);
+            }
         }
     }
 

--- a/src/logging/k8s_events.rs
+++ b/src/logging/k8s_events.rs
@@ -79,6 +79,9 @@ pub fn publish_controller_error_as_k8s_event<ReconcileErr, QueueErr>(
 }
 
 mod message {
+    /// Ensures that `msg` is at most `max_len` _bytes_ long
+    ///
+    /// If `msg` is longer than `max_len` then the extra text is replaced with an ellipsis.
     pub fn truncate_with_ellipsis(msg: &mut String, max_len: usize) {
         const ELLIPSIS: char = '…';
         const ELLIPSIS_LEN: usize = ELLIPSIS.len_utf8();


### PR DESCRIPTION
## Description
As reported by @maltesander.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
