### PR TITLE
Truncate events to the actual length limit, rather than a constant amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Truncate k8s event strings correctly, when required ([#337]).
+
+[#337]: https://github.com/stackabletech/operator-rs/pull/337
+
 ## [0.13.0] - 2022-02-23
 
 ### Added

--- a/src/logging/k8s_events.rs
+++ b/src/logging/k8s_events.rs
@@ -28,10 +28,7 @@ fn error_to_event<E: ReconcilerError>(err: &E) -> Event {
             }
         }
     };
-    dbg!(full_msg.len());
     message::truncate_with_ellipsis(&mut full_msg, 1024);
-    dbg!(full_msg.len());
-    assert!(full_msg.len() <= 1024);
     Event {
         type_: EventType::Warning,
         reason: err.category().to_string(),


### PR DESCRIPTION
## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
