### PR TITLE
[Merged by Bors] - Add support for logging to Jaeger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- `initialize_logging` now takes an app name and tracing target ([#360]).
+- BREAKING: `initialize_logging` now takes an app name and tracing target ([#360]).
 
 [#360]: https://github.com/stackabletech/operator-rs/pull/360
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Export logs to Jaeger ([#360]).
+
+### Changed
+
+- `initialize_logging` now takes an app name and tracing target ([#360]).
+
+[#360]: https://github.com/stackabletech/operator-rs/pull/360
+
 ## [0.15.0] - 2022.03.21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 backoff = "0.4.0"
 derivative = "2.2.0"
+tracing-opentelemetry = "0.17.1"
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"] }
 
 [dev-dependencies]
 rstest = "0.12.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,9 +107,9 @@
 //! ```
 //!
 //!
-use crate::error;
 use crate::error::OperatorResult;
 use crate::namespace::WatchNamespace;
+use crate::{error, logging::TracingTarget};
 use clap::Args;
 use product_config::ProductConfigManager;
 use std::{
@@ -198,6 +198,9 @@ pub struct ProductOperatorRun {
     /// Provides a specific namespace to watch (instead of watching all namespaces)
     #[clap(long, env, default_value = "", parse(from_str))]
     pub watch_namespace: WatchNamespace,
+    /// Tracing log collector system
+    #[clap(long, env, default_value_t, arg_enum)]
+    pub tracing_target: TracingTarget,
 }
 
 /// A path to a [`ProductConfigManager`] spec file
@@ -362,7 +365,8 @@ mod tests {
             opts,
             ProductOperatorRun {
                 product_config: ProductConfigPath::from("bar".as_ref()),
-                watch_namespace: WatchNamespace::One("foo".to_string())
+                watch_namespace: WatchNamespace::One("foo".to_string()),
+                tracing_target: TracingTarget::None,
             }
         );
 
@@ -372,7 +376,8 @@ mod tests {
             opts,
             ProductOperatorRun {
                 product_config: ProductConfigPath::from("bar".as_ref()),
-                watch_namespace: WatchNamespace::All
+                watch_namespace: WatchNamespace::All,
+                tracing_target: TracingTarget::None,
             }
         );
 
@@ -383,7 +388,8 @@ mod tests {
             opts,
             ProductOperatorRun {
                 product_config: ProductConfigPath::from("bar".as_ref()),
-                watch_namespace: WatchNamespace::One("foo".to_string())
+                watch_namespace: WatchNamespace::One("foo".to_string()),
+                tracing_target: TracingTarget::None,
             }
         );
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@
 //!
 //! ```no_run
 //! // Handle CLI arguments
-//! use clap::{crate_version, App, Parser};
+//! use clap::{crate_version, Parser};
 //! use kube::{CustomResource, CustomResourceExt};
 //! use schemars::JsonSchema;
 //! use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@
 //! Product config handling works similarly:
 //!
 //! ```no_run
-//! use clap::{crate_version, App, Parser};
+//! use clap::{crate_version, Parser};
 //! use stackable_operator::cli;
 //! use stackable_operator::error::OperatorResult;
 //!
@@ -94,7 +94,7 @@
 //!     cli::Command::Crd => {
 //!         // Print CRD objects
 //!     }
-//!     cli::Command::Run(cli::ProductOperatorRun { product_config, watch_namespace }) => {
+//!     cli::Command::Run(cli::ProductOperatorRun { product_config, watch_namespace, .. }) => {
 //!         let product_config = product_config.load(&[
 //!             "deploy/config-spec/properties.yaml",
 //!             "/etc/stackable/spark-operator/config-spec/properties.yaml",
@@ -156,13 +156,15 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 ///     common: ProductOperatorRun,
 /// }
 /// use clap::Parser;
+/// use stackable_operator::logging::TracingTarget;
 /// use stackable_operator::namespace::WatchNamespace;
 /// let opts = Command::<Run>::parse_from(["foobar-operator", "run", "--name", "foo", "--product-config", "bar", "--watch-namespace", "foobar"]);
 /// assert_eq!(opts, Command::Run(Run {
 ///     name: "foo".to_string(),
 ///     common: ProductOperatorRun {
 ///         product_config: ProductConfigPath::from("bar".as_ref()),
-///         watch_namespace: WatchNamespace::One("foobar".to_string())
+///         watch_namespace: WatchNamespace::One("foobar".to_string()),
+///         tracing_target: TracingTarget::None
 ///     },
 /// }));
 /// ```

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,8 +1,20 @@
 use tracing;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 
 pub mod controller;
 mod k8s_events;
+
+#[derive(Debug, Clone, clap::ArgEnum, PartialEq, Eq)]
+pub enum TracingTarget {
+    None,
+    Jaeger,
+}
+
+impl Default for TracingTarget {
+    fn default() -> Self {
+        Self::None
+    }
+}
 
 /// Initializes `tracing` logging with options from the environment variable
 /// given in the `env` parameter.
@@ -10,20 +22,35 @@ mod k8s_events;
 /// We force users to provide a variable name so it can be different per product.
 /// We encourage it to be the product name plus `_LOG`, e.g. `FOOBAR_OPERATOR_LOG`.
 /// If no environment variable is provided, the maximum log level is set to INFO.
-pub fn initialize_logging(env: &str) {
+pub fn initialize_logging(env: &str, app_name: &str, tracing_target: TracingTarget) {
     let filter = match EnvFilter::try_from_env(env) {
         Ok(env_filter) => env_filter,
         _ => EnvFilter::try_new(tracing::Level::INFO.to_string())
             .expect("Failed to initialize default tracing level to INFO"),
     };
 
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    let fmt = tracing_subscriber::fmt::layer();
+    let registry = Registry::default().with(filter).with(fmt);
+
+    match tracing_target {
+        TracingTarget::None => registry.init(),
+        TracingTarget::Jaeger => {
+            let jaeger = opentelemetry_jaeger::new_pipeline()
+                .with_service_name(app_name)
+                .install_batch(opentelemetry::runtime::Tokio)
+                .expect("Failed to initialize Jaeger pipeline");
+            let opentelemetry = tracing_opentelemetry::layer().with_tracer(jaeger);
+            registry.with(opentelemetry).init();
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
 
     use tracing::{debug, error, info};
+
+    use crate::logging::TracingTarget;
 
     // If there is a proper way to programmatically inspect the global max level than we should use that.
     // Until then, this is mostly a sanity check for the implementation above.
@@ -34,7 +61,7 @@ mod test {
     // to see them all.
     #[test]
     pub fn test_default_tracing_level_is_set_to_info() {
-        super::initialize_logging("NOT_SET");
+        super::initialize_logging("NOT_SET", "test", TracingTarget::None);
 
         error!("ERROR level messages should be seen.");
         info!("INFO level messages should also be seen by default.");


### PR DESCRIPTION
## Description

This enables individual operators to export logs to Jaeger. However, operator packaging must also be modified to add a `jaeger-agent` sidecar and enable tracing where applicable.

Logging to Jaeger is opt-in, since otherwise it clogs up the local logs with errors about failing to submit traces.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
