### PR TITLE
[Merged by Bors] - Added resolve to S3ConnectionDef

### DIFF
--- a/src/commons/s3.rs
+++ b/src/commons/s3.rs
@@ -158,7 +158,9 @@ impl S3ConnectionDef {
     ) -> OperatorResult<S3ConnectionSpec> {
         match self {
             S3ConnectionDef::Inline(s3_connection_spec) => Ok(s3_connection_spec.clone()),
-            S3ConnectionDef::Reference(s3_conn_reference) => S3ConnectionSpec::get(s3_conn_reference, client, namespace),
+            S3ConnectionDef::Reference(s3_conn_reference) => {
+                S3ConnectionSpec::get(s3_conn_reference, client, namespace)
+            }
         }
     }
 }

--- a/src/commons/s3.rs
+++ b/src/commons/s3.rs
@@ -58,7 +58,7 @@ impl S3BucketSpec {
     ) -> OperatorResult<InlinedS3BucketSpec> {
         match self.connection.as_ref() {
             Some(connection_def) => Ok(InlinedS3BucketSpec {
-                connection: Some(connection_def.resolve(client, namespace)),
+                connection: Some(connection_def.resolve(client, namespace).await?),
                 bucket_name: self.bucket_name.clone(),
             }),
             None => Ok(InlinedS3BucketSpec {
@@ -159,7 +159,7 @@ impl S3ConnectionDef {
         match self {
             S3ConnectionDef::Inline(s3_connection_spec) => Ok(s3_connection_spec.clone()),
             S3ConnectionDef::Reference(s3_conn_reference) => {
-                S3ConnectionSpec::get(s3_conn_reference, client, namespace)
+                S3ConnectionSpec::get(s3_conn_reference, client, namespace).await
             }
         }
     }


### PR DESCRIPTION
## Description

- Renamed ConnectionDef to S3ConnectionDef for consistency
- Added a `resolve` function to the S3ConnectionDef, similar to the function on the S3BucketDef
- minor documentation fix

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
