### PR TITLE
Separate Kubernetes client into a client part and an API part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to this project will be documented in this file.
 
 - Extended `ClusterResource` with `Secret`, `ServiceAccount` and `RoleBinding` ([#485]).
 
+### Changed
+
+- BREAKING: Kubernetes client separated into a client part and an API part. This
+  follows now the same pattern as in kube-rs and was necessary because kube-rs
+  0.75.0 constrains the Resource trait by a scope (see
+  "https://github.com/kube-rs/kube/pull/956"). For instance,
+  `client.get::<ConfigMap>(configmap_name, namespace)` must be migrated to
+  `client.get_namespaced_api::<ConfigMap>(namespace).get(configmap_name)`
+  ([#481]).
+- Check added that `ClusterResources` are in the namespace of the
+  cluster ([#481]).
+- k8s-openapi 0.15.0 -> 0.16.0 ([#481])
+- kube-rs 0.74.0 -> 0.75.0 ([#481])
+
+[#481]: https://github.com/stackabletech/operator-rs/pull/481
 [#485]: https://github.com/stackabletech/operator-rs/pull/485
 
 ## [0.25.2] - 2022-09-27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ const_format = "0.2.26"
 either = "1.8.0"
 futures = "0.3.23"
 json-patch = "0.2.6"
-k8s-openapi = { version = "0.15.0", default-features = false, features = ["schemars", "v1_24"] }
-kube = { version = "0.74.0", features = ["jsonpatch", "runtime", "derive"] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["schemars", "v1_24"] }
+kube = { version = "0.75.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,12 +4,13 @@ use crate::label_selector;
 use either::Either;
 use futures::StreamExt;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use k8s_openapi::ClusterResourceScope;
 use kube::api::{DeleteParams, ListParams, Patch, PatchParams, PostParams, Resource, ResourceExt};
 use kube::client::Client as KubeClient;
-use kube::core::Status;
+use kube::core::{DynamicResourceScope, NamespaceResourceScope, Status};
 use kube::runtime::wait::delete::delete_and_finalize;
 use kube::runtime::WatchStreamExt;
-use kube::{Api, Config};
+use kube::Config;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::convert::TryFrom;
@@ -21,32 +22,125 @@ use tracing::trace;
 #[derive(Clone)]
 pub struct Client {
     client: KubeClient,
-    patch_params: PatchParams,
-    post_params: PostParams,
-    delete_params: DeleteParams,
-    /// Default namespace as defined in the kubeconfig this client has been created from.
-    pub default_namespace: String,
+    field_manager: Option<String>,
 }
 
 impl Client {
-    pub fn new(
-        client: KubeClient,
-        field_manager: Option<String>,
-        default_namespace: String,
-    ) -> Self {
+    pub fn new(client: KubeClient, field_manager: Option<String>) -> Self {
         Client {
             client,
-            post_params: PostParams {
-                field_manager: field_manager.clone(),
-                ..PostParams::default()
-            },
+            field_manager,
+        }
+    }
+
+    /// Returns a [kube::client::Client] that can be freely used.
+    /// It does not need to be cloned before first use.
+    pub fn as_kube_client(&self) -> KubeClient {
+        self.client.clone()
+    }
+
+    /// Returns an [Api] object for resources with an indeterminate dynamic scope.
+    ///
+    /// If a namespace is given then the returned Api is usable for namespaced resources in this
+    /// namespace. If no namespace is given then the returned Api is usable for cluster-scoped
+    /// resources.
+    pub fn get_api<T>(&self, namespace: Option<&str>) -> Api<T>
+    where
+        T: Resource<Scope = DynamicResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        let kube_api = if let Some(namespace) = namespace {
+            kube::Api::namespaced_with(self.client.clone(), namespace, &T::DynamicType::default())
+        } else {
+            kube::Api::all(self.client.clone())
+        };
+        Api::new(kube_api, self.field_manager.clone())
+    }
+
+    /// Returns an [Api] object for namespaced resources. If no namespace is given then the default
+    /// one is used.
+    pub fn get_namespaced_api_opt<T>(&self, namespace: Option<&str>) -> Api<T>
+    where
+        T: Resource<Scope = NamespaceResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        if let Some(namespace) = namespace {
+            self.get_namespaced_api(namespace)
+        } else {
+            self.get_default_namespaced_api()
+        }
+    }
+
+    /// Returns an [Api] object for namespaced resources in the given namespace.
+    pub fn get_namespaced_api<T>(&self, namespace: &str) -> Api<T>
+    where
+        T: Resource<Scope = NamespaceResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        let kube_api = kube::Api::namespaced(self.client.clone(), namespace);
+        Api::new(kube_api, self.field_manager.clone())
+    }
+
+    /// Returns an [Api] object for namespaced resources in the default namespace.
+    pub fn get_default_namespaced_api<T>(&self) -> Api<T>
+    where
+        T: Resource<Scope = NamespaceResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        let kube_api = kube::Api::default_namespaced(self.client.clone());
+        Api::new(kube_api, self.field_manager.clone())
+    }
+
+    /// Returns an [Api] object for namespaced resources across all namespaces.
+    pub fn get_all_api<T>(&self) -> Api<T>
+    where
+        T: Resource<Scope = NamespaceResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        let kube_api = kube::Api::all(self.client.clone());
+        Api::new(kube_api, self.field_manager.clone())
+    }
+
+    /// Returns an [Api] object for cluster-scoped resources.
+    pub fn get_cluster_api<T>(&self) -> Api<T>
+    where
+        T: Resource<Scope = ClusterResourceScope>,
+        <T as Resource>::DynamicType: Default,
+    {
+        let kube_api = kube::Api::all(self.client.clone());
+        Api::new(kube_api, self.field_manager.clone())
+    }
+}
+
+/// The generic Api abstraction
+///
+/// It wraps an underlying [kube::Api] and provides some common functionality.
+pub struct Api<T> {
+    kube_api: kube::Api<T>,
+    patch_params: PatchParams,
+    post_params: PostParams,
+    delete_params: DeleteParams,
+}
+
+impl<T> Api<T> {
+    pub fn new(kube_api: kube::Api<T>, field_manager: Option<String>) -> Api<T> {
+        Api {
+            kube_api,
             patch_params: PatchParams {
-                field_manager,
+                field_manager: field_manager.clone(),
                 ..PatchParams::default()
             },
+            post_params: PostParams {
+                field_manager,
+                ..PostParams::default()
+            },
             delete_params: DeleteParams::default(),
-            default_namespace,
         }
+    }
+
+    /// Returns the wrapped [kube::Api] and consumes this one.
+    pub fn as_kube_api(self) -> kube::Api<T> {
+        self.kube_api
     }
 
     /// Server-side apply requires a `field_manager` that uniquely identifies a single usage site,
@@ -61,68 +155,33 @@ impl Client {
         params
     }
 
-    /// Returns a [kube::client::Client]] that can be freely used.
-    /// It does not need to be cloned before first use.
-    pub fn as_kube_client(&self) -> KubeClient {
-        self.client.clone()
-    }
-
     /// Retrieves a single instance of the requested resource type with the given name.
-    pub async fn get<T>(&self, resource_name: &str, namespace: Option<&str>) -> OperatorResult<T>
+    pub async fn get(&self, resource_name: &str) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
-        Ok(self.get_api(namespace).get(resource_name).await?)
+        Ok(self.kube_api.get(resource_name).await?)
     }
 
     /// Retrieves a single instance of the requested resource type with the given name, if it exists.
-    pub async fn get_opt<T>(
-        &self,
-        resource_name: &str,
-        namespace: Option<&str>,
-    ) -> OperatorResult<Option<T>>
+    pub async fn get_opt(&self, resource_name: &str) -> OperatorResult<Option<T>>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
-        Ok(self.get_api(namespace).get_opt(resource_name).await?)
-    }
-
-    /// Returns Ok(true) if the resource has been registered in Kubernetes, Ok(false) if it could
-    /// not be found and Error in any other case (e.g. connection to Kubernetes failed in some way).
-    /// Kubernetes does not offer a pure exists check. Therefore we currently use the get() method
-    /// and ignore the (in case of existing) returned resource. We should replace this with a pure
-    /// exists method as soon as it becomes available (e.g. only returning Ok/Success) to reduce
-    /// network traffic.
-    #[deprecated(since = "0.24.0", note = "Replaced by `get_opt`")]
-    pub async fn exists<T>(
-        &self,
-        resource_name: &str,
-        namespace: Option<&str>,
-    ) -> OperatorResult<bool>
-    where
-        T: Clone + Debug + DeserializeOwned + Resource,
-        <T as Resource>::DynamicType: Default,
-    {
-        self.get_opt::<T>(resource_name, namespace)
-            .await
-            .map(|obj| obj.is_some())
+        Ok(self.kube_api.get_opt(resource_name).await?)
     }
 
     /// Retrieves all instances of the requested resource type.
     ///
     /// The `list_params` parameter can be used to pass in a `label_selector` or a `field_selector`.
-    pub async fn list<T>(
-        &self,
-        namespace: Option<&str>,
-        list_params: &ListParams,
-    ) -> OperatorResult<Vec<T>>
+    pub async fn list(&self, list_params: &ListParams) -> OperatorResult<Vec<T>>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
-        Ok(self.get_api(namespace).list(list_params).await?.items)
+        Ok(self.kube_api.list(list_params).await?.items)
     }
 
     /// Lists resources from the API using a LabelSelector.
@@ -131,13 +190,8 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// - `namespace` - Optional name of the namespace to search in. Otherwise searches in all namespaces.
     /// - `selector` - A reference to a `LabelSelector` to filter out pods
-    pub async fn list_with_label_selector<T>(
-        &self,
-        namespace: Option<&str>,
-        selector: &LabelSelector,
-    ) -> OperatorResult<Vec<T>>
+    pub async fn list_with_label_selector(&self, selector: &LabelSelector) -> OperatorResult<Vec<T>>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
@@ -148,25 +202,22 @@ impl Client {
             label_selector: Some(selector_string),
             ..ListParams::default()
         };
-        self.list(namespace, &list_params).await
+        Ok(self.kube_api.list(&list_params).await?.items)
     }
 
     /// Creates a new resource.
-    pub async fn create<T>(&self, resource: &T) -> OperatorResult<T>
+    pub async fn create(&self, resource: &T) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource + Serialize,
         <T as Resource>::DynamicType: Default,
     {
-        Ok(self
-            .get_api(resource.namespace().as_deref())
-            .create(&self.post_params, resource)
-            .await?)
+        Ok(self.kube_api.create(&self.post_params, resource).await?)
     }
 
     /// Patches a resource using the `MERGE` patch strategy described
     /// in [JSON Merge Patch](https://tools.ietf.org/html/rfc7386)
     /// This will fail for objects that do not exist yet.
-    pub async fn merge_patch<T, P>(&self, resource: &T, patch: P) -> OperatorResult<T>
+    pub async fn merge_patch<P>(&self, resource: &T, patch: P) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
@@ -181,7 +232,7 @@ impl Client {
     /// and the merge strategy can differ from field to field and will be defined by the
     /// schema of the resource in question.
     /// This will _create_ or _update_ existing resources.
-    pub async fn apply_patch<T, P>(
+    pub async fn apply_patch<P>(
         &self,
         field_manager_scope: &str,
         resource: &T,
@@ -201,7 +252,7 @@ impl Client {
     }
 
     /// Patches a resource using the `JSON` patch strategy described in [JavaScript Object Notation (JSON) Patch](https://tools.ietf.org/html/rfc6902).
-    pub async fn json_patch<T>(&self, resource: &T, patch: json_patch::Patch) -> OperatorResult<T>
+    pub async fn json_patch(&self, resource: &T, patch: json_patch::Patch) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
@@ -215,7 +266,7 @@ impl Client {
         self.patch(resource, patch, &self.patch_params).await
     }
 
-    async fn patch<T, P>(
+    async fn patch<P>(
         &self,
         resource: &T,
         patch: Patch<P>,
@@ -227,14 +278,14 @@ impl Client {
         P: Debug + Serialize,
     {
         Ok(self
-            .get_api(resource.namespace().as_deref())
+            .kube_api
             .patch(&resource.name_any(), patch_params, &patch)
             .await?)
     }
 
     /// Patches subresource status in a given Resource using apply strategy.
     /// The subresource status must be defined beforehand in the Crd.
-    pub async fn apply_patch_status<T, S>(
+    pub async fn apply_patch_status<S>(
         &self,
         field_manager_scope: &str,
         resource: &T,
@@ -242,7 +293,6 @@ impl Client {
     ) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource<DynamicType = ()>,
-        <T as Resource>::DynamicType: Default,
         S: Debug + Serialize,
     {
         let meta = resource.meta();
@@ -266,7 +316,7 @@ impl Client {
 
     /// Patches subresource status in a given Resource using merge strategy.
     /// The subresource status must be defined beforehand in the Crd.
-    pub async fn merge_patch_status<T, S>(&self, resource: &T, status: &S) -> OperatorResult<T>
+    pub async fn merge_patch_status<S>(&self, resource: &T, status: &S) -> OperatorResult<T>
     where
         T: DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
@@ -281,7 +331,7 @@ impl Client {
     /// Patches subresource status in a given Resource using merge strategy.
     /// The subresource status must be defined beforehand in the Crd.
     /// Patches a resource using the `JSON` patch strategy described in [JavaScript Object Notation (JSON) Patch](https://tools.ietf.org/html/rfc6902).
-    pub async fn json_patch_status<T>(
+    pub async fn json_patch_status(
         &self,
         resource: &T,
         patch: json_patch::Patch,
@@ -310,7 +360,7 @@ impl Client {
     ///   With a strategic merge patch, a list is either replaced or merged depending on its patch strategy.
     ///   The patch strategy is specified by the value of the patchStrategy key in a field tag in the Kubernetes source code.
     ///   For example, the Containers field of PodSpec struct has a patchStrategy of merge.
-    async fn patch_status<T, S>(
+    async fn patch_status<S>(
         &self,
         resource: &T,
         patch: Patch<S>,
@@ -321,8 +371,8 @@ impl Client {
         <T as Resource>::DynamicType: Default,
         S: Debug + Serialize,
     {
-        let api = self.get_api(resource.namespace().as_deref());
-        Ok(api
+        Ok(self
+            .kube_api
             .patch_status(&resource.name_any(), patch_params, &patch)
             .await?)
     }
@@ -331,13 +381,13 @@ impl Client {
     /// The operation is called `replace` in the Kubernetes API.
     /// While a `patch` can just update a partial object
     /// a `update` will always replace the full object.
-    pub async fn update<T>(&self, resource: &T) -> OperatorResult<T>
+    pub async fn update(&self, resource: &T) -> OperatorResult<T>
     where
         T: Clone + Debug + DeserializeOwned + Resource + Serialize,
         <T as Resource>::DynamicType: Default,
     {
         Ok(self
-            .get_api(resource.namespace().as_deref())
+            .kube_api
             .replace(&resource.name_any(), &self.post_params, resource)
             .await?)
     }
@@ -349,13 +399,13 @@ impl Client {
     /// Which of the two are returned depends on the API being called.
     /// Take a look at the Kubernetes API reference.
     /// Some `delete` endpoints return the object and others return a `Status` object.
-    pub async fn delete<T>(&self, resource: &T) -> OperatorResult<Either<T, Status>>
+    pub async fn delete(&self, resource: &T) -> OperatorResult<Either<T, Status>>
     where
         T: Clone + Debug + DeserializeOwned + Resource,
         <T as Resource>::DynamicType: Default,
     {
-        let api: Api<T> = self.get_api(resource.namespace().as_deref());
-        Ok(api
+        Ok(self
+            .kube_api
             .delete(&resource.name_any(), &self.delete_params)
             .await?)
     }
@@ -367,13 +417,13 @@ impl Client {
     ///
     /// Afterwards it loops and checks regularly whether the resource has been deleted
     /// from Kubernetes
-    pub async fn ensure_deleted<T>(&self, resource: T) -> OperatorResult<()>
+    pub async fn ensure_deleted(&self, resource: T) -> OperatorResult<()>
     where
         T: Clone + Debug + DeserializeOwned + Resource + Send + 'static,
         <T as Resource>::DynamicType: Default,
     {
         Ok(delete_and_finalize(
-            self.get_api::<T>(resource.namespace().as_deref()),
+            self.kube_api.clone(),
             resource
                 .meta()
                 .name
@@ -386,42 +436,12 @@ impl Client {
         .await?)
     }
 
-    /// Returns an [kube::Api] object which is either namespaced or not depending on whether
-    /// or not a namespace string is passed in.
-    pub fn get_api<T>(&self, namespace: Option<&str>) -> Api<T>
-    where
-        T: Resource,
-        <T as Resource>::DynamicType: Default,
-    {
-        match namespace {
-            None => self.get_all_api(),
-            Some(namespace) => self.get_namespaced_api(namespace),
-        }
-    }
-
-    pub fn get_all_api<T>(&self) -> Api<T>
-    where
-        T: Resource,
-        <T as Resource>::DynamicType: Default,
-    {
-        Api::all(self.client.clone())
-    }
-
-    pub fn get_namespaced_api<T>(&self, namespace: &str) -> Api<T>
-    where
-        T: Resource,
-        <T as Resource>::DynamicType: Default,
-    {
-        Api::namespaced(self.client.clone(), namespace)
-    }
-
     /// Waits indefinitely until resources matching given `ListParams` are created in Kubernetes.
     /// If the resource is already present, this method just returns. Makes no assumptions about resource's state,
     /// e.g. a pod created could be created, but not in a ready state.
     ///
     /// # Arguments
     ///
-    /// - `namespace` - Optional namespace to look for the resources in.
     /// - `lp` - Parameters to filter resources to wait for in given namespace.
     ///
     /// # Example
@@ -442,19 +462,20 @@ impl Client {
     /// // Will time out in 1 second unless the nonexistent-pod actually exists
     ///  let wait_created_result: Result<(), Elapsed> = tokio::time::timeout(
     ///          Duration::from_secs(1),
-    ///          client.wait_created::<Pod>(Some(&client.default_namespace), lp.clone()),
+    ///          client
+    ///              .get_default_namespaced_api::<Pod>()
+    ///              .wait_created(lp.clone()),
     ///      )
     ///      .await;
     /// }
     /// ```
     ///
-    pub async fn wait_created<T>(&self, namespace: Option<&str>, lp: ListParams)
+    pub async fn wait_created(&self, lp: ListParams)
     where
         T: Resource + Clone + Debug + DeserializeOwned + Send + 'static,
         <T as Resource>::DynamicType: Default,
     {
-        let api: Api<T> = self.get_api(namespace);
-        let watcher = kube::runtime::watcher(api, lp).boxed();
+        let watcher = kube::runtime::watcher(self.kube_api.clone(), lp).boxed();
         watcher
             .applied_objects()
             .skip_while(|res| std::future::ready(res.is_err()))
@@ -467,11 +488,9 @@ pub async fn create_client(field_manager: Option<String>) -> OperatorResult<Clie
     let kubeconfig: Config = kube::Config::infer()
         .await
         .map_err(kube::Error::InferConfig)?;
-    let default_namespace = kubeconfig.default_namespace.clone();
     Ok(Client::new(
         kube::Client::try_from(kubeconfig)?,
         field_manager,
-        default_namespace,
     ))
 }
 
@@ -480,7 +499,7 @@ mod tests {
     use futures::StreamExt;
     use k8s_openapi::api::core::v1::{Container, Pod, PodSpec};
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
-    use kube::api::{ListParams, ObjectMeta, PostParams, ResourceExt};
+    use kube::api::{ListParams, ObjectMeta, ResourceExt};
     use kube::runtime::watcher::Event;
     use std::collections::BTreeMap;
     use std::time::Duration;
@@ -512,9 +531,9 @@ mod tests {
             }),
             ..Pod::default()
         };
-        let api = client.get_api(Some(&client.default_namespace));
+        let api = client.get_default_namespaced_api();
         let created_pod = api
-            .create(&PostParams::default(), &pod_to_wait_for)
+            .create(&pod_to_wait_for)
             .await
             .expect("Test pod not created.");
         let lp: ListParams = ListParams::default().fields(&format!(
@@ -529,14 +548,16 @@ mod tests {
         // Timeout is not acceptable
         tokio::time::timeout(
             Duration::from_secs(30), // Busybox is ~5MB and sub 1 sec to start.
-            client.wait_created::<Pod>(Some(&client.default_namespace), lp.clone()),
+            api.wait_created(lp.clone()),
         )
         .await
         .expect("The tested wait_created function timed out.");
 
         // A second, manually constructed watcher is used to verify the ListParams filter out the correct resource
         // and the `wait_created` function returned when the correct resources had been detected.
-        let mut ready_watcher = kube::runtime::watcher::<Pod>(api, lp).boxed();
+        let mut ready_watcher =
+            kube::runtime::watcher::<Pod>(client.get_default_namespaced_api().as_kube_api(), lp)
+                .boxed();
         while let Some(result) = ready_watcher.next().await {
             match result {
                 Ok(event) => match event {
@@ -558,8 +579,7 @@ mod tests {
             }
         }
 
-        client
-            .delete(&created_pod)
+        api.delete(&created_pod)
             .await
             .expect("Expected test_wait_created pod to be deleted.");
     }
@@ -576,7 +596,9 @@ mod tests {
         // There is no such pod, therefore the `wait_created` function call times out.
         let wait_created_result: Result<(), Elapsed> = tokio::time::timeout(
             Duration::from_secs(1),
-            client.wait_created::<Pod>(Some(&client.default_namespace), lp.clone()),
+            client
+                .get_default_namespaced_api::<Pod>()
+                .wait_created(lp.clone()),
         )
         .await;
 
@@ -596,8 +618,9 @@ mod tests {
             match_labels: Some(match_labels.clone()),
             ..LabelSelector::default()
         };
-        let no_pods: Vec<Pod> = client
-            .list_with_label_selector(Some(&client.default_namespace), &label_selector)
+        let api = client.get_default_namespaced_api();
+        let no_pods: Vec<Pod> = api
+            .list_with_label_selector(&label_selector)
             .await
             .expect("Expected LabelSelector to return a result with zero pods.");
         assert!(no_pods.is_empty());
@@ -621,20 +644,18 @@ mod tests {
             }),
             ..Pod::default()
         };
-        let api = client.get_api(Some(&client.default_namespace));
         let created_pod = api
-            .create(&PostParams::default(), &pod_to_wait_for)
+            .create(&pod_to_wait_for)
             .await
             .expect("Test pod not created.");
 
-        let one_pod: Vec<Pod> = client
-            .list_with_label_selector(Some(&client.default_namespace), &label_selector)
+        let one_pod: Vec<Pod> = api
+            .list_with_label_selector(&label_selector)
             .await
             .expect("Expected LabelSelector to return a result with zero pods.");
 
         assert_eq!(1, one_pod.len());
-        client
-            .delete(&created_pod)
+        api.delete(&created_pod)
             .await
             .expect("Expected Pod to be deleted");
     }

--- a/src/commons/authentication.rs
+++ b/src/commons/authentication.rs
@@ -55,7 +55,8 @@ impl AuthenticationClass {
         authentication_class_name: &str,
     ) -> Result<AuthenticationClass, Error> {
         client
-            .get::<AuthenticationClass>(authentication_class_name, None) // AuthenticationClass has ClusterScope
+            .get_cluster_api::<AuthenticationClass>()
+            .get(authentication_class_name)
             .await
     }
 }

--- a/src/commons/opa.rs
+++ b/src/commons/opa.rs
@@ -211,7 +211,8 @@ impl OpaConfig {
         namespace: Option<&str>,
     ) -> OperatorResult<String> {
         client
-            .get::<ConfigMap>(&self.config_map_name, namespace)
+            .get_namespaced_api_opt::<ConfigMap>(namespace)
+            .get(&self.config_map_name)
             .await?
             .data
             .and_then(|mut data| data.remove("OPA"))

--- a/src/commons/s3.rs
+++ b/src/commons/s3.rs
@@ -44,7 +44,8 @@ impl S3BucketSpec {
         namespace: Option<&str>,
     ) -> OperatorResult<S3BucketSpec> {
         client
-            .get::<S3Bucket>(resource_name, namespace)
+            .get_namespaced_api_opt::<S3Bucket>(namespace)
+            .get(resource_name)
             .await
             .map(|crd| crd.spec)
             .map_err(|_source| error::Error::MissingS3Bucket {
@@ -184,7 +185,8 @@ impl S3ConnectionSpec {
         namespace: Option<&str>,
     ) -> OperatorResult<S3ConnectionSpec> {
         client
-            .get::<S3Connection>(resource_name, namespace)
+            .get_namespaced_api_opt::<S3Connection>(namespace)
+            .get(resource_name)
             .await
             .map(|conn| conn.spec)
             .map_err(|_source| error::Error::MissingS3Connection {

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,16 @@ pub enum Error {
     MissingLabel { label: &'static str },
 
     #[error(
+        "Resource contains an unexpected namespace. \
+            Expected: {expected_namespace}, \
+            actual: {actual_namespace}"
+    )]
+    UnexpectedNamespace {
+        expected_namespace: String,
+        actual_namespace: String,
+    },
+
+    #[error(
         "Label contains unexpected content. \
             Expected: {label}={expected_content}, \
             actual: {label}={actual_content}"

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,5 +1,6 @@
 //! This module provides helpers and constants to deal with namespaces
 use crate::client::Client;
+use k8s_openapi::NamespaceResourceScope;
 use kube::{Api, Resource};
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -23,11 +24,12 @@ impl WatchNamespace {
     /// depending on which variant we are.
     pub fn get_api<T>(&self, client: &Client) -> Api<T>
     where
-        T: Resource<DynamicType = ()>,
+        T: Resource<DynamicType = (), Scope = NamespaceResourceScope>,
     {
-        match self {
+        let api = match self {
             WatchNamespace::All => client.get_all_api(),
             WatchNamespace::One(namespace) => client.get_namespaced_api(namespace),
-        }
+        };
+        api.as_kube_api()
     }
 }


### PR DESCRIPTION
## Description

### Changed

- **BREAKING:** Kubernetes client separated into a client part and an API part. This follows now the same pattern as in kube-rs and was necessary because kube-rs 0.75.0 constrains the Resource trait by a scope (see https://github.com/kube-rs/kube/pull/956). For instance, `client.get::<ConfigMap>(configmap_name, namespace)` must be migrated to `client.get_namespaced_api::<ConfigMap>(namespace).get(configmap_name)`.
- Check added that `ClusterResources` are in the namespace of the cluster.
- k8s-openapi 0.15.0 -> 0.16.0
- kube-rs 0.74.0 -> 0.75.0

Closes #471 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
