### PR TITLE
[Merged by Bors] - Separate operator and controller names with `_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the separator character between operator and controller names ([#507]).
+
+[#507]: https://github.com/stackabletech/operator-rs/pull/507
+
 ## [0.27.0] - 2022-11-14
 
 ### Added

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ pub fn print_startup_string(
 ///
 /// `operator` should be a FQDN-style operator name (for example: `zookeeper.stackable.tech`).
 /// `controller` should typically be the lower-case version of the primary resource that the
-/// controller manages (for example: `zookeeperclusters`).
+/// controller manages (for example: `zookeepercluster`).
 pub(crate) fn format_full_controller_name(operator: &str, controller: &str) -> String {
-    format!("{operator}/{controller}")
+    format!("{operator}_{controller}")
 }


### PR DESCRIPTION


## Description

`/` broke using the combined names in label values. Thanks to @maltesander for catching this.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
