### PR TITLE
[Merged by Bors] - Update to kube-rs 0.82.2 and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- kube: 0.78.0 -> 0.82.2 ([#589]).
+- k8s-openapi: 0.17.0 -> 0.18.0 ([#589]).
+
+[#589]: https://github.com/stackabletech/operator-rs/pull/589
+
 ## [0.40.2] - 2023-04-12
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ clap = { version = "4.1.4", features = ["derive", "cargo", "env"] }
 const_format = "0.2.30"
 either = "1.8.1"
 futures = "0.3.26"
-json-patch = "0.3.0"
-k8s-openapi = { version = "0.17.0", default-features = false, features = ["schemars", "v1_26"] }
-kube = { version = "0.78.0", features = ["jsonpatch", "runtime", "derive"] }
+json-patch = "1.0.0"
+k8s-openapi = { version = "0.18.0", default-features = false, features = ["schemars", "v1_26"] }
+kube = { version = "0.82.2", features = ["jsonpatch", "runtime", "derive"] }
 lazy_static = "1.4.0"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.4.0" }
 rand = "0.8.5"
@@ -37,7 +37,7 @@ stackable-operator-derive = { path = "stackable-operator-derive" }
 snafu = "0.7.4"
 
 [dev-dependencies]
-rstest = "0.16.0"
+rstest = "0.17.0"
 tempfile = "3.3.0"
 
 [workspace]

--- a/src/commons/product_image_selection.rs
+++ b/src/commons/product_image_selection.rs
@@ -67,19 +67,14 @@ pub struct ResolvedProductImage {
     pub pull_secrets: Option<Vec<LocalObjectReference>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename = "PascalCase")]
 #[derive(AsRefStr)]
 pub enum PullPolicy {
+    #[default]
     IfNotPresent,
     Always,
     Never,
-}
-
-impl Default for PullPolicy {
-    fn default() -> PullPolicy {
-        PullPolicy::IfNotPresent
-    }
 }
 
 impl ProductImage {

--- a/src/commons/s3.rs
+++ b/src/commons/s3.rs
@@ -205,19 +205,16 @@ impl S3ConnectionSpec {
     }
 }
 
-#[derive(strum::Display, Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    strum::Display, Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum S3AccessStyle {
     /// Use path-style access as described in <https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access>
     Path,
     /// Use as virtual hosted-style access as described in <https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access>
+    #[default]
     VirtualHosted,
-}
-
-impl Default for S3AccessStyle {
-    fn default() -> Self {
-        S3AccessStyle::VirtualHosted
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

fixes https://github.com/stackabletech/operator-rs/issues/588

updated dependencies:
- kube-rs 0.82.2
- k8s-openapi 0.18.0
- json_patch 1.0.0
- rstest 0.17.0

other:
- derive defaults for some enums instead of impl (clippy)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
