### PR TITLE
Extend cluster resources for status and cluster operation (paused, stopped)

### DIFF
--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     client::{Client, GetApi},
-    commons::cluster_operation::ClusterSpecCommons,
+    commons::cluster_operation::ClusterOperation,
     error::{Error, OperatorResult},
     k8s_openapi::{
         api::{
@@ -67,8 +67,8 @@ pub enum ClusterResourceApplyStrategy {
     ClusterStopped,
 }
 
-impl From<&ClusterSpecCommons> for ClusterResourceApplyStrategy {
-    fn from(commons_spec: &ClusterSpecCommons) -> Self {
+impl From<&ClusterOperation> for ClusterResourceApplyStrategy {
+    fn from(commons_spec: &ClusterOperation) -> Self {
         if commons_spec.reconciliation_paused == Some(true) {
             ClusterResourceApplyStrategy::ReconciliationPaused
         } else if commons_spec.stopped == Some(true) {

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -91,7 +91,10 @@ impl ClusterResourceApplyStrategy {
                 client
                     .get(
                         &resource.name_any(),
-                        resource.namespace().as_deref().unwrap(),
+                        resource
+                            .namespace()
+                            .as_deref()
+                            .ok_or(Error::MissingObjectKey { key: "namespace" })?,
                     )
                     .await
             }

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -69,9 +69,9 @@ pub enum ClusterResourceApplyStrategy {
 
 impl From<&ClusterOperation> for ClusterResourceApplyStrategy {
     fn from(commons_spec: &ClusterOperation) -> Self {
-        if commons_spec.reconciliation_paused == Some(true) {
+        if commons_spec.reconciliation_paused {
             ClusterResourceApplyStrategy::ReconciliationPaused
-        } else if commons_spec.stopped == Some(true) {
+        } else if commons_spec.stopped {
             ClusterResourceApplyStrategy::ClusterStopped
         } else {
             ClusterResourceApplyStrategy::Default

--- a/src/commons/cluster_operation.rs
+++ b/src/commons/cluster_operation.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterOperation {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stopped: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reconciliation_paused: Option<bool>,
+    #[serde(default)]
+    pub stopped: bool,
+    #[serde(default)]
+    pub reconciliation_paused: bool,
 }

--- a/src/commons/cluster_operation.rs
+++ b/src/commons/cluster_operation.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ClusterSpecCommons {
+pub struct ClusterOperation {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stopped: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/commons/cluster_operation.rs
+++ b/src/commons/cluster_operation.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClusterSpecCommons {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopped: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reconciliation_paused: Option<bool>,
+}

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod affinity;
 pub mod authentication;
+pub mod cluster_operation;
 pub mod ldap;
 pub mod listener;
 pub mod opa;


### PR DESCRIPTION
## Description

- Extended `ClusterResource` with a strategy to influence how resources are applied and to mutate certain resources like StatefulSets
- Added `ClusterOperation` struct with `reconciliation_paused` and `stopped` flags

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
