### PR TITLE
[Merged by Bors] - Added TlsAuthenticationProvider to be used in AuthenticationClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- New commons::s3 module with common S3 connection structs ([#377])
+- New commons::s3 module with common S3 connection structs ([#377]).
+- New `TlsAuthenticationProvider` for `AuthenticationClass` ([#387]).
 
 [#377]: https://github.com/stackabletech/operator-rs/issues/377
+[#387]: https://github.com/stackabletech/operator-rs/pull/387
 
 ## [0.17.0] - 2022-04-14
 

--- a/src/commons/authentication.rs
+++ b/src/commons/authentication.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::commons::ldap::LdapAuthenticationProvider;
+use crate::commons::{ldap::LdapAuthenticationProvider, tls::TlsAuthenticationProvider};
 use kube::CustomResource;
 use schemars::JsonSchema;
 
@@ -24,6 +24,8 @@ pub struct AuthenticationClassSpec {
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)]
 pub enum AuthenticationClassProvider {
     Ldap(LdapAuthenticationProvider),
+    Tls(TlsAuthenticationProvider),
 }

--- a/src/commons/tls.rs
+++ b/src/commons/tls.rs
@@ -14,8 +14,6 @@ pub enum TlsVerification {
     None {},
     /// Use TLS and ca certificate to verify the server
     Server(TlsServerVerification),
-    /// Use TLS and ca certificate to verify the server and the client
-    Mutual(TlsMutualVerification),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
@@ -42,4 +40,14 @@ pub enum CaCert {
     /// Note that a SecretClass does not need to have a key but can also work with just a ca cert.
     /// So if you got provided with a ca cert but don't have access to the key you can still use this method.
     SecretClass(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TlsAuthenticationProvider {
+    /// See `<https://github.com/stackabletech/documentation/tree/main/modules/contributor/pages/adr/ADR016-tls-authentication.adoc>`.
+    /// If `client_cert_secret_class` is not set, the TLS settings may also be used for client authentication.
+    /// If `client_cert_secret_class` is set, the [SecretClass](https://docs.stackable.tech/secret-operator/secretclass.html)
+    /// will be used to provision client certificates.
+    pub client_cert_secret_class: Option<String>,
 }

--- a/src/commons/tls.rs
+++ b/src/commons/tls.rs
@@ -45,7 +45,7 @@ pub enum CaCert {
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsAuthenticationProvider {
-    /// See `<https://github.com/stackabletech/documentation/tree/main/modules/contributor/pages/adr/ADR016-tls-authentication.adoc>`.
+    /// See `<https://docs.stackable.tech/home/contributor/adr/ADR016-tls-authentication.html>`.
     /// If `client_cert_secret_class` is not set, the TLS settings may also be used for client authentication.
     /// If `client_cert_secret_class` is set, the [SecretClass](https://docs.stackable.tech/secret-operator/secretclass.html)
     /// will be used to provision client certificates.


### PR DESCRIPTION
## Description

- added TlsAuthenticationProvider as discussed in https://github.com/stackabletech/documentation/pull/186
- removed MutualTlsVerification

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
