### PR TITLE
[Merged by Bors] - refactor: Remove unused error states from crate::error::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,15 +27,6 @@ pub enum Error {
     #[error("RoleGroup [{role_group}] for Role [{role}] is missing. This may happen after custom resource changes. Will requeue.")]
     MissingRoleGroup { role: String, role_group: String },
 
-    #[error("Environment variable error: {source}")]
-    EnvironmentVariableError {
-        #[from]
-        source: std::env::VarError,
-    },
-
-    #[error("Invalid name for resource: {errors:?}")]
-    InvalidName { errors: Vec<String> },
-
     #[error(
         "A required File is missing. Not found in any of the following locations: {search_path:?}"
     )]


### PR DESCRIPTION
## Description

Some errors expressed by the crate's Error enum are not used anywhere
and can therefore be deleted.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
