### PR TITLE
[Merged by Bors] - Use Volume as the primary mechanism for directing Listener traffic, rather than labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+This is a rerelease of 0.25.1 which some last-minute incompatible API changes to the additions that would have been released in 0.25.1.
+
+### Changed
+
+- Use Volume as the primary mechanism for directing Listener traffic, rather than labels ([#474]).
+
+[#474]: https://github.com/stackabletech/operator-rs/pull/474
+
 ## ~~[0.25.1] - 2022-09-23~~ YANKED
 
 ### Added

--- a/src/commons/listener.rs
+++ b/src/commons/listener.rs
@@ -57,8 +57,14 @@ pub struct ListenerSpec {
     /// Ports that should be exposed.
     pub ports: Option<Vec<ListenerPort>>,
     /// Whether incoming traffic should also be directed to `Pod`s that are not `Ready`.
-    #[serde(default)]
-    pub publish_not_ready_addresses: bool,
+    #[schemars(default = "Self::default_publish_not_ready_addresses")]
+    pub publish_not_ready_addresses: Option<bool>,
+}
+
+impl ListenerSpec {
+    fn default_publish_not_ready_addresses() -> Option<bool> {
+        Some(true)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]

--- a/src/commons/listener.rs
+++ b/src/commons/listener.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
-use k8s_openapi::api::core::v1::{Node, Pod, Service};
+use k8s_openapi::api::core::v1::{Node, Pod, Service, Volume};
 
 /// Defines a policy for how [`Listener`]s should be exposed.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -38,6 +38,7 @@ pub enum ServiceType {
 /// Essentially a Stackable extension of a Kubernetes [`Service`]. Compared to [`Service`], [`Listener`] changes two things:
 /// 1. It uses a cluster-level policy object ([`ListenerClass`]) to define how exactly the exposure works
 /// 2. It has a consistent API for reading back the exposed address(es) of the service
+/// 3. The [`Pod`] must mount a [`Volume`] referring to the `Listener`, which also allows us to control stickiness
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
 #[kube(
     group = "listeners.stackable.tech",
@@ -50,10 +51,14 @@ pub enum ServiceType {
 pub struct ListenerSpec {
     /// The name of the [`ListenerClass`].
     pub class_name: Option<String>,
-    /// Labels that the [`Pod`]s must share in order to be exposed.
-    pub pod_selector: Option<BTreeMap<String, String>>,
+    /// Extra labels that the [`Pod`]s must match in order to be exposed. They must _also_ still have a `Volume` referring to the listener.
+    #[serde(default)]
+    pub extra_pod_selector_labels: BTreeMap<String, String>,
     /// Ports that should be exposed.
     pub ports: Option<Vec<ListenerPort>>,
+    /// Whether incoming traffic should also be directed to `Pod`s that are not `Ready`.
+    #[serde(default)]
+    pub publish_not_ready_addresses: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/listener-operator/pull/1

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
