### PR TITLE
[Merged by Bors] - RBAC naming helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `ClusterResources` implementation for `Job` ([#581]).
+- Helper methods to generate RBAC `ServiceAccount` and `ClusterRole` names ([#581]).
+
+[#581]: https://github.com/stackabletech/operator-rs/pull/581
+
 ## [0.40.0] - 2023-04-11
 
 ### Added

--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -7,6 +7,7 @@ use crate::{
     k8s_openapi::{
         api::{
             apps::v1::{DaemonSet, DaemonSetSpec, StatefulSet, StatefulSetSpec},
+            batch::v1::Job,
             core::v1::{
                 ConfigMap, ObjectReference, PodSpec, PodTemplateSpec, Secret, Service,
                 ServiceAccount,
@@ -154,6 +155,7 @@ impl ClusterResource for Service {}
 impl ClusterResource for ServiceAccount {}
 impl ClusterResource for RoleBinding {}
 impl ClusterResource for Secret {}
+impl ClusterResource for Job {}
 impl ClusterResource for StatefulSet {
     fn maybe_mutate(self, strategy: &ClusterResourceApplyStrategy) -> Self {
         match strategy {

--- a/src/commons/rbac.rs
+++ b/src/commons/rbac.rs
@@ -13,7 +13,7 @@ pub fn build_rbac_resources<T: Clone + Resource<DynamicType = ()>>(
     rbac_prefix: &str,
     labels: BTreeMap<String, String>,
 ) -> OperatorResult<(ServiceAccount, RoleBinding)> {
-    let sa_name = format!("{rbac_prefix}-sa");
+    let sa_name = service_account_name(rbac_prefix);
     let service_account = ServiceAccount {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(resource)
@@ -27,7 +27,7 @@ pub fn build_rbac_resources<T: Clone + Resource<DynamicType = ()>>(
     let role_binding = RoleBinding {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(resource)
-            .name(format!("{rbac_prefix}-rolebinding"))
+            .name(role_binding_name(rbac_prefix))
             .ownerreference_from_resource(resource, None, Some(true))?
             .with_labels(labels)
             .build(),
@@ -45,6 +45,18 @@ pub fn build_rbac_resources<T: Clone + Resource<DynamicType = ()>>(
     };
 
     Ok((service_account, role_binding))
+}
+
+/// Generate the service account name.
+/// The `rbac_prefix` is meant to be the product name, for example: zookeeper, airflow, etc.
+pub fn service_account_name(rbac_prefix: &str) -> String {
+    format!("{rbac_prefix}-serviceaccount")
+}
+
+/// Generate the role binding name.
+/// The `rbac_prefix` is meant to be the product name, for example: zookeeper, airflow, etc.
+pub fn role_binding_name(rbac_prefix: &str) -> String {
+    format!("{rbac_prefix}-rolebinding")
 }
 
 #[cfg(test)]

--- a/src/commons/rbac.rs
+++ b/src/commons/rbac.rs
@@ -61,7 +61,7 @@ pub fn role_binding_name(rbac_prefix: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::commons::rbac::build_rbac_resources;
+    use crate::commons::rbac::{build_rbac_resources, role_binding_name, service_account_name};
     use kube::CustomResource;
     use schemars::{self, JsonSchema};
     use serde::{Deserialize, Serialize};
@@ -99,7 +99,7 @@ mod tests {
             build_rbac_resources(&cluster, RESOURCE_NAME, BTreeMap::new()).unwrap();
 
         assert_eq!(
-            Some(format!("{RESOURCE_NAME}-sa")),
+            Some(service_account_name(RESOURCE_NAME)),
             rbac_sa.metadata.name,
             "service account does not match"
         );
@@ -110,7 +110,7 @@ mod tests {
         );
 
         assert_eq!(
-            Some(format!("{RESOURCE_NAME}-rolebinding")),
+            Some(role_binding_name(RESOURCE_NAME)),
             rbac_rolebinding.metadata.name,
             "rolebinding does not match"
         );


### PR DESCRIPTION
## Description

- added cluster resource job impl (airflow, superset)
- added RBAC naming helper methods

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
