### PR TITLE
[Merged by Bors] - Implement ClusterResource for ServiceAccount and RoleBinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Extended `ClusterResource` with `Secret`, `ServiceAccount` and `RoleBinding` ([#485]).
+
+[#485]: https://github.com/stackabletech/operator-rs/pull/485
+
 ## [0.25.2] - 2022-09-27
 
 This is a rerelease of 0.25.1 which some last-minute incompatible API changes to the additions that would have been released in 0.25.1.

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -18,6 +18,7 @@ use crate::{
     kube::{Resource, ResourceExt},
     labels::{APP_INSTANCE_LABEL, APP_MANAGED_BY_LABEL, APP_NAME_LABEL},
 };
+use k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding};
 use kube::core::ErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info};
@@ -37,6 +38,8 @@ impl ClusterResource for ConfigMap {}
 impl ClusterResource for DaemonSet {}
 impl ClusterResource for Service {}
 impl ClusterResource for StatefulSet {}
+impl ClusterResource for ServiceAccount {}
+impl ClusterResource for RoleBinding {}
 
 /// A structure containing the cluster resources.
 ///
@@ -280,6 +283,8 @@ impl ClusterResources {
             self.delete_orphaned_resources_of_kind::<StatefulSet>(client),
             self.delete_orphaned_resources_of_kind::<DaemonSet>(client),
             self.delete_orphaned_resources_of_kind::<ConfigMap>(client),
+            self.delete_orphaned_resources_of_kind::<ServiceAccount>(client),
+            self.delete_orphaned_resources_of_kind::<RoleBinding>(client),
         )?;
 
         Ok(())

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -18,7 +18,7 @@ use crate::{
     kube::{Resource, ResourceExt},
     labels::{APP_INSTANCE_LABEL, APP_MANAGED_BY_LABEL, APP_NAME_LABEL},
 };
-use k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding};
+use k8s_openapi::api::{core::v1::Secret, core::v1::ServiceAccount, rbac::v1::RoleBinding};
 use kube::core::ErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info};
@@ -40,6 +40,7 @@ impl ClusterResource for Service {}
 impl ClusterResource for StatefulSet {}
 impl ClusterResource for ServiceAccount {}
 impl ClusterResource for RoleBinding {}
+impl ClusterResource for Secret {}
 
 /// A structure containing the cluster resources.
 ///
@@ -285,6 +286,7 @@ impl ClusterResources {
             self.delete_orphaned_resources_of_kind::<ConfigMap>(client),
             self.delete_orphaned_resources_of_kind::<ServiceAccount>(client),
             self.delete_orphaned_resources_of_kind::<RoleBinding>(client),
+            self.delete_orphaned_resources_of_kind::<Secret>(client),
         )?;
 
         Ok(())


### PR DESCRIPTION
## Description

These are currently used by zookeeper-operator, so if we want to be consistent and deploy everything with clusterresources then we'll need to add support for them.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
