### PR TITLE
Add ListenerOperatorVolumeSourceBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Builder for `EphemeralVolumeSource`s added which are used by the listener-operator ([#496]).
+
+[#496]: https://github.com/stackabletech/operator-rs/pull/496
+
 ## [0.26.0] - 2022-10-20
 
 ### Added


### PR DESCRIPTION
## Description

Add ListenerOperatorVolumeSourceBuilder

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Closes stackabletech/listener-operator#5

The builder is already used in https://github.com/stackabletech/kafka-operator/commit/3a72373057e886bb337aeb5100204373d1ce53d4.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
