### PR TITLE
[Merged by Bors] - Add product image selection struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.25.1] - 2022-09-23
+## ~~[0.25.1] - 2022-09-23~~ YANKED
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added product image selection struct ([#476]).
+
+### Changed
+
+- Bump kube to `0.76.0` ([#476]).
+
+[#476]: https://github.com/stackabletech/operator-rs/pull/476
+
 ## [0.26.1] - 2022-11-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,5 @@ snafu = "0.7.1"
 rstest = "0.15.0"
 tempfile = "3.3.0"
 
-[features]
-#default = ["native-tls"]
-#native-tls = ["kube/native-tls"]
-#rustls-tls = ["kube/rustls-tls"]
-
 [workspace]
 members = ["stackable-operator-derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,7 @@ rustls-tls = ["kube/rustls-tls"]
 
 [workspace]
 members = ["stackable-operator-derive"]
+
+[patch.crates-io]
+# Add https://github.com/kube-rs/kube/pull/1028
+kube = { git = "https://github.com/sbernauer/kube.git", branch = "release-0.74.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ either = "1.8.0"
 futures = "0.3.23"
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["schemars", "v1_24"] }
-kube = { git = "https://github.com/kube-rs/kube.git", branch = "main", features = ["jsonpatch", "runtime", "derive"] }
+kube = { version = "0.76.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ either = "1.8.0"
 futures = "0.3.23"
 json-patch = "0.2.6"
 k8s-openapi = { version = "0.15.0", default-features = false, features = ["schemars", "v1_24"] }
-kube = { version = "0.74.0", features = ["jsonpatch", "runtime", "derive"] }
+kube = { git = "https://github.com/sbernauer/kube.git", branch = "release-0.74.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"
@@ -46,7 +46,3 @@ rustls-tls = ["kube/rustls-tls"]
 
 [workspace]
 members = ["stackable-operator-derive"]
-
-[patch.crates-io]
-# Add https://github.com/kube-rs/kube/pull/1028
-kube = { git = "https://github.com/sbernauer/kube.git", branch = "release-0.74.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ rstest = "0.15.0"
 tempfile = "3.3.0"
 
 [features]
-default = ["native-tls"]
-native-tls = ["kube/native-tls"]
-rustls-tls = ["kube/rustls-tls"]
+#default = ["native-tls"]
+#native-tls = ["kube/native-tls"]
+#rustls-tls = ["kube/rustls-tls"]
 
 [workspace]
 members = ["stackable-operator-derive"]

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -4,7 +4,9 @@ use k8s_openapi::api::core::v1::{
 };
 use std::fmt;
 
-use crate::{error::Error, validation::is_rfc_1123_label};
+use crate::{
+    commons::product_image_selection::ProductImage, error::Error, validation::is_rfc_1123_label,
+};
 
 /// A builder to build [`Container`] objects.
 ///
@@ -42,6 +44,16 @@ impl ContainerBuilder {
 
     pub fn image_pull_policy(&mut self, image_pull_policy: impl Into<String>) -> &mut Self {
         self.image_pull_policy = Some(image_pull_policy.into());
+        self
+    }
+
+    pub fn image_from_product_image(
+        &mut self,
+        product_image: &ProductImage,
+        image_base_name: &str,
+    ) -> &mut Self {
+        self.image = Some(product_image.image(image_base_name));
+        self.image_pull_policy = Some(product_image.image_pull_policy());
         self
     }
 

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -48,6 +48,9 @@ impl ContainerBuilder {
         self
     }
 
+    /// Adds the following container attributes from a [ResolvedProductImage]:
+    /// * image
+    /// * image_pull_policy
     pub fn image_from_product_image(&mut self, product_image: &ResolvedProductImage) -> &mut Self {
         self.image = Some(product_image.image.clone());
         self.image_pull_policy = Some(product_image.image_pull_policy.clone());

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -5,7 +5,8 @@ use k8s_openapi::api::core::v1::{
 use std::fmt;
 
 use crate::{
-    commons::product_image_selection::ProductImage, error::Error, validation::is_rfc_1123_label,
+    commons::product_image_selection::ResolvedProductImage, error::Error,
+    validation::is_rfc_1123_label,
 };
 
 /// A builder to build [`Container`] objects.
@@ -47,13 +48,9 @@ impl ContainerBuilder {
         self
     }
 
-    pub fn image_from_product_image(
-        &mut self,
-        product_image: &ProductImage,
-        image_base_name: &str,
-    ) -> &mut Self {
-        self.image = Some(product_image.image(image_base_name));
-        self.image_pull_policy = Some(product_image.image_pull_policy());
+    pub fn image_from_product_image(&mut self, product_image: &ResolvedProductImage) -> &mut Self {
+        self.image = Some(product_image.image.clone());
+        self.image_pull_policy = Some(product_image.image_pull_policy.clone());
         self
     }
 

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -3,6 +3,7 @@ pub mod security;
 pub mod volume;
 
 use crate::builder::meta::ObjectMetaBuilder;
+use crate::commons::product_image_selection::ProductImage;
 use crate::error::{Error, OperatorResult};
 
 use k8s_openapi::{
@@ -153,6 +154,18 @@ impl PodBuilder {
         self.image_pull_secrets
             .get_or_insert_with(Vec::new)
             .extend(secrets.map(|s| LocalObjectReference { name: Some(s) }));
+        self
+    }
+
+    pub fn image_pull_secrets_from_product_image(
+        &mut self,
+        product_image: &ProductImage,
+    ) -> &mut Self {
+        if let Some(pull_secrets) = &product_image.pull_secrets() {
+            self.image_pull_secrets
+                .get_or_insert_with(Vec::new)
+                .extend_from_slice(pull_secrets);
+        }
         self
     }
 

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -157,8 +157,7 @@ impl PodBuilder {
         self
     }
 
-    /// Adds the following pod attributes from a [ResolvedProductImage]:
-    /// * image_pull_secrets
+    /// Extend the pod's image_pull_secrets field with the pull secrets from a given [ResolvedProductImage]
     pub fn image_pull_secrets_from_product_image(
         &mut self,
         product_image: &ResolvedProductImage,

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -157,6 +157,8 @@ impl PodBuilder {
         self
     }
 
+    /// Adds the following container attributes from a [ResolvedProductImage]:
+    /// * image_pull_secrets
     pub fn image_pull_secrets_from_product_image(
         &mut self,
         product_image: &ResolvedProductImage,

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -3,7 +3,7 @@ pub mod security;
 pub mod volume;
 
 use crate::builder::meta::ObjectMetaBuilder;
-use crate::commons::product_image_selection::ProductImage;
+use crate::commons::product_image_selection::ResolvedProductImage;
 use crate::error::{Error, OperatorResult};
 
 use k8s_openapi::{
@@ -159,9 +159,9 @@ impl PodBuilder {
 
     pub fn image_pull_secrets_from_product_image(
         &mut self,
-        product_image: &ProductImage,
+        product_image: &ResolvedProductImage,
     ) -> &mut Self {
-        if let Some(pull_secrets) = &product_image.pull_secrets() {
+        if let Some(pull_secrets) = &product_image.pull_secrets {
             self.image_pull_secrets
                 .get_or_insert_with(Vec::new)
                 .extend_from_slice(pull_secrets);

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -157,7 +157,7 @@ impl PodBuilder {
         self
     }
 
-    /// Adds the following container attributes from a [ResolvedProductImage]:
+    /// Adds the following pod attributes from a [ResolvedProductImage]:
     /// * image_pull_secrets
     pub fn image_pull_secrets_from_product_image(
         &mut self,

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -4,6 +4,7 @@ pub mod authentication;
 pub mod ldap;
 pub mod listener;
 pub mod opa;
+pub mod product_image_selection;
 pub mod resources;
 pub mod s3;
 pub mod secret_class;

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -47,11 +47,11 @@ pub struct ResolvedProductImage {
 }
 
 impl ProductImageSelection {
-    pub fn resolve(self, image_base_name: &str) -> ResolvedProductImage {
+    pub fn resolve(&self, image_base_name: &str) -> ResolvedProductImage {
         match self {
             ProductImageSelection::Custom(custom) => ResolvedProductImage {
-                image: custom.custom,
-                product_version: custom.product_version,
+                image: custom.custom.to_string(),
+                product_version: custom.product_version.to_string(),
             },
             ProductImageSelection::StackableVersion(stackable_version) => {
                 let repo = stackable_version
@@ -65,7 +65,7 @@ impl ProductImageSelection {
                 );
                 ResolvedProductImage {
                     image,
-                    product_version: stackable_version.product_version,
+                    product_version: stackable_version.product_version.to_string(),
                 }
             }
             ProductImageSelection::Stackable(stackable) => {
@@ -78,7 +78,7 @@ impl ProductImageSelection {
                 );
                 ResolvedProductImage {
                     image,
-                    product_version: stackable.product_version,
+                    product_version: stackable.product_version.to_string(),
                 }
             }
         }

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -166,210 +166,198 @@ impl ProductImage {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     use rstest::rstest;
+    use rstest::rstest;
 
-//     #[rstest]
-//     #[case::stackable_version_without_repo(
-//         "superset",
-//         r#"
-//         productVersion: 1.4.1
-//         stackableVersion: 2.1.0
-//         "#,
-//         ResolvedProductImage {
-//             image: "docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::stackable_version_with_repo(
-//         "trino",
-//         r#"
-//         productVersion: 1.4.1
-//         stackableVersion: 2.1.0
-//         repo: my.corp/myteam/stackable
-//         "#,
-//         ResolvedProductImage {
-//             image: "my.corp/myteam/stackable/trino:1.4.1-stackable2.1.0".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::custom(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         "#,
-//         ResolvedProductImage {
-//             image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::stackable_without_repo(
-//         "superset",
-//         r#"
-//         productVersion: 1.4.1
-//         "#,
-//         ResolvedProductImage {
-//             image: "docker.stackable.tech/stackable/superset:1.4.1-stackableTODO".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::default(
-//         "superset",
-//         r#"
-//         productVersion: auto
-//         "#,
-//         ResolvedProductImage {
-//             image: "docker.stackable.tech/stackable/superset:TODO-stackableTODO".to_string(),
-//             product_version: "TODO".to_string(),
-//         }
-//     )]
-//     #[case::stackable_with_repo(
-//         "superset",
-//         r#"
-//         productVersion: 1.4.1
-//         repo: my.corp/myteam/stackable
-//         "#,
-//         ResolvedProductImage {
-//             image: "my.corp/myteam/stackable/superset:1.4.1-stackableTODO".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::custom_takes_precedence(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         stackableVersion: not-used
-//         "#,
-//         ResolvedProductImage {
-//             image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     #[case::custom_takes_precedence(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         repo: not-used
-//         "#,
-//         ResolvedProductImage {
-//             image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
-//             product_version: "1.4.1".to_string(),
-//         }
-//     )]
-//     fn test_correct_resolved_image(
-//         #[case] product_image_base_name: String,
-//         #[case] input: String,
-//         #[case] expected: ResolvedProductImage,
-//     ) {
-//         let product_image: ProductImage = serde_yaml::from_str(&input).expect("Illegal test input");
-//         let product_image = product_image
-//             .image_selection
-//             .resolve(&product_image_base_name);
+    #[rstest]
+    #[case::stackable_version_without_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        stackableVersion: 2.1.0
+        "#,
+        ResolvedProductImage {
+            image: "docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::stackable_version_with_repo(
+        "trino",
+        r#"
+        productVersion: 1.4.1
+        stackableVersion: 2.1.0
+        repo: my.corp/myteam/stackable
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/trino:1.4.1-stackable2.1.0".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::custom(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::stackable_without_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        "#,
+        ResolvedProductImage {
+            image: "docker.stackable.tech/stackable/superset:1.4.1-stackableTODO".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::default(
+        "superset",
+        r#"
+        productVersion: auto
+        "#,
+        ResolvedProductImage {
+            image: "docker.stackable.tech/stackable/superset:TODO-stackableTODO".to_string(),
+            product_version: "TODO".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::stackable_with_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        repo: my.corp/myteam/stackable
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:1.4.1-stackableTODO".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::custom_takes_precedence(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        stackableVersion: not-used
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::pull_policy_if_not_present(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        repo: not-used
+        pullPolicy: IfNotPresent
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "IfNotPresent".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::pull_policy_always(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        repo: not-used
+        pullPolicy: Always
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "Always".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::pull_policy_never(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        repo: not-used
+        pullPolicy: Never
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "Never".to_string(),
+            pull_secrets: None,
+        }
+    )]
+    #[case::pull_secrets(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        repo: not-used
+        pullPolicy: Always
+        pullSecrets:
+        - name: myPullSecrets1
+        - name: myPullSecrets2
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+            image_pull_policy: "Always".to_string(),
+            pull_secrets: Some(vec![LocalObjectReference{name: Some("myPullSecrets1".to_string())}, LocalObjectReference{name: Some("myPullSecrets2".to_string())}]),
+        }
+    )]
+    fn test_correct_resolved_image(
+        #[case] image_base_name: String,
+        #[case] input: String,
+        #[case] expected: ResolvedProductImage,
+    ) {
+        let product_image: ProductImage = serde_yaml::from_str(&input).expect("Illegal test input");
+        let resolved_product_image = product_image.resolve(&image_base_name);
 
-//         assert_eq!(product_image, expected);
-//     }
+        assert_eq!(resolved_product_image, expected);
+    }
 
-//     #[rstest]
-//     #[case::custom(
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         "#,
-//         "data did not match any variant of untagged enum ProductImageSelection at line 2 column 9"
-//     )]
-//     #[case::stackable_version(
-//         r#"
-//         stackableVersion: 2.1.0
-//         "#,
-//         "data did not match any variant of untagged enum ProductImageSelection at line 2 column 9"
-//     )]
-//     #[case::empty(
-//         "{}",
-//         "data did not match any variant of untagged enum ProductImageSelection"
-//     )]
-//     fn test_invalid_image(#[case] input: String, #[case] expected: String) {
-//         let err = serde_yaml::from_str::<ProductImage>(&input).expect_err("Must be error");
+    #[rstest]
+    #[case::custom(
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        "#,
+        "data did not match any variant of untagged enum ProductImageSelection at line 2 column 9"
+    )]
+    #[case::stackable_version(
+        r#"
+        stackableVersion: 2.1.0
+        "#,
+        "data did not match any variant of untagged enum ProductImageSelection at line 2 column 9"
+    )]
+    #[case::empty(
+        "{}",
+        "data did not match any variant of untagged enum ProductImageSelection"
+    )]
+    fn test_invalid_image(#[case] input: String, #[case] expected: String) {
+        let err = serde_yaml::from_str::<ProductImage>(&input).expect_err("Must be error");
 
-//         assert_eq!(err.to_string(), expected);
-//     }
-
-//     #[rstest]
-//     #[case::default(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         "#,
-//         "my.corp/myteam/stackable/superset:latest-and-greatest",
-//         "IfNotPresent",
-//         None
-//     )]
-//     #[case::always(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         pullPolicy: Always
-//         "#,
-//         "my.corp/myteam/stackable/superset:latest-and-greatest",
-//         "Always",
-//         None
-//     )]
-//     #[case::if_not_present(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         pullPolicy: IfNotPresent
-//         "#,
-//         "my.corp/myteam/stackable/superset:latest-and-greatest",
-//         "IfNotPresent",
-//         None
-//     )]
-//     #[case::never(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         pullPolicy: Never
-//         "#,
-//         "my.corp/myteam/stackable/superset:latest-and-greatest",
-//         "Never",
-//         None
-//     )]
-//     #[case::never(
-//         "superset",
-//         r#"
-//         custom: my.corp/myteam/stackable/superset:latest-and-greatest
-//         productVersion: 1.4.1
-//         pullPolicy: Never
-//         pullSecrets:
-//         - name: myPullSecrets1
-//         - name: myPullSecrets2
-//         "#,
-//         "my.corp/myteam/stackable/superset:latest-and-greatest",
-//         "Never",
-//         Some(vec![LocalObjectReference{name: Some("myPullSecrets1".to_string())}, LocalObjectReference{name: Some("myPullSecrets2".to_string())}]),
-//     )]
-//     fn test_container_attributes(
-//         #[case] product_image_base_name: String,
-//         #[case] input: String,
-//         #[case] expected_image: String,
-//         #[case] expected_pull_policy: String,
-//         #[case] expected_pull_secrets: Option<Vec<LocalObjectReference>>,
-//     ) {
-//         let product_image: ProductImage = serde_yaml::from_str(&input).expect("Illegal test input");
-
-//         assert_eq!(
-//             product_image.image(&product_image_base_name),
-//             expected_image
-//         );
-//         assert_eq!(product_image.image_pull_policy(), expected_pull_policy);
-//         assert_eq!(product_image.pull_secrets(), &expected_pull_secrets);
-//     }
-// }
+        assert_eq!(err.to_string(), expected);
+    }
+}

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -34,15 +34,6 @@ pub enum ProductImageSelection {
     Stackable(ProductImageStackable),
 }
 
-impl Default for ProductImageSelection {
-    fn default() -> Self {
-        Self::Stackable(ProductImageStackable {
-            product_version: "auto".to_string(),
-            repo: None,
-        })
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProductImageCustom {

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -97,8 +97,10 @@ impl Default for PullPolicy {
 }
 
 impl ProductImage {
-    pub fn pull_secrets(&self) -> &Option<Vec<LocalObjectReference>> {
-        &self.pull_secrets
+    pub fn product_version(&self, image_base_name: &str) -> String {
+        self.image_selection
+            .resolve(image_base_name)
+            .product_version
     }
 
     pub fn image(&self, image_base_name: &str) -> String {
@@ -107,6 +109,9 @@ impl ProductImage {
 
     pub fn image_pull_policy(&self) -> String {
         self.pull_policy.as_ref().to_string()
+    }
+    pub fn pull_secrets(&self) -> &Option<Vec<LocalObjectReference>> {
+        &self.pull_secrets
     }
 }
 

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -57,7 +57,7 @@ pub struct ProductImageStackableVersion {
 pub struct ResolvedProductImage {
     /// Version of the product, e.g. `1.4.1`.
     pub product_version: String,
-    /// App version as it should be used into [`get_recommended_labels`]
+    /// App version as formatted for [`get_recommended_labels`]
     pub app_version_label: String,
     /// Image to be used for the product image e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
     pub image: String,

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -75,7 +75,7 @@ pub struct ProductImageStackable {
     repo: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, JsonSchema)]
 pub struct ResolvedProductImage {
     pub product_version: String,
     pub image: String,

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -1,0 +1,211 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const STACKABLE_DOCKER_REPO: &str = "docker.stackable.tech/stackable";
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum ProductImageSelection {
+    // Order matters!
+    // The variants will be tried from top to bottom
+    Custom(ProductImageCustom),
+    StackableVersion(ProductImageStackableVersion),
+    // The following enum variant is commented out for now, as the operators currently don't know which stackableVersions they are compatible with.
+    // In the future they should be able to automatically pick a fitting stackableVersion for them.
+    // The concept of the untagged enum was tested with all known upcoming variants to make sure we don't run into strange problems in the future.
+    // They code snippets are left for illustration and can be commented in as soon as the operators can pick the stackableVersions automatically.
+    Stackable(ProductImageStackable),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductImageCustom {
+    custom: String,
+    product_version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductImageStackableVersion {
+    product_version: String,
+    stackable_version: String,
+    repo: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductImageStackable {
+    product_version: String,
+    repo: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedProductImage {
+    pub image: String,
+    pub product_version: String,
+}
+
+impl ProductImageSelection {
+    pub fn resolve(self, image_base_name: &str) -> ResolvedProductImage {
+        match self {
+            ProductImageSelection::Custom(custom) => ResolvedProductImage {
+                image: custom.custom,
+                product_version: custom.product_version,
+            },
+            ProductImageSelection::StackableVersion(stackable_version) => {
+                let repo = stackable_version
+                    .repo
+                    .as_deref()
+                    .unwrap_or(STACKABLE_DOCKER_REPO);
+                let image = format!(
+                    "{repo}/{image_base_name}:{product_version}-stackable{stackable_version}",
+                    product_version = stackable_version.product_version,
+                    stackable_version = stackable_version.stackable_version,
+                );
+                ResolvedProductImage {
+                    image,
+                    product_version: stackable_version.product_version,
+                }
+            }
+            ProductImageSelection::Stackable(stackable) => {
+                let stackable_version = "TODO";
+                let repo = stackable.repo.as_deref().unwrap_or(STACKABLE_DOCKER_REPO);
+
+                let image = format!(
+                    "{repo}/{image_base_name}:{product_version}-stackable{stackable_version}",
+                    product_version = stackable.product_version,
+                );
+                ResolvedProductImage {
+                    image,
+                    product_version: stackable.product_version,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::stackable_version_without_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        stackableVersion: 2.1.0
+        "#,
+        ResolvedProductImage {
+            image: "docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::stackable_version_with_repo(
+        "trino",
+        r#"
+        productVersion: 1.4.1
+        stackableVersion: 2.1.0
+        repo: my.corp/myteam/stackable
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/trino:1.4.1-stackable2.1.0".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::custom(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::stackable_without_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        "#,
+        ResolvedProductImage {
+            image: "docker.stackable.tech/stackable/superset:1.4.1-stackableTODO".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::stackable_with_repo(
+        "superset",
+        r#"
+        productVersion: 1.4.1
+        repo: my.corp/myteam/stackable
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:1.4.1-stackableTODO".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::custom_takes_precedence(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        stackableVersion: not-used
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    #[case::custom_takes_precedence(
+        "superset",
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        productVersion: 1.4.1
+        repo: not-used
+        "#,
+        ResolvedProductImage {
+            image: "my.corp/myteam/stackable/superset:latest-and-greatest".to_string(),
+            product_version: "1.4.1".to_string(),
+        }
+    )]
+    fn test_correct_resolved_image(
+        #[case] product_image_base_name: String,
+        #[case] input: String,
+        #[case] expected: ResolvedProductImage,
+    ) {
+        let product_image:ProductImageSelection =
+            serde_yaml::from_str(&input).expect("Illegal test input");
+        let product_image = product_image.resolve(&product_image_base_name);
+
+        assert_eq!(product_image, expected);
+    }
+
+    #[rstest]
+    #[case::empty(
+        "{}",
+        "data did not match any variant of untagged enum ProductImageSelection"
+    )]
+    #[case::custom(
+        r#"
+        custom: my.corp/myteam/stackable/superset:latest-and-greatest
+        "#,
+        "data did not match any variant of untagged enum ProductImageSelection"
+    )]
+    #[case::stackable_version(
+        r#"
+        stackableVersion: 2.1.0
+        "#,
+        "data did not match any variant of untagged enum ProductImageSelection"
+    )]
+    fn test_invalid_image(
+        #[case] input: String,
+        #[case] expected: String,
+    ) {
+        let err = serde_yaml::from_str::<ProductImageSelection>(&input).expect_err("Must be error");
+
+        assert_eq!(err.to_string(), expected);
+    }
+}

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -99,23 +99,6 @@ impl Default for PullPolicy {
 }
 
 impl ProductImage {
-    // pub fn product_version(&self, image_base_name: &str) -> String {
-    //     self.image_selection
-    //         .resolve(image_base_name)
-    //         .product_version
-    // }
-
-    // pub fn image(&self, image_base_name: &str) -> String {
-    //     self.image_selection.resolve(image_base_name).image
-    // }
-
-    // pub fn image_pull_policy(&self) -> String {
-    //     self.pull_policy.as_ref().to_string()
-    // }
-    // pub fn pull_secrets(&self) -> &Option<Vec<LocalObjectReference>> {
-    //     &self.pull_secrets
-    // }
-
     pub fn resolve(&self, image_base_name: &str) -> ResolvedProductImage {
         let image_pull_policy = self.pull_policy.as_ref().to_string();
         let pull_secrets = self.pull_secrets.clone();

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -68,6 +68,7 @@ pub struct ProductImageStackableVersion {
 #[serde(rename_all = "camelCase")]
 pub struct ProductImageStackable {
     /// Version of the product, e.g. `1.4.1`.
+    /// Set it to `auto` to let the operator automatically pick the recommended product version he is compatible with.
     // Note that this is not an Option<String>, as in this case no attribute is needed for this enum variant and this enum variant will match *any* arbitrary input,
     // thus making the validation useless
     product_version: String,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -40,7 +40,7 @@ pub struct ObjectLabels<'a, T> {
     ///
     /// This version should include the Stackable version, such as `3.0.0-stackable0.1.0`.
     /// If the Stackable version is not known, the product version should be used together with a suffix (if possible).
-    /// In the case of custom product images provided by the user, only the product version is known,
+    /// If a custom product image is provided by the user (in which case only the product version is known),
     /// `3.0.0-<tag-of-custom-image>` should be used.
     ///
     /// However, this is pure documentation and should not be parsed.

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 
 #[cfg(doc)]
 use crate::builder::ObjectMetaBuilder;
+#[cfg(doc)]
+use crate::commons::product_image_selection::ResolvedProductImage;
 
 const APP_KUBERNETES_LABEL_BASE: &str = "app.kubernetes.io/";
 
@@ -30,10 +32,16 @@ pub struct ObjectLabels<'a, T> {
     pub owner: &'a T,
     /// The name of the app being managed, such as `zookeeper`
     pub app_name: &'a str,
-    /// The version of the app being managed (not of the operator)
+    /// The version of the app being managed (not of the operator).
     ///
-    /// This version should include the Stackable version, such as `0.1.0-stackable0.1.0`. In the case of custom product images,
-    /// the tag should be appended, such as `<productversion>-<tag>`. However, this is pure documentation and should not be parsed.
+    /// If setting this label on a Stackable product please use the provided `app_version_label` attribute of the
+    /// [`ResolvedProductImage`] struct
+    ///
+    /// This version should include the Stackable version, such as `3.0.0-stackable0.1.0`.
+    /// If the Stackable version is not known, the product version should be used together with a suffix (if possible).
+    /// In the case of custom product images provided by the user, only the product version is known,
+    /// `3.0.0-<tag-of-custom-image>` should be used.
+    /// However, this is pure documentation and should not be parsed.
     pub app_version: &'a str,
     /// The name of the operator and controller managing the object
     pub managed_by: &'a str,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -35,8 +35,7 @@ pub struct ObjectLabels<'a, T> {
     pub app_name: &'a str,
     /// The version of the app being managed (not of the operator).
     ///
-    /// If setting this label on a Stackable product please use the provided `app_version_label` attribute of the
-    /// [`ResolvedProductImage`] struct
+    /// If setting this label on a Stackable product then please use [`ResolvedProductImage::app_version_label`]
     ///
     /// This version should include the Stackable version, such as `3.0.0-stackable0.1.0`.
     /// If the Stackable version is not known, then the product version should be used together with a suffix (if possible).

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -40,7 +40,7 @@ pub struct ObjectLabels<'a, T> {
     /// This version should include the Stackable version, such as `3.0.0-stackable0.1.0`.
     /// If the Stackable version is not known, then the product version should be used together with a suffix (if possible).
     /// If a custom product image is provided by the user (in which case only the product version is known),
-    /// `3.0.0-<tag-of-custom-image>` should be used.
+    /// then the format `3.0.0-<tag-of-custom-image>` should be used.
     ///
     /// However, this is pure documentation and should not be parsed.
     pub app_version: &'a str,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -39,7 +39,7 @@ pub struct ObjectLabels<'a, T> {
     /// [`ResolvedProductImage`] struct
     ///
     /// This version should include the Stackable version, such as `3.0.0-stackable0.1.0`.
-    /// If the Stackable version is not known, the product version should be used together with a suffix (if possible).
+    /// If the Stackable version is not known, then the product version should be used together with a suffix (if possible).
     /// If a custom product image is provided by the user (in which case only the product version is known),
     /// `3.0.0-<tag-of-custom-image>` should be used.
     ///

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -42,6 +42,7 @@ pub struct ObjectLabels<'a, T> {
     /// If the Stackable version is not known, the product version should be used together with a suffix (if possible).
     /// In the case of custom product images provided by the user, only the product version is known,
     /// `3.0.0-<tag-of-custom-image>` should be used.
+    ///
     /// However, this is pure documentation and should not be parsed.
     pub app_version: &'a str,
     /// The DNS-style name of the operator managing the object (such as `zookeeper.stackable.tech`)


### PR DESCRIPTION
## Description
For https://github.com/stackabletech/operator-rs/issues/470
Reference implementation in kafka: https://github.com/stackabletech/kafka-operator/pull/482
ADR is [here](https://docs.stackable.tech/home/stable/contributor/adr/ADR018-product_image_versioning.html)

The idea is to add all the currently known enum variants to see that the concept works. Before merging the `ProductImageSelection::Stackable` enum variant will be removed/commented out.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
