### PR TITLE
[Merged by Bors] - feat: ContainerBuilder should reject illegal container names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - BREAKING:kube `0.73.1` -> `0.74.0` ([#440]). Deprecate `ResourceExt::name` in favour of safe `name_*` alternatives. [kube-#945]
-- `ContainerBuilder::new` validates container name to be RFC 1035-compliant([#292]).
+- `ContainerBuilder::new` validates container name to be RFC 1123-compliant([#292]).
 
 [#432]: https://github.com/stackabletech/operator-rs/pull/432
 [#440]: https://github.com/stackabletech/operator-rs/pull/440

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - BREAKING:kube `0.73.1` -> `0.74.0` ([#440]). Deprecate `ResourceExt::name` in favour of safe `name_*` alternatives. [kube-#945]
+- `ContainerBuilder::new` validates container name to be RFC 1035-compliant([#292]).
 
 [#432]: https://github.com/stackabletech/operator-rs/pull/432
 [#440]: https://github.com/stackabletech/operator-rs/pull/440

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -239,7 +239,7 @@ impl ContainerBuilder {
             Ok(_) => Ok(()),
             Err(err) => Err(Error::InvalidContainerName {
                 container_name: name.to_owned(),
-                violation: err.join(","),
+                violation: err.join(", "),
             }),
         }
     }

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -4,7 +4,7 @@ use k8s_openapi::api::core::v1::{
 };
 use std::fmt;
 
-use crate::{error::Error, validation::is_rfc_1035_label};
+use crate::{error::Error, validation::is_rfc_1123_label};
 
 /// A builder to build [`Container`] objects.
 ///
@@ -230,10 +230,10 @@ impl ContainerBuilder {
         }
     }
 
-    /// Validates a container name is according to the [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt) standards.
+    /// Validates a container name is according to the [RFC 1123](https://www.ietf.org/rfc/rfc1123.txt) standard.
     /// Returns [Ok] if the name is according to the standard, and [Err] if not.
     fn validate_container_name(name: &str) -> Result<(), Error> {
-        let validation_result = is_rfc_1035_label(name);
+        let validation_result = is_rfc_1123_label(name);
 
         match validation_result {
             Ok(_) => Ok(()),
@@ -462,17 +462,17 @@ mod tests {
         assert!(ContainerBuilder::new("name-with-hyphen").is_ok());
         assert_container_builder_err(
             ContainerBuilder::new("ends-with-hyphen-"),
-            "regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+            "regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?",
         );
         assert_container_builder_err(
             ContainerBuilder::new("-starts-with-hyphen"),
-            "regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+            "regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?",
         );
     }
 
     #[test]
     fn test_container_name_contains_number() {
-        assert!(ContainerBuilder::new("name-0-name").is_ok());
+        assert!(ContainerBuilder::new("1name-0-name1").is_ok());
     }
 
     #[test]
@@ -480,7 +480,7 @@ mod tests {
         assert!(ContainerBuilder::new("name_name").is_err());
         assert_container_builder_err(
             ContainerBuilder::new("name_name"),
-            "regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')",
+            "(e.g. 'example-label',  or '1-label-1', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
         );
     }
 
@@ -499,6 +499,7 @@ mod tests {
                     container_name: _,
                     violation,
                 } => {
+                    println!("{violation}");
                     assert!(violation.contains(expected_err_contains));
                 }
                 _ => {

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -270,13 +270,15 @@ mod tests {
     #[test]
     fn test_pod_builder() {
         let container = ContainerBuilder::new("containername")
+            .expect("ContainerBuilder not created")
             .image("stackable/zookeeper:2.4.14")
             .command(vec!["zk-server-start.sh".to_string()])
             .args(vec!["stackable/conf/zk.properties".to_string()])
             .add_volume_mount("zk-worker-1", "conf/")
             .build();
 
-        let init_container = ContainerBuilder::new("init_containername")
+        let init_container = ContainerBuilder::new("init-containername")
+            .expect("ContainerBuilder not created")
             .image("stackable/zookeeper:2.4.14")
             .command(vec!["wrapper.sh".to_string()])
             .args(vec!["12345".to_string()])
@@ -326,7 +328,7 @@ mod tests {
                 .init_containers
                 .as_ref()
                 .and_then(|containers| containers.get(0).as_ref().map(|c| c.name.clone())),
-            Some("init_containername".to_string())
+            Some("init-containername".to_string())
         );
 
         assert_eq!(
@@ -348,6 +350,7 @@ mod tests {
     #[test]
     fn test_pod_builder_image_pull_secrets() {
         let container = ContainerBuilder::new("container")
+            .expect("ContainerBuilder not created")
             .image("private-comapany/product:2.4.14")
             .build();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,8 +85,6 @@ pub enum Error {
 
     #[error("Cannot convert quantity [{value}] to Java heap value with unit [{target_unit}].")]
     CannotConvertToJavaHeapValue { value: String, target_unit: String },
-    #[error("Conversion error: [message]")]
-    ConversionError { message: String },
 
     #[error("container name {container_name:?} is invalid: {violation}")]
     InvalidContainerName {

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,7 +88,7 @@ pub enum Error {
     #[error("Conversion error: [message]")]
     ConversionError { message: String },
 
-    #[error("Given container name: '{container_name}'. Reason: {violation}")]
+    #[error("container name {container_name:?} is invalid: {violation}")]
     InvalidContainerName {
         container_name: String,
         violation: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,14 @@ pub enum Error {
 
     #[error("Cannot convert quantity [{value}] to Java heap value with unit [{target_unit}].")]
     CannotConvertToJavaHeapValue { value: String, target_unit: String },
+    #[error("Conversion error: [message]")]
+    ConversionError { message: String },
+
+    #[error("Given container name: '{container_name}'. Reason: {violation}")]
+    InvalidContainerName {
+        container_name: String,
+        violation: String,
+    },
 }
 
 pub type OperatorResult<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
## Description

*ContainerBuilder checks names to be RFC 1035 compliant*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

https://github.com/stackabletech/operator-rs/issues/292

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
