### PR TITLE
[Merged by Bors] - Orphaned resources handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `AuthenticationClass::resolve` helper function ([#432]).
+- Cluster resources can be added to a struct which determines the orphaned
+  resources and deletes them ([#436]).
+
+### Changed
+
+- BREAKING: The `managed_by` label must be passed explicitly to the
+  `ObjectMetaBuilder::with_recommended_labels` function ([#436]).
 
 [#432]: https://github.com/stackabletech/operator-rs/pull/432
+[#436]: https://github.com/stackabletech/operator-rs/pull/436
 
 ## [0.22.0] - 2022-07-05
 

--- a/src/builder/meta.rs
+++ b/src/builder/meta.rs
@@ -153,6 +153,7 @@ impl ObjectMetaBuilder {
         resource: &T,
         app_name: &str,
         app_version: &str,
+        app_managed_by: &str,
         app_component: &str,
         role_name: &str,
     ) -> &mut Self {
@@ -160,6 +161,7 @@ impl ObjectMetaBuilder {
             resource,
             app_name,
             app_version,
+            app_managed_by,
             app_component,
             role_name,
         );
@@ -330,7 +332,7 @@ mod tests {
             .namespace("bar")
             .ownerreference_from_resource(&pod, Some(true), Some(false))
             .unwrap()
-            .with_recommended_labels(&pod, "test_app", "1.0", "component", "role")
+            .with_recommended_labels(&pod, "test_app", "1.0", "app-operator", "component", "role")
             .with_annotation("foo", "bar")
             .build();
 

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -275,14 +275,12 @@ impl ClusterResources {
     ///
     /// * `client` - The client which is used to access Kubernetes
     pub async fn delete_orphaned_resources(self, client: &Client) -> OperatorResult<()> {
-        self.delete_orphaned_resources_of_kind::<Service>(client)
-            .await?;
-        self.delete_orphaned_resources_of_kind::<StatefulSet>(client)
-            .await?;
-        self.delete_orphaned_resources_of_kind::<DaemonSet>(client)
-            .await?;
-        self.delete_orphaned_resources_of_kind::<ConfigMap>(client)
-            .await?;
+        tokio::try_join!(
+            self.delete_orphaned_resources_of_kind::<Service>(client),
+            self.delete_orphaned_resources_of_kind::<StatefulSet>(client),
+            self.delete_orphaned_resources_of_kind::<DaemonSet>(client),
+            self.delete_orphaned_resources_of_kind::<ConfigMap>(client),
+        )?;
 
         Ok(())
     }

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -1,0 +1,280 @@
+use std::{
+    collections::HashSet,
+    fmt::{self, Debug, Display, Formatter},
+};
+
+use crate::{
+    client::Client,
+    error::OperatorResult,
+    k8s_openapi::{
+        api::{
+            apps::v1::StatefulSet,
+            core::v1::{ConfigMap, ObjectReference, Service},
+        },
+        apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement},
+    },
+    kube::{Resource, ResourceExt},
+    labels::{self, APP_INSTANCE_LABEL, APP_MANAGED_BY_LABEL, APP_NAME_LABEL},
+};
+use serde::{de::DeserializeOwned, Serialize};
+use tracing::info;
+
+pub struct ClusterResources {
+    namespace: String,
+    app_instance: String,
+    app_name: String,
+    app_managed_by: String,
+    field_manager_scope: String,
+    services: Vec<Service>,
+    configmaps: Vec<ConfigMap>,
+    statefulsets: Vec<StatefulSet>,
+}
+
+impl ClusterResources {
+    pub fn new(
+        app_name: &str,
+        field_manager_scope: &str,
+        cluster: &ObjectReference,
+        services: &[Service],
+        configmaps: &[ConfigMap],
+        statefulsets: &[StatefulSet],
+    ) -> Self {
+        ClusterResources {
+            namespace: cluster
+                .namespace
+                .as_ref()
+                .expect("Cluster namespace expected")
+                .to_owned(),
+            app_instance: cluster
+                .name
+                .as_ref()
+                .expect("Cluster name expected")
+                .to_owned(),
+            app_name: app_name.into(),
+            app_managed_by: labels::get_app_managed_by_value(app_name),
+            field_manager_scope: field_manager_scope.into(),
+            services: services.into(),
+            configmaps: configmaps.into(),
+            statefulsets: statefulsets.into(),
+        }
+    }
+
+    pub async fn update(&self, client: &Client) -> OperatorResult<()> {
+        self.patch_resources(client, &self.configmaps).await?;
+        self.patch_resources(client, &self.statefulsets).await?;
+        self.patch_resources(client, &self.services).await?;
+
+        self.delete_orphaned_resources(client, &self.services)
+            .await?;
+        self.delete_orphaned_resources(client, &self.statefulsets)
+            .await?;
+        self.delete_orphaned_resources(client, &self.configmaps)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn patch_resources<T>(&self, client: &Client, resources: &[T]) -> OperatorResult<()>
+    where
+        T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()> + Serialize,
+    {
+        for resource in resources {
+            client
+                .apply_patch(&self.field_manager_scope, resource, resource)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_orphaned_resources<T>(
+        &self,
+        client: &Client,
+        desired_resources: &[T],
+    ) -> OperatorResult<()>
+    where
+        T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,
+    {
+        let actual_cluster_resources = self.list_actual_cluster_resources::<T>(client).await?;
+
+        let desired_resource_id_set: ResourceIdSet = desired_resources.into();
+
+        let orphaned_resources = actual_cluster_resources
+            .into_iter()
+            .filter(|actual_resource| !desired_resource_id_set.contains(actual_resource))
+            .collect::<Vec<_>>();
+
+        if !orphaned_resources.is_empty() {
+            info!(
+                "Deleting orphaned {}: {}",
+                T::plural(&()),
+                ResourceIdSet::from(orphaned_resources.as_ref())
+            );
+            for resource in &orphaned_resources {
+                client.delete(resource).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn list_actual_cluster_resources<T>(&self, client: &Client) -> OperatorResult<Vec<T>>
+    where
+        T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,
+    {
+        let label_selector = LabelSelector {
+            match_expressions: Some(vec![
+                LabelSelectorRequirement {
+                    key: APP_INSTANCE_LABEL.into(),
+                    operator: "In".into(),
+                    values: Some(vec![self.app_instance.to_owned()]),
+                },
+                LabelSelectorRequirement {
+                    key: APP_NAME_LABEL.into(),
+                    operator: "In".into(),
+                    values: Some(vec![self.app_name.to_owned()]),
+                },
+                LabelSelectorRequirement {
+                    key: APP_MANAGED_BY_LABEL.into(),
+                    operator: "In".into(),
+                    values: Some(vec![self.app_managed_by.to_owned()]),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        client
+            .list_with_label_selector(Some(&self.namespace), &label_selector)
+            .await
+    }
+}
+
+struct ResourceIdSet(HashSet<ResourceId>);
+
+impl<T> From<&[T]> for ResourceIdSet
+where
+    T: Resource<DynamicType = ()>,
+{
+    fn from(resources: &[T]) -> Self {
+        Self(resources.iter().map(ResourceId::from).collect())
+    }
+}
+
+impl Display for ResourceIdSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut resource_id_strings = self.0.iter().map(ResourceId::to_string).collect::<Vec<_>>();
+        resource_id_strings.sort();
+        write!(f, "{}", resource_id_strings.join(", "))
+    }
+}
+
+impl ResourceIdSet {
+    fn contains<T: Resource<DynamicType = ()>>(&self, resource: &T) -> bool {
+        self.0.contains(&resource.into())
+    }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct ResourceId {
+    namespace: Option<String>,
+    name: String,
+}
+
+impl<T> From<&T> for ResourceId
+where
+    T: Resource<DynamicType = ()>,
+{
+    fn from(resource: &T) -> Self {
+        Self {
+            namespace: resource.namespace(),
+            name: resource.name(),
+        }
+    }
+}
+
+impl Display for ResourceId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(namespace) = &self.namespace {
+            write!(f, ".{}", namespace)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{Node, Pod};
+    use kube::core::ObjectMeta;
+
+    #[test]
+    fn check_content_of_resourceidset() {
+        let resource1 = create_namespaced_resource("namespace", "resource1");
+        let resource2 = create_namespaced_resource("namespace", "resource2");
+        let resource3 = create_namespaced_resource("namespace", "resource3");
+
+        let resource_id_set =
+            ResourceIdSet::from(vec![resource1.to_owned(), resource2.to_owned()].as_ref());
+
+        assert!(resource_id_set.contains(&resource1));
+        assert!(resource_id_set.contains(&resource2));
+        assert!(!resource_id_set.contains(&resource3));
+    }
+
+    #[test]
+    fn display_resourceidset() {
+        let resource1 = create_namespaced_resource("namespace", "resource1");
+        let resource2 = create_namespaced_resource("namespace", "resource2");
+
+        let resource_id_set1 = ResourceIdSet::from(Vec::<Pod>::new().as_ref());
+        let resource_id_set2 = ResourceIdSet::from(vec![resource1.to_owned()].as_ref());
+        let resource_id_set3 = ResourceIdSet::from(vec![resource1, resource2].as_ref());
+
+        assert_eq!("", resource_id_set1.to_string());
+        assert_eq!("resource1.namespace", resource_id_set2.to_string());
+        assert_eq!(
+            "resource1.namespace, resource2.namespace",
+            resource_id_set3.to_string()
+        );
+    }
+
+    #[test]
+    fn display_namespaced_resourceid() {
+        let resource = create_namespaced_resource("namespace", "name");
+
+        let resource_id = ResourceId::from(&resource);
+
+        assert_eq!("name.namespace", resource_id.to_string());
+    }
+
+    #[test]
+    fn display_non_namespaced_resourceid() {
+        let resource = create_non_namespaced_resource("name");
+
+        let resource_id = ResourceId::from(&resource);
+
+        assert_eq!("name", resource_id.to_string());
+    }
+
+    fn create_namespaced_resource(namespace: &str, name: &str) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some(namespace.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn create_non_namespaced_resource(name: &str) -> Node {
+        Node {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+}

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -22,7 +22,12 @@ use kube::core::ErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info};
 
-/// A cluster resource handled by `ClusterResources`.
+/// A cluster resource handled by [`ClusterResources`].
+///
+/// This trait is used in the function signatures of [`ClusterResources`] and restricts the
+/// possible kinds of resources. [`ClusterResources::finalize`] iterates over all implementations
+/// and removes the orphaned resources. Therefore if a new implementation is added, it must be
+/// added to [`ClusterResources::finalize`] as well.
 pub trait ClusterResource:
     Clone + Debug + DeserializeOwned + Resource<DynamicType = ()> + Serialize
 {
@@ -246,8 +251,9 @@ impl ClusterResources {
 
     /// Finalizes the cluster creation.
     ///
-    /// All orphaned resources, i.e. resources which are labelled as if they belong to this cluster
-    /// instance but were not added to the cluster resources, are deleted.
+    /// The orphaned resources of all kinds of resources which implement the [`ClusterResource`]
+    /// trait, are deleted. A resource is seen as orphaned if it is labelled as if it belongs to
+    /// this cluster instance but was not added to the cluster resources before.
     ///
     /// The following resource labels are compared:
     /// * `app.kubernetes.io/instance`

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{Error, OperatorResult},
     k8s_openapi::{
         api::{
-            apps::v1::StatefulSet,
+            apps::v1::{DaemonSet, StatefulSet},
             core::v1::{ConfigMap, ObjectReference, Service},
         },
         apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement},
@@ -238,6 +238,7 @@ impl ClusterResources {
     ///
     /// The following resource types are considered:
     /// * `ConfigMap`
+    /// * `DaemonSet`
     /// * `Service`
     /// * `StatefulSet`
     ///
@@ -253,6 +254,7 @@ impl ClusterResources {
         self.delete_orphaned_resources::<Service>(client).await?;
         self.delete_orphaned_resources::<StatefulSet>(client)
             .await?;
+        self.delete_orphaned_resources::<DaemonSet>(client).await?;
         self.delete_orphaned_resources::<ConfigMap>(client).await?;
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,20 @@ pub enum Error {
     #[error("Object is missing key: {key}")]
     MissingObjectKey { key: &'static str },
 
+    #[error("Label is missing: {label}")]
+    MissingLabel { label: &'static str },
+
+    #[error(
+        "Label contains unexpected content. \
+            Expected: {label}={expected_content}, \
+            actual: {label}={actual_content}"
+    )]
+    UnexpectedLabelContent {
+        label: &'static str,
+        expected_content: String,
+        actual_content: String,
+    },
+
     #[error("LabelSelector is invalid: {message}")]
     InvalidLabelSelector { message: String },
 

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -36,10 +36,14 @@ where
     labels.insert(APP_VERSION_LABEL.to_string(), app_version.to_string());
     labels.insert(
         APP_MANAGED_BY_LABEL.to_string(),
-        format!("{}-operator", app_name),
+        get_app_managed_by_value(app_name),
     );
 
     labels
+}
+
+pub fn get_app_managed_by_value(app_name: &str) -> String {
+    format!("{}-operator", app_name)
 }
 
 /// The labels required to match against objects of a certain role, assuming that those objects

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -23,6 +23,7 @@ pub fn get_recommended_labels<T>(
     resource: &T,
     app_name: &str,
     app_version: &str,
+    app_managed_by: &str,
     app_role: &str,
     app_role_group: &str,
 ) -> BTreeMap<String, String>
@@ -34,16 +35,9 @@ where
     // TODO: Add operator version label
     // TODO: part-of is empty for now, decide on how this can be used in a proper fashion
     labels.insert(APP_VERSION_LABEL.to_string(), app_version.to_string());
-    labels.insert(
-        APP_MANAGED_BY_LABEL.to_string(),
-        get_app_managed_by_value(app_name),
-    );
+    labels.insert(APP_MANAGED_BY_LABEL.to_string(), app_managed_by.to_string());
 
     labels
-}
-
-pub fn get_app_managed_by_value(app_name: &str) -> String {
-    format!("{}-operator", app_name)
 }
 
 /// The labels required to match against objects of a certain role, assuming that those objects

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod builder;
 pub mod cli;
 pub mod client;
+pub mod cluster_resources;
 pub mod commons;
 pub mod config;
 pub mod crd;


### PR DESCRIPTION
## Description

Provides a structure where cluster resources can be added.

When calling the `update` function, all provided resources will be patched and the deployed resources which are not provided will be deleted.

This is work in progress! The implementation is not suitable for all operators and will be changed.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

The implementation is already tested in:
* stackabletech/hbase-operator#215
  Integration tests: [![Build Status](https://ci.stackable.tech/buildStatus/icon?job=hbase-operator-it-custom&build=20)](https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hbase-operator-it-custom/18/)
* https://github.com/stackabletech/airflow-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/druid-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/hdfs-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/hive-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/kafka-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/nifi-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/opa-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/superset-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/trino-operator/tree/orphaned_resources_handling
* https://github.com/stackabletech/zookeeper-operator/tree/orphaned_resources_handling

@adwk67 will have a look at spark-k8s-operator if there is anything to do.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
