### PR TITLE
[Merged by Bors] - The storage class was not correctly carried over from PVCConfig structs into derived PVC objects.

### DIFF
--- a/src/commons/resources.rs
+++ b/src/commons/resources.rs
@@ -156,6 +156,7 @@ impl PvcConfig {
                 access_modes: access_modes
                     .map(|modes| modes.into_iter().map(String::from).collect()),
                 selector: self.selectors.clone(),
+                storage_class_name: self.storage_class.clone(),
                 resources: Some(ResourceRequirements {
                     requests: Some({
                         let mut map = BTreeMap::new();
@@ -285,7 +286,7 @@ mod tests {
         metadata:
             name: test
         spec:
-            storageClass: CustomClass
+            storageClassName: CustomClass
             resources:
                 requests:
                     storage: 10Gi"#
@@ -305,7 +306,7 @@ mod tests {
         metadata:
             name: test
         spec:
-            storageClass: CustomClass
+            storageClassName: CustomClass
             resources:
                 requests:
                     storage: 10Gi


### PR DESCRIPTION
## Description

Fixes #411

Adds copying of storageclass from PVCConfig into derived PVC objects.
Signed-off-by: Sönke Liebau <soenke.liebau@stackable.de>
<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
