### PR TITLE
Role override regression

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1566,9 +1566,7 @@ mod tests {
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
         LabelSelector, LabelSelectorRequirement, OwnerReference,
     };
-    use std::array::IntoIter;
     use std::collections::BTreeMap;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_security_context_builder() {
@@ -1653,15 +1651,15 @@ mod tests {
         let container_port_1: i32 = 20000;
         let container_port_name_1 = "bar_port_name";
         let resources = ResourceRequirements {
-            limits: Some(BTreeMap::from_iter(IntoIter::new([
+            limits: Some([
                 ("cpu".to_string(), Quantity("3000m".to_string())),
                 ("memory".to_string(), Quantity("6Gi".to_string())),
                 ("nvidia.com/gpu".to_string(), Quantity("1".to_string())),
-            ]))),
-            requests: Some(BTreeMap::from_iter(IntoIter::new([
+            ].into()),
+            requests: Some([
                 ("cpu".to_string(), Quantity("2000m".to_string())),
                 ("memory".to_string(), Quantity("4Gi".to_string())),
-            ]))),
+            ].into()),
         };
 
         let container = ContainerBuilder::new("testcontainer")

--- a/src/product_config_utils.rs
+++ b/src/product_config_utils.rs
@@ -561,7 +561,10 @@ mod tests {
                 result.insert("file".to_string(), Some(conf.to_string()));
             }
             if file == "role_overrides_test" {
-                result.insert(String::from("override"), Some(String::from("from compute_files")));
+                result.insert(
+                    String::from("override"),
+                    Some(String::from("from compute_files")),
+                );
             }
             Ok(result)
         }
@@ -1324,9 +1327,8 @@ mod tests {
         assert!(config_for_role_and_wrong_group.is_err());
     }
 
-
     // This test demonstrates a bug and fails with:
-    // 
+    //
     // thread 'product_config_utils::tests::test_role_config_overrides_win' panicked at 'assertion failed: `(left == right)`
     // left: `{"role_group": {File("foo.bar"): {"override": Some("from compute_files")}}}`,
     // right: `{"role_group": {File("foo.bar"): {"override": Some("from role")}}}`', src/product_config_utils.rs:1366:9
@@ -1342,9 +1344,15 @@ mod tests {
             config: build_common_config(
                 None,
                 // should override
-                Some([(String::from(file_name), [(String::from("override"), String::from("from role"))].into())].into()),
+                Some(
+                    [(
+                        String::from(file_name),
+                        [(String::from("override"), String::from("from role"))].into(),
+                    )]
+                    .into(),
+                ),
                 None,
-                None
+                None,
             ),
             role_groups: collection! {role_group.to_string() => RoleGroup {
                 replicas: Some(1),
@@ -1367,15 +1375,11 @@ mod tests {
             }
         };
 
-        let property_kinds = vec![
-            PropertyNameKind::File(file_name.to_string()),
-        ];
+        let property_kinds = vec![PropertyNameKind::File(file_name.to_string())];
 
         let config =
             transform_role_to_config(&String::new(), ROLE_GROUP, &role, &property_kinds).unwrap();
 
         assert_eq!(config, expected);
     }
-
-
 }


### PR DESCRIPTION
## Description

This just demonstrates a bug in the handling of configuration overrides but doesn't fix it since the bug is not critical.

The bug is described in more detail here: https://github.com/stackabletech/operator-rs/issues/339

The fix might require some redesign of the way config overrides are handled and might not be worth doing in isolation.

Remove the `#[ignore]` attribute on the test to verify the problem.


## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
