### PR TITLE
[Merged by Bors] - Use ephemeral secret-op volumes rather than csi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `SecretClassVolume` and `SecretOperatorVolumeSourceBuilder` now support secret-aware pod scheduling ([#396], [secret-#125]).
+
+### Changed
+
+- BREAKING: `SecretClassVolume::to_csi_volume` renamed to `to_ephemeral_volume` and now returns `EphemeralVolumeSource` ([#396]).
+- BREAKING: `SecretOperatorVolumeSourceBuilder` now returns `EphemeralVolumeSource` ([#396]).
+- BREAKING: Secret-Operator-related features now require Secret-Operator 0.4.0 ([#396]).
+
+[#396]: https://github.com/stackabletech/operator-rs/pull/396
+[secret-#125]: https://github.com/stackabletech/secret-operator/pull/125
+
 ## [0.19.0] - 2022-05-05
 
 ### Changed

--- a/src/commons/secret_class.rs
+++ b/src/commons/secret_class.rs
@@ -1,5 +1,5 @@
 use crate::builder::SecretOperatorVolumeSourceBuilder;
-use k8s_openapi::api::core::v1::CSIVolumeSource;
+use k8s_openapi::api::core::v1::EphemeralVolumeSource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct SecretClassVolume {
 }
 
 impl SecretClassVolume {
-    pub fn to_csi_volume(&self) -> CSIVolumeSource {
+    pub fn to_ephemeral_volume(&self) -> EphemeralVolumeSource {
         let mut secret_operator_volume_builder =
             SecretOperatorVolumeSourceBuilder::new(&self.secret_class);
 
@@ -59,7 +59,7 @@ mod tests {
                 services: vec!["myservice".to_string()],
             }),
         }
-        .to_csi_volume();
+        .to_ephemeral_volume();
 
         let expected_volume_attributes = BTreeMap::from([
             (
@@ -74,7 +74,13 @@ mod tests {
 
         assert_eq!(
             expected_volume_attributes,
-            secret_class_volume.volume_attributes.unwrap()
+            secret_class_volume
+                .volume_claim_template
+                .unwrap()
+                .metadata
+                .unwrap()
+                .annotations
+                .unwrap()
         );
     }
 }


### PR DESCRIPTION


## Description

Requires https://github.com/stackabletech/secret-operator/pull/125, see that PR for motivation

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
