### PR TITLE
[Merged by Bors] - Fix processing of log4j events in Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the parsing of log4j and logback files in the Vector configuration, avoid
+  rounding errors in the timestamps, and improve the handling of unparseable
+  log events ([#577]).
+
+[#577]: https://github.com/stackabletech/operator-rs/pull/577
+
 ## [0.39.0] - 2023-03-31
 
 ### Added


### PR DESCRIPTION
## Description

Fix the parsing of log4j and logback files in the Vector configuration, avoid rounding errors in the timestamps, and improve the handling of unparseable log events.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Fixes #576 

## Affected operators

- hbase-operator (stackabletech/hbase-operator#339)
- hdfs-operator (stackabletech/hdfs-operator#341)
- kafka-operator (stackabletech/kafka-operator#577)
- nifi-operator (stackabletech/nifi-operator#452)
- zookeeper-operator (stackabletech/zookeeper-operator#663)

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
