### PR TITLE
[Merged by Bors] - Import listener-operator CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- listener-operator CRDs ([#469]).
+
+[#469]: https://github.com/stackabletech/operator-rs/pull/469
+
 ## [0.25.0] - 2022-08-23
 
 ### Added

--- a/src/commons/listener.rs
+++ b/src/commons/listener.rs
@@ -1,0 +1,95 @@
+//! This modules provides resource types used to interact with [listener-operator](https://docs.stackable.tech/listener-operator/stable/index.html)
+
+use std::collections::BTreeMap;
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[cfg(doc)]
+use k8s_openapi::api::core::v1::{Node, Pod, Service};
+
+/// Defines a policy for how [`Listener`]s should be exposed.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "listeners.stackable.tech",
+    version = "v1alpha1",
+    kind = "ListenerClass"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ListenerClassSpec {
+    pub service_type: ServiceType,
+    /// Annotations that should be added to the [`Service`] object.
+    #[serde(default)]
+    pub service_annotations: BTreeMap<String, String>,
+}
+
+/// The method used to access the services.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq, Eq)]
+pub enum ServiceType {
+    /// Reserve a port on each node.
+    NodePort,
+    /// Provision a dedicated load balancer.
+    LoadBalancer,
+}
+
+/// Exposes a set of pods to the outside world.
+///
+/// Essentially a Stackable extension of a Kubernetes [`Service`]. Compared to [`Service`], [`Listener`] changes two things:
+/// 1. It uses a cluster-level policy object ([`ListenerClass`]) to define how exactly the exposure works
+/// 2. It has a consistent API for reading back the exposed address(es) of the service
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
+#[kube(
+    group = "listeners.stackable.tech",
+    version = "v1alpha1",
+    kind = "Listener",
+    namespaced,
+    status = "ListenerStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ListenerSpec {
+    /// The name of the [`ListenerClass`].
+    pub class_name: Option<String>,
+    /// Labels that the [`Pod`]s must share in order to be exposed.
+    pub pod_selector: Option<BTreeMap<String, String>>,
+    /// Ports that should be exposed.
+    pub ports: Option<Vec<ListenerPort>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListenerPort {
+    /// The name of the port.
+    ///
+    /// The name of each port *must* be unique within a single [`Listener`].
+    pub name: String,
+    /// The port number.
+    pub port: i32,
+    /// The layer-4 protocol (`TCP` or `UDP`).
+    pub protocol: Option<String>,
+}
+
+/// Informs users about how to reach the [`Listener`].
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListenerStatus {
+    /// The backing Kubernetes [`Service`].
+    pub service_name: Option<String>,
+    /// All addresses that the [`Listener`] is currently reachable from.
+    pub ingress_addresses: Option<Vec<ListenerIngress>>,
+    /// Port mappings for accessing the [`Listener`] on each [`Node`] that the [`Pod`]s are currently running on.
+    ///
+    /// This is only intended for internal use by listener-operator itself. This will be left unset if using a [`ListenerClass`] that does
+    /// not require [`Node`]-local access.
+    pub node_ports: Option<BTreeMap<String, i32>>,
+}
+
+/// One address that a [`Listener`] is accessible from.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListenerIngress {
+    /// The hostname or IP address to the [`Listener`].
+    pub address: String,
+    /// Port mapping table.
+    pub ports: BTreeMap<String, i32>,
+}

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod authentication;
 pub mod ldap;
+pub mod listener;
 pub mod opa;
 pub mod resources;
 pub mod s3;


### PR DESCRIPTION
## Description

These are taken from https://github.com/stackabletech/listener-operator/pull/1, but imported since all operators are likely to depend on, at least, `Listener` for discovery.

The expectation is that these will be removed from listener-operator once this PR is merged.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
