### PR TITLE
[Merged by Bors] - Bump kube to 0.78.0 and k8s-openapi to 0.17.0. Bump k8s version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Disable Vector agent by default ([#526]).
-- Bump kube to 0.78.0 and k8s-openapi to 0.17.0. Bump k8s version from 1.24 to 1.26 ([#532]).
+- Bump kube to 0.78.0 and k8s-openapi to 0.17.0. Bump k8s version from 1.24 to 1.26 ([#533]).
 
 [#526]: https://github.com/stackabletech/operator-rs/pull/526
-[#532]: https://github.com/stackabletech/operator-rs/pull/532
+[#533]: https://github.com/stackabletech/operator-rs/pull/533
 
 ## [0.30.1] - 2022-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Disable Vector agent by default ([#526]).
+- Bump kube to 0.78.0 and k8s-openapi to 0.17.0. Bump k8s version from 1.24 to 1.26 ([#532]).
 
 [#526]: https://github.com/stackabletech/operator-rs/pull/526
+[#532]: https://github.com/stackabletech/operator-rs/pull/532
 
 ## [0.30.1] - 2022-12-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ clap = { version = "4.0.29", features = ["derive", "cargo", "env"] }
 const_format = "0.2.30"
 either = "1.8.0"
 futures = "0.3.25"
-json-patch = "0.2.6"
-k8s-openapi = { version = "0.16.0", default-features = false, features = ["schemars", "v1_24"] }
-kube = { version = "0.76.0", features = ["jsonpatch", "runtime", "derive"] }
+json-patch = "0.3.0"
+k8s-openapi = { version = "0.17.0", default-features = false, features = ["schemars", "v1_26"] }
+kube = { version = "0.78.0", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -359,6 +359,7 @@ mod tests {
                 ]
                 .into(),
             ),
+            claims: None,
         };
 
         let container = ContainerBuilder::new("testcontainer")

--- a/src/builder/pod/container.rs
+++ b/src/builder/pod/container.rs
@@ -359,7 +359,7 @@ mod tests {
                 ]
                 .into(),
             ),
-            claims: None,
+            ..ResourceRequirements::default()
         };
 
         let container = ContainerBuilder::new("testcontainer")

--- a/src/commons/resources.rs
+++ b/src/commons/resources.rs
@@ -310,6 +310,10 @@ impl<T, K> Into<ResourceRequirements> for Resources<T, K> {
             } else {
                 Some(requests)
             },
+            // Dynamic resource allocation by using resourceClaims was added as *alpha* feature in Kubernetes 1.26.
+            // We might want to support it after a while, but currently all the customers would need to active
+            // the `DynamicResourceAllocation` feature gate.
+            claims: None,
         }
     }
 }


### PR DESCRIPTION
<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
