### PR TITLE
Added watch_namespace parameter to `ProductOperatorRun`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- BREAKING: Added CLI `watch_namespace` parameter to ProductOperatorRun in
+  preparation for operators watching a single namespace ([#332]).
+
 ### Changed
 
 - Build against Kubernetes 1.23 ([#330]).
 
 [#330]: https://github.com/stackabletech/operator-rs/pull/330
+[#332]: https://github.com/stackabletech/operator-rs/pull/332
 
 ## [0.12.0] - 2022-02-18
-
 
 ### Changed
 - Reported K8s events are now limited to 1024 bytes ([#327]).
@@ -24,7 +29,6 @@ All notable changes to this project will be documented in this file.
 [#327]: https://github.com/stackabletech/operator-rs/pull/327
 
 ## [0.11.0] - 2022-02-17
-
 
 ### Added
 - Infrastructure for logging errors as K8s events ([#322]).
@@ -43,7 +47,6 @@ All notable changes to this project will be documented in this file.
 
 ## [0.10.0] - 2022-02-04
 
-
 ### Added
 - Unified `ClusterRef` type for referring to cluster objects ([#307]).
 
@@ -59,7 +62,6 @@ All notable changes to this project will be documented in this file.
 [#307]: https://github.com/stackabletech/operator-rs/pull/307
 
 ## [0.9.0] - 2022-01-27
-
 
 ### Changed
 - Fixed `Client::apply_patch_status` always failing ([#300]).
@@ -81,7 +83,6 @@ All notable changes to this project will be documented in this file.
 [#293]: https://github.com/stackabletech/operator-rs/pull/293
 
 ## [0.7.0] - 2021-12-22
-
 
 ### Changed
 - BREAKING: Introduced proper (Result) error handling for `transform_all_roles_to_config` ([#282]).
@@ -196,7 +197,6 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.2] - 2021-09-21
 
-
 ### Changed
 
 - `kube-rs`: `0.59` → `0.60` ([#217]).
@@ -213,7 +213,6 @@ All notable changes to this project will be documented in this file.
 [#215]: https://github.com/stackabletech/operator-rs/pull/215
 
 ## [0.2.0] - 2021-09-17
-
 
 ### Added
 - Extracted the versioning support for up and downgrades from operators ([#211]).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Stackable Operator Framework"
 edition = "2021"
 license = "Apache-2.0"
 name = "stackable-operator"
-version = "0.13.0-nightly"
+version = "0.12.0"
 repository = "https://github.com/stackabletech/operator-rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-authors = ["Lars Francke <lars.francke@stackable.de>"]
+authors = ["Stackable GmbH <info@stackable.de>"]
 description = "Stackable Operator Framework"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 name = "stackable-operator"
-version = "0.12.0"
+version = "0.13.0-nightly"
 repository = "https://github.com/stackabletech/operator-rs"
 
 [dependencies]
 chrono = { version = "0.4.19", default-features = false }
-clap = { version = "3.0.13", features = ["derive", "cargo"] }
+clap = { version = "3.0.13", features = ["derive", "cargo", "env"] }
 const_format = "0.2.22"
 either = "1.6.1"
 futures = "0.3.19"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,7 +94,7 @@
 //!     cli::Command::Crd => {
 //!         // Print CRD objects
 //!     }
-//!     cli::Command::Run(cli::ProductOperatorRun { product_config }) => {
+//!     cli::Command::Run(cli::ProductOperatorRun { product_config, watch_namespace }) => {
 //!         let product_config = product_config.load(&[
 //!             "deploy/config-spec/properties.yaml",
 //!             "/etc/stackable/spark-operator/config-spec/properties.yaml",
@@ -155,11 +155,12 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 ///     common: ProductOperatorRun,
 /// }
 /// use clap::Parser;
-/// let opts = Command::<Run>::parse_from(["foobar-operator", "run", "--name", "foo", "--product-config", "bar"]);
+/// let opts = Command::<Run>::parse_from(["foobar-operator", "run", "--name", "foo", "--product-config", "bar", "--watch-namespace", "foobar"]);
 /// assert_eq!(opts, Command::Run(Run {
 ///     name: "foo".to_string(),
 ///     common: ProductOperatorRun {
 ///         product_config: ProductConfigPath::from("bar".as_ref()),
+///         watch_namespace: Some("foobar".to_string())
 ///     },
 /// }));
 /// ```
@@ -191,6 +192,9 @@ pub struct ProductOperatorRun {
         parse(from_os_str)
     )]
     pub product_config: ProductConfigPath,
+    /// Provides a specific namespace to watch (instead of watching all namespaces)
+    #[clap(long, env)]
+    pub watch_namespace: Option<String>
 }
 
 /// A path to a [`ProductConfigManager`] spec file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,7 +194,7 @@ pub struct ProductOperatorRun {
     pub product_config: ProductConfigPath,
     /// Provides a specific namespace to watch (instead of watching all namespaces)
     #[clap(long, env)]
-    pub watch_namespace: Option<String>
+    pub watch_namespace: Option<String>,
 }
 
 /// A path to a [`ProductConfigManager`] spec file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,6 +189,7 @@ pub struct ProductOperatorRun {
         short = 'p',
         value_name = "FILE",
         default_value = "",
+        env,
         parse(from_os_str)
     )]
     pub product_config: ProductConfigPath,


### PR DESCRIPTION
## Description

- Preparation to let operators watch a single namespace

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
