### PR TITLE
feat: add restart-policy helper for PodBuilder

### DIFF
--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -37,6 +37,7 @@ pub struct PodBuilder {
     volumes: Option<Vec<Volume>>,
     service_account_name: Option<String>,
     image_pull_secrets: Option<Vec<LocalObjectReference>>,
+    restart_policy: Option<String>,
 }
 
 impl PodBuilder {
@@ -361,6 +362,11 @@ impl PodBuilder {
         self
     }
 
+    pub fn restart_policy(&mut self, restart_policy: &str) -> &mut Self {
+        self.restart_policy = Some(String::from(restart_policy));
+        self
+    }
+
     fn build_spec(&self) -> PodSpec {
         PodSpec {
             containers: self.containers.clone(),
@@ -382,6 +388,7 @@ impl PodBuilder {
             enable_service_links: Some(false),
             service_account_name: self.service_account_name.clone(),
             image_pull_secrets: self.image_pull_secrets.clone(),
+            restart_policy: self.restart_policy.clone(),
             ..PodSpec::default()
         }
     }
@@ -541,5 +548,14 @@ mod tests {
                 name: Some("company-registry-secret".to_string())
             }]
         );
+    }
+
+    #[rstest]
+    fn test_pod_builder_restart_policy(mut pod_builder_with_name_and_container: PodBuilder) {
+        let pod = pod_builder_with_name_and_container
+            .restart_policy("Always")
+            .build()
+            .unwrap();
+        assert_eq!(pod.spec.unwrap().restart_policy.unwrap(), "Always");
     }
 }


### PR DESCRIPTION
## Description
Adds a helper Method to add a restart policy to PodBuilder. Fixes #538
Regarding comments and Documentation I copied the prevailing style. Tell me if I need to add something.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments : Pretty much self explanatory. Copied the style
- [x] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
