### PR TITLE
Allow constructing SecretOperatorVolumeScope from user-provided string

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
 
     #[error("Error converting CRD byte array to UTF-8")]
     CrdFromUtf8Error(#[source] std::string::FromUtf8Error),
+
+    #[error("Invalid scope for secret-operator volume")]
+    InvalidSecretOperatorVolumeScopeError { scope: String },
 }
 
 pub type OperatorResult<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
## Description
Follow up of https://github.com/stackabletech/operator-rs/pull/342
Now superset-operator can constuct SecretOperatorVolumeScope from user-provided string from AuthenticationClass CRD

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
