### PR TITLE
[Merged by Bors] - Upgrade to kube-rs 0.75.0 (`Api`-Less Edition(TM))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- kube-rs: 0.74.0 -> 0.75.0 ([#490]).
+- `Client` methods now take the namespace as a `&str` (for namespaced resources) or `&()` (for cluster-scoped resources),
+  rather than always taking an `Option<&str>` ([#490]).
+
+[#490]: https://github.com/stackabletech/operator-rs/pull/490
+
 ## [0.25.3] - 2022-10-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - kube-rs: 0.74.0 -> 0.75.0 ([#490]).
-- `Client` methods now take the namespace as a `&str` (for namespaced resources) or `&()` (for cluster-scoped resources),
-  rather than always taking an `Option<&str>` ([#490]).
+- BREAKING: `Client` methods now take the namespace as a `&str` (for namespaced resources) or
+  `&()` (for cluster-scoped resources), rather than always taking an `Option<&str>` ([#490]).
 
 [#490]: https://github.com/stackabletech/operator-rs/pull/490
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ const_format = "0.2.26"
 either = "1.8.0"
 futures = "0.3.23"
 json-patch = "0.2.6"
-k8s-openapi = { version = "0.15.0", default-features = false, features = ["schemars", "v1_24"] }
-kube = { version = "0.74.0", features = ["jsonpatch", "runtime", "derive"] }
+k8s-openapi = { version = "0.16.0", default-features = false, features = ["schemars", "v1_24"] }
+kube = { version = "0.75.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -477,8 +477,6 @@ pub trait GetApi: Resource + Sized {
         Self::DynamicType: Default;
     /// Get the namespace of `Self`.
     fn get_namespace(&self) -> &Self::Namespace;
-    /// Coerce a string namespace into `Self::Namespace`.
-    fn namespace_from_str(ns: &str) -> &Self::Namespace;
 }
 
 impl<K> GetApi for K
@@ -496,9 +494,6 @@ where
     fn get_namespace(&self) -> &Self::Namespace {
         <(K, K::Scope) as GetApiImpl>::get_namespace(self)
     }
-    fn namespace_from_str(ns: &str) -> &Self::Namespace {
-        <(K, K::Scope) as GetApiImpl>::namespace_from_str(ns)
-    }
 }
 
 #[doc(hidden)]
@@ -510,7 +505,6 @@ pub trait GetApiImpl {
     where
         <Self::Resource as Resource>::DynamicType: Default;
     fn get_namespace(res: &Self::Resource) -> &Self::Namespace;
-    fn namespace_from_str(ns: &str) -> &Self::Namespace;
 }
 
 impl<K> GetApiImpl for (K, NamespaceResourceScope)
@@ -528,9 +522,6 @@ where
     fn get_namespace(res: &Self::Resource) -> &Self::Namespace {
         res.meta().namespace.as_deref().unwrap_or_default()
     }
-    fn namespace_from_str(ns: &str) -> &Self::Namespace {
-        ns
-    }
 }
 
 impl<K> GetApiImpl for (K, ClusterResourceScope)
@@ -546,9 +537,6 @@ where
         Api::all(client)
     }
     fn get_namespace(_res: &Self::Resource) -> &Self::Namespace {
-        &()
-    }
-    fn namespace_from_str(_ns: &str) -> &Self::Namespace {
         &()
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -441,7 +441,7 @@ impl Client {
     /// // Will time out in 1 second unless the nonexistent-pod actually exists
     ///  let wait_created_result: Result<(), Elapsed> = tokio::time::timeout(
     ///          Duration::from_secs(1),
-    ///          client.wait_created::<Pod>(Some(&client.default_namespace), lp.clone()),
+    ///          client.wait_created::<Pod>(&client.default_namespace, lp.clone()),
     ///      )
     ///      .await;
     /// }

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    client::Client,
+    client::{Client, GetApi},
     error::{Error, OperatorResult},
     k8s_openapi::{
         api::{
@@ -30,7 +30,7 @@ use tracing::{debug, info};
 /// implementations and removes the orphaned resources. Therefore if a new implementation is added,
 /// it must be added to [`ClusterResources::delete_orphaned_resources`] as well.
 pub trait ClusterResource:
-    Clone + Debug + DeserializeOwned + Resource<DynamicType = ()> + Serialize
+    Clone + Debug + DeserializeOwned + Resource<DynamicType = ()> + GetApi + Serialize
 {
 }
 
@@ -403,7 +403,7 @@ impl ClusterResources {
         };
 
         let resources = client
-            .list_with_label_selector::<T>(Some(&self.namespace), &label_selector)
+            .list_with_label_selector::<T>(T::namespace_from_str(&self.namespace), &label_selector)
             .await?;
 
         Ok(resources)

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -411,7 +411,7 @@ impl ClusterResources {
         };
 
         let resources = client
-            .list_with_label_selector::<T>(&*self.namespace, &label_selector)
+            .list_with_label_selector::<T>(&self.namespace, &label_selector)
             .await?;
 
         Ok(resources)

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -18,7 +18,10 @@ use crate::{
     kube::{Resource, ResourceExt},
     labels::{APP_INSTANCE_LABEL, APP_MANAGED_BY_LABEL, APP_NAME_LABEL},
 };
-use k8s_openapi::api::{core::v1::Secret, core::v1::ServiceAccount, rbac::v1::RoleBinding};
+use k8s_openapi::{
+    api::{core::v1::Secret, core::v1::ServiceAccount, rbac::v1::RoleBinding},
+    NamespaceResourceScope,
+};
 use kube::core::ErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, info};
@@ -30,7 +33,12 @@ use tracing::{debug, info};
 /// implementations and removes the orphaned resources. Therefore if a new implementation is added,
 /// it must be added to [`ClusterResources::delete_orphaned_resources`] as well.
 pub trait ClusterResource:
-    Clone + Debug + DeserializeOwned + Resource<DynamicType = ()> + GetApi + Serialize
+    Clone
+    + Debug
+    + DeserializeOwned
+    + Resource<DynamicType = (), Scope = NamespaceResourceScope>
+    + GetApi<Namespace = str>
+    + Serialize
 {
 }
 
@@ -403,7 +411,7 @@ impl ClusterResources {
         };
 
         let resources = client
-            .list_with_label_selector::<T>(T::namespace_from_str(&self.namespace), &label_selector)
+            .list_with_label_selector::<T>(&*self.namespace, &label_selector)
             .await?;
 
         Ok(resources)

--- a/src/commons/authentication.rs
+++ b/src/commons/authentication.rs
@@ -55,7 +55,7 @@ impl AuthenticationClass {
         authentication_class_name: &str,
     ) -> Result<AuthenticationClass, Error> {
         client
-            .get::<AuthenticationClass>(authentication_class_name, None) // AuthenticationClass has ClusterScope
+            .get::<AuthenticationClass>(authentication_class_name, &()) // AuthenticationClass has ClusterScope
             .await
     }
 }

--- a/src/commons/s3.rs
+++ b/src/commons/s3.rs
@@ -41,7 +41,7 @@ impl S3BucketSpec {
     pub async fn get(
         resource_name: &str,
         client: &Client,
-        namespace: Option<&str>,
+        namespace: &str,
     ) -> OperatorResult<S3BucketSpec> {
         client
             .get::<S3Bucket>(resource_name, namespace)
@@ -56,7 +56,7 @@ impl S3BucketSpec {
     pub async fn inlined(
         &self,
         client: &Client,
-        namespace: Option<&str>,
+        namespace: &str,
     ) -> OperatorResult<InlinedS3BucketSpec> {
         match self.connection.as_ref() {
             Some(connection_def) => Ok(InlinedS3BucketSpec {
@@ -99,7 +99,7 @@ impl S3BucketDef {
     pub async fn resolve(
         &self,
         client: &Client,
-        namespace: Option<&str>,
+        namespace: &str,
     ) -> OperatorResult<InlinedS3BucketSpec> {
         match self {
             S3BucketDef::Inline(s3_bucket) => s3_bucket.inlined(client, namespace).await,
@@ -126,7 +126,7 @@ impl S3ConnectionDef {
     pub async fn resolve(
         &self,
         client: &Client,
-        namespace: Option<&str>,
+        namespace: &str,
     ) -> OperatorResult<S3ConnectionSpec> {
         match self {
             S3ConnectionDef::Inline(s3_connection_spec) => Ok(s3_connection_spec.clone()),
@@ -181,7 +181,7 @@ impl S3ConnectionSpec {
     pub async fn get(
         resource_name: &str,
         client: &Client,
-        namespace: Option<&str>,
+        namespace: &str,
     ) -> OperatorResult<S3ConnectionSpec> {
         client
             .get::<S3Connection>(resource_name, namespace)

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,5 +1,6 @@
 //! This module provides helpers and constants to deal with namespaces
 use crate::client::Client;
+use k8s_openapi::NamespaceResourceScope;
 use kube::{Api, Resource};
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -23,11 +24,11 @@ impl WatchNamespace {
     /// depending on which variant we are.
     pub fn get_api<T>(&self, client: &Client) -> Api<T>
     where
-        T: Resource<DynamicType = ()>,
+        T: Resource<DynamicType = (), Scope = NamespaceResourceScope>,
     {
         match self {
             WatchNamespace::All => client.get_all_api(),
-            WatchNamespace::One(namespace) => client.get_namespaced_api(namespace),
+            WatchNamespace::One(namespace) => client.get_api::<T>(namespace),
         }
     }
 }


### PR DESCRIPTION
## Description

This is an alternate take on #481/#471 that does not introduce a new operator-framework-level `Api` type. Instead, it introduces a new `GetApi` trait that lets `Client::get_api` specialize as needed.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
