### PR TITLE
[Merged by Bors] - Removed affinity property that was added by accitdent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there.
+- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there. ([#522])
 
 [#552]: https://github.com/stackabletech/operator-rs/pull/522
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there. ([#522])
+- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there. ([#552])
 
 [#552]: https://github.com/stackabletech/operator-rs/pull/522
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
-- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there. ([#552])
+- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there ([#552]).
 
 [#552]: https://github.com/stackabletech/operator-rs/pull/522
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `affinity` property from the RoleGroup that was added in [#520] but not intended to be there.
+
+[#552]: https://github.com/stackabletech/operator-rs/pull/522
+
 ## [0.30.0] - 2022-12-19
 
 ### Added

--- a/src/product_config_utils.rs
+++ b/src/product_config_utils.rs
@@ -625,7 +625,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (true, true, true, false) => Role {
@@ -640,7 +639,6 @@ mod tests {
                     config: build_common_config(
                         build_test_config(GROUP_CONFIG, GROUP_ENV, GROUP_CLI), None, None, None),
                     selector: None,
-                    affinity: None,
                 }},
             },
             (true, true, false, true) => Role {
@@ -658,7 +656,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (true, true, false, false) => Role {
@@ -676,7 +673,6 @@ mod tests {
                         None,
                         None),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (true, false, true, true) => Role {
@@ -694,7 +690,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (true, false, true, false) => Role {
@@ -708,7 +703,6 @@ mod tests {
                     replicas: Some(1),
                     config: CommonConfiguration::default(),
                     selector: None,
-                    affinity: None,
                 }},
             },
             (true, false, false, true) => Role {
@@ -727,7 +721,6 @@ mod tests {
                         build_cli_override(GROUP_CLI_OVERRIDE)
                     ),
                     selector: None,
-                    affinity: None,
                 }},
             },
             (true, false, false, false) => Role {
@@ -741,7 +734,6 @@ mod tests {
                     replicas: Some(1),
                     config: CommonConfiguration::default(),
                     selector: None,
-                    affinity: None,
                 }},
             },
             (false, true, true, true) => Role {
@@ -759,7 +751,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, true, true, false) => Role {
@@ -777,7 +768,6 @@ mod tests {
                         None,
                         None),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, true, false, true) => Role {
@@ -790,7 +780,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, true, false, false) => Role {
@@ -803,7 +792,6 @@ mod tests {
                         None,
                         None),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, false, true, true) => Role {
@@ -821,7 +809,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, false, true, false) => Role {
@@ -835,7 +822,6 @@ mod tests {
                     replicas: Some(1),
                     config: CommonConfiguration::default(),
                     selector: None,
-                    affinity: None,
                 }},
             },
             (false, false, false, true) => Role {
@@ -848,7 +834,6 @@ mod tests {
                         build_env_override(GROUP_ENV_OVERRIDE),
                         build_cli_override(GROUP_CLI_OVERRIDE)),
                         selector: None,
-                        affinity: None,
                 }},
             },
             (false, false, false, false) => Role {
@@ -857,7 +842,6 @@ mod tests {
                     replicas: Some(1),
                     config: CommonConfiguration::default(),
                     selector: None,
-                    affinity: None,
                 }},
             },
         }
@@ -1062,7 +1046,6 @@ mod tests {
                     build_env_override(GROUP_ENV_OVERRIDE),
                     None),
                 selector: None,
-                affinity: None,
             }},
         };
 
@@ -1122,7 +1105,6 @@ mod tests {
                     None
                 ),
                 selector: None,
-                affinity: None,
             },
             role_group_2.to_string() => RoleGroup {
                 replicas: Some(1),
@@ -1133,7 +1115,6 @@ mod tests {
                     None
                 ),
                 selector: None,
-                affinity: None,
             }}
         }),
             role_2.to_string() => (vec![PropertyNameKind::Cli], Role {
@@ -1152,7 +1133,6 @@ mod tests {
                     None
                 ),
                 selector: None,
-                affinity: None,
             }},
         })
         };
@@ -1215,7 +1195,6 @@ mod tests {
                             None
                         ),
                         selector: None,
-                        affinity: None,
                     }}
             }
             ),
@@ -1231,7 +1210,6 @@ mod tests {
                             None
                         ),
                         selector: None,
-                        affinity: None,
                     }}
             }
             ),

--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -93,7 +93,6 @@ use crate::{
     product_config_utils::Configuration,
 };
 use derivative::Derivative;
-use k8s_openapi::api::core::v1::Affinity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use kube::{runtime::reflector::ObjectRef, Resource};
 use schemars::JsonSchema;
@@ -166,7 +165,6 @@ impl<T: Configuration + 'static> Role<T> {
                             },
                             replicas: group.replicas,
                             selector: group.selector,
-                            affinity: group.affinity,
                         },
                     )
                 })
@@ -185,7 +183,6 @@ pub struct RoleGroup<T> {
     pub config: CommonConfiguration<T>,
     pub replicas: Option<u16>,
     pub selector: Option<LabelSelector>,
-    pub affinity: Option<Affinity>,
 }
 
 impl<T> RoleGroup<T> {


### PR DESCRIPTION
## Description

I wanted to add the affinity functions to the PodBuilder, not the RoleGroup. Oops.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
