### PR TITLE
[Merged by Bors] - Structify arguments to `get_recommended_labels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: `get_recommended_labels` and `with_recommended_labels` now takes a struct of named arguments ([#501]).
+
+[#501]: https://github.com/stackabletech/operator-rs/pull/501
+
 ## [0.26.1] - 2022-11-08
 
 ### Added

--- a/src/builder/meta.rs
+++ b/src/builder/meta.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, OperatorResult};
-use crate::labels;
+use crate::labels::{self, ObjectLabels};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
 use kube::{Resource, ResourceExt};
 use std::collections::BTreeMap;
@@ -150,21 +150,9 @@ impl ObjectMetaBuilder {
     /// flexibility if needed.
     pub fn with_recommended_labels<T: Resource>(
         &mut self,
-        resource: &T,
-        app_name: &str,
-        app_version: &str,
-        app_managed_by: &str,
-        app_component: &str,
-        role_name: &str,
+        object_labels: ObjectLabels<T>,
     ) -> &mut Self {
-        let recommended_labels = labels::get_recommended_labels(
-            resource,
-            app_name,
-            app_version,
-            app_managed_by,
-            app_component,
-            role_name,
-        );
+        let recommended_labels = labels::get_recommended_labels(object_labels);
         self.labels
             .get_or_insert_with(BTreeMap::new)
             .extend(recommended_labels);
@@ -332,7 +320,14 @@ mod tests {
             .namespace("bar")
             .ownerreference_from_resource(&pod, Some(true), Some(false))
             .unwrap()
-            .with_recommended_labels(&pod, "test_app", "1.0", "app-operator", "component", "role")
+            .with_recommended_labels(ObjectLabels {
+                owner: &pod,
+                app_name: "test_app",
+                app_version: "1.0",
+                managed_by: "app-operator",
+                role: "role",
+                role_group: "rolegroup",
+            })
             .with_annotation("foo", "bar")
             .build();
 

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -32,8 +32,8 @@ pub struct ObjectLabels<'a, T> {
     pub app_name: &'a str,
     /// The version of the app being managed (not of the operator)
     ///
-    /// This version should include the Stackable version, such as `0.1.0-stackable0.1.0`. However, this is pure
-    /// documentation and should not be parsed.
+    /// This version should include the Stackable version, such as `0.1.0-stackable0.1.0`. In the case of custom product images,
+    /// the tag should be appended, such as `<productversion>-<tag>`. However, this is pure documentation and should not be parsed.
     pub app_version: &'a str,
     /// The name of the operator and controller managing the object
     pub managed_by: &'a str,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -2,6 +2,9 @@ use const_format::concatcp;
 use kube::api::{Resource, ResourceExt};
 use std::collections::BTreeMap;
 
+#[cfg(doc)]
+use crate::builder::ObjectMetaBuilder;
+
 const APP_KUBERNETES_LABEL_BASE: &str = "app.kubernetes.io/";
 
 /// The name of the application e.g. "mysql"

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -18,24 +18,45 @@ pub const APP_PART_OF_LABEL: &str = concatcp!(APP_KUBERNETES_LABEL_BASE, "part-o
 pub const APP_MANAGED_BY_LABEL: &str = concatcp!(APP_KUBERNETES_LABEL_BASE, "managed-by");
 pub const APP_ROLE_GROUP_LABEL: &str = concatcp!(APP_KUBERNETES_LABEL_BASE, "role-group");
 
+/// Recommended labels to set on objects created by Stackable operators
+///
+/// See [`get_recommended_labels`] and [`ObjectMetaBuilder::with_recommended_labels`].
+#[derive(Debug, Clone, Copy)]
+pub struct ObjectLabels<'a, T> {
+    /// The name of the object that this object is being created on behalf of, such as a `ZookeeperCluster`
+    pub owner: &'a T,
+    /// The name of the app being managed, such as `zookeeper`
+    pub app_name: &'a str,
+    /// The version of the app being managed (not of the operator)
+    pub app_version: &'a str,
+    /// The name of the operator and controller managing the object
+    pub managed_by: &'a str,
+    /// The role that this object belongs to
+    pub role: &'a str,
+    /// The role group that this object belongs to
+    pub role_group: &'a str,
+}
+
 /// Create kubernetes recommended labels
 pub fn get_recommended_labels<T>(
-    resource: &T,
-    app_name: &str,
-    app_version: &str,
-    app_managed_by: &str,
-    app_role: &str,
-    app_role_group: &str,
+    ObjectLabels {
+        owner,
+        app_name,
+        app_version,
+        managed_by,
+        role,
+        role_group,
+    }: ObjectLabels<T>,
 ) -> BTreeMap<String, String>
 where
     T: Resource,
 {
-    let mut labels = role_group_selector_labels(resource, app_name, app_role, app_role_group);
+    let mut labels = role_group_selector_labels(owner, app_name, role, role_group);
 
     // TODO: Add operator version label
     // TODO: part-of is empty for now, decide on how this can be used in a proper fashion
     labels.insert(APP_VERSION_LABEL.to_string(), app_version.to_string());
-    labels.insert(APP_MANAGED_BY_LABEL.to_string(), app_managed_by.to_string());
+    labels.insert(APP_MANAGED_BY_LABEL.to_string(), managed_by.to_string());
 
     labels
 }
@@ -43,36 +64,36 @@ where
 /// The labels required to match against objects of a certain role, assuming that those objects
 /// are defined using [`get_recommended_labels`]
 pub fn role_group_selector_labels<T: Resource>(
-    resource: &T,
+    owner: &T,
     app_name: &str,
-    app_role: &str,
-    app_role_group: &str,
+    role: &str,
+    role_group: &str,
 ) -> BTreeMap<String, String> {
-    let mut labels = role_selector_labels(resource, app_name, app_role);
-    labels.insert(APP_ROLE_GROUP_LABEL.to_string(), app_role_group.to_string());
+    let mut labels = role_selector_labels(owner, app_name, role);
+    labels.insert(APP_ROLE_GROUP_LABEL.to_string(), role_group.to_string());
     labels
 }
 
 /// The labels required to match against objects of a certain role group, assuming that those objects
 /// are defined using [`get_recommended_labels`]
 pub fn role_selector_labels<T: Resource>(
-    resource: &T,
+    owner: &T,
     app_name: &str,
-    app_role: &str,
+    role: &str,
 ) -> BTreeMap<String, String> {
-    let mut labels = build_common_labels_for_all_managed_resources(app_name, &resource.name_any());
-    labels.insert(APP_COMPONENT_LABEL.to_string(), app_role.to_string());
+    let mut labels = build_common_labels_for_all_managed_resources(app_name, &owner.name_any());
+    labels.insert(APP_COMPONENT_LABEL.to_string(), role.to_string());
     labels
 }
 
 /// The APP_NAME_LABEL (Spark, Kafka, ZooKeeper...) and APP_INSTANCES_LABEL (simple, test ...) are
-/// required to identify resources that belong to a certain Custom Resource.
+/// required to identify resources that belong to a certain owner object (such as a particular `ZookeeperCluster`).
 pub fn build_common_labels_for_all_managed_resources(
     app_name: &str,
-    app_instance: &str,
+    owner_name: &str,
 ) -> BTreeMap<String, String> {
     let mut labels = BTreeMap::new();
     labels.insert(APP_NAME_LABEL.to_string(), app_name.to_string());
-    labels.insert(APP_INSTANCE_LABEL.to_string(), app_instance.to_string());
+    labels.insert(APP_INSTANCE_LABEL.to_string(), owner_name.to_string());
     labels
 }

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -31,6 +31,9 @@ pub struct ObjectLabels<'a, T> {
     /// The name of the app being managed, such as `zookeeper`
     pub app_name: &'a str,
     /// The version of the app being managed (not of the operator)
+    ///
+    /// This version should include the Stackable version, such as `0.1.0-stackable0.1.0`. However, this is pure
+    /// documentation and should not be parsed.
     pub app_version: &'a str,
     /// The name of the operator and controller managing the object
     pub managed_by: &'a str,


### PR DESCRIPTION
## Description

Hopefully this should help clarify how the different names hold together, and help make it clearer how to adjust for later changes going forward.

This doesn't cover `role_group_selector_labels` or `role_selector_labels` since they have a more obvious inherent structure to them, and I don't see them changing as much (especially since they are effectively part of the public API).

This is kind of coupled to #492, do we want to merge that into this PR or do that one on top of this afterwards?

Fixes #491.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
