### PR TITLE
[Merged by Bors] - Bump kube to 0.70.0. Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2022.03.21
+
 ### Added
 
 - Common `OpaConfig` to specify a config map and package name ([#357]).
@@ -11,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Split up the builder module into submodules. This is not breaking yet due to reexports. Deprecation warning has been added for `operator-rs` `0.15.0` ([#348]).
+- Update to `kube` `0.70.0` ([Release Notes](https://github.com/kube-rs/kube-rs/releases/tag/0.70.0)). The signature and the Ok action in reconcile fns has been simplified slightly. Because of this the signature of `report_controller_reconciled` had to be changed slightly ([#359]).
 
 [#348]: https://github.com/stackabletech/operator-rs/pull/348
 [#357]: https://github.com/stackabletech/operator-rs/pull/357

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Stackable Operator Framework"
 edition = "2021"
 license = "Apache-2.0"
 name = "stackable-operator"
-version = "0.14.1"
+version = "0.15.0"
 repository = "https://github.com/stackabletech/operator-rs"
 
 [dependencies]
@@ -15,7 +15,7 @@ either = "1.6.1"
 futures = "0.3.19"
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.14.0", default-features = false, features = ["schemars", "v1_23"] }
-kube = { version = "0.69.1", features = ["jsonpatch", "runtime", "derive"] }
+kube = { version = "0.70.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.3.1" }
 rand = "0.8.4"

--- a/src/logging/controller.rs
+++ b/src/logging/controller.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use kube::{
     core::DynamicObject,
     runtime::{
-        controller::{self, ReconcilerAction},
+        controller::{self, Action},
         reflector::ObjectRef,
     },
     Resource,
@@ -46,7 +46,7 @@ pub trait ReconcilerError: Error {
 pub fn report_controller_reconciled<K, ReconcileErr, QueueErr>(
     client: &Client,
     controller_name: &str,
-    result: &Result<(ObjectRef<K>, ReconcilerAction), controller::Error<ReconcileErr, QueueErr>>,
+    result: &Result<(ObjectRef<K>, Action), controller::Error<ReconcileErr, QueueErr>>,
 ) where
     K: Resource,
     ReconcileErr: ReconcilerError,


### PR DESCRIPTION
## Description

Bump kube to 0.70.0 for bugfix https://github.com/kube-rs/kube-rs/pull/852.
As this is a braking change I've updated to a new minor version.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
