### PR TITLE
[Merged by Bors] - feat: add Display for ClusterCondition

### DIFF
--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -591,4 +591,82 @@ mod test {
         assert_eq!(got.status, expected.status);
         assert_eq!(got.message, expected.message);
     }
+
+    #[test]
+    fn test_display_short() {
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::False,
+            message: Some("This should not be displayed".into()),
+            ..Default::default()
+        };
+
+        assert!(!condition.is_good());
+        assert_eq!(condition.display_short(), "Unavailable".to_string());
+
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::True,
+            message: Some("This should not be displayed".into()),
+            ..Default::default()
+        };
+
+        assert!(condition.is_good());
+        assert_eq!(condition.display_short(), "Available".to_string());
+    }
+
+    #[test]
+    fn test_display_long() {
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::False,
+            message: Some("This should be displayed".into()),
+            ..Default::default()
+        };
+
+        assert!(!condition.is_good());
+        assert_eq!(
+            condition.display_long(),
+            "Unavailable: This should be displayed".to_string()
+        );
+
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::True,
+            message: Some("This should be displayed".into()),
+            ..Default::default()
+        };
+
+        assert!(condition.is_good());
+        assert_eq!(
+            condition.display_long(),
+            "Available: This should be displayed".to_string()
+        );
+    }
+
+    #[test]
+    fn test_display_short_or_long() {
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::False,
+            message: Some("This should be displayed if unhealthy".into()),
+            ..Default::default()
+        };
+
+        assert!(!condition.is_good());
+        assert_eq!(
+            condition.display_short_or_long(),
+            "Unavailable: This should be displayed if unhealthy".to_string()
+        );
+
+        let condition = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::True,
+            message: Some("This should not be displayed".into()),
+            ..Default::default()
+        };
+
+        assert!(condition.is_good());
+        assert_eq!(condition.display_short_or_long(), "Available".to_string());
+    }
 }

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -142,6 +142,24 @@ impl std::fmt::Display for ClusterCondition {
     }
 }
 
+impl ClusterCondition {
+    /// Returns a short display string. This method wraps the
+    /// [`std::fmt::Display`] implementation of the [`ClusterCondition`].
+    pub fn display_short(&self) -> String {
+        self.to_string()
+    }
+
+    /// Returns a long display string. This method uses the
+    /// [`std::fmt::Display`] implementation of the [`ClusterCondition`] and
+    /// combines it with the optional message to provide more context.
+    pub fn display_long(&self) -> String {
+        match &self.message {
+            Some(message) => format!("{}: {}", self.to_string(), message),
+            None => self.to_string(),
+        }
+    }
+}
+
 #[derive(
     Clone,
     Copy,

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -158,6 +158,20 @@ impl ClusterCondition {
             None => self.to_string(),
         }
     }
+
+    /// Returns either a short ot long display string, This method additionally
+    /// checks if the status is either [`ClusterConditionStatus::False`] or
+    /// [`ClusterConditionStatus::Unknown`] and then returns the long display
+    /// string which contains the optional message to provide more context. In
+    /// case the status is [`ClusterConditionStatus::True`], it only returns
+    /// the short display string. Internally this method uses the
+    /// `display_short` and `display_long` methods.
+    pub fn display_short_or_long(&self) -> String {
+        match self.status {
+            ClusterConditionStatus::False | ClusterConditionStatus::Unknown => self.display_long(),
+            ClusterConditionStatus::True => self.display_short(),
+        }
+    }
 }
 
 #[derive(

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -154,7 +154,7 @@ impl ClusterCondition {
     /// combines it with the optional message to provide more context.
     pub fn display_long(&self) -> String {
         match &self.message {
-            Some(message) => format!("{}: {}", self.to_string(), message),
+            Some(message) => format!("{}: {}", self, message),
             None => self.to_string(),
         }
     }

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -143,6 +143,32 @@ impl std::fmt::Display for ClusterCondition {
 }
 
 impl ClusterCondition {
+    /// Returns if the [`ClusterCondition`] is considered to be an error.
+    pub fn is_error(&self) -> bool {
+        match self.type_ {
+            ClusterConditionType::Available => match self.status {
+                ClusterConditionStatus::False | ClusterConditionStatus::Unknown => true,
+                ClusterConditionStatus::True => false,
+            },
+            ClusterConditionType::Degraded => match self.status {
+                ClusterConditionStatus::False | ClusterConditionStatus::Unknown => false,
+                ClusterConditionStatus::True => true,
+            },
+            ClusterConditionType::Progressing => match self.status {
+                ClusterConditionStatus::False | ClusterConditionStatus::Unknown => true,
+                ClusterConditionStatus::True => false,
+            },
+            ClusterConditionType::ReconciliationPaused => match self.status {
+                ClusterConditionStatus::False | ClusterConditionStatus::True => false,
+                ClusterConditionStatus::Unknown => true,
+            },
+            ClusterConditionType::Stopped => match self.status {
+                ClusterConditionStatus::True | ClusterConditionStatus::Unknown => true,
+                ClusterConditionStatus::False => false,
+            },
+        }
+    }
+
     /// Returns a short display string. This method wraps the
     /// [`std::fmt::Display`] implementation of the [`ClusterCondition`].
     pub fn display_short(&self) -> String {
@@ -167,9 +193,9 @@ impl ClusterCondition {
     /// the short display string. Internally this method uses the
     /// `display_short` and `display_long` methods.
     pub fn display_short_or_long(&self) -> String {
-        match self.status {
-            ClusterConditionStatus::False | ClusterConditionStatus::Unknown => self.display_long(),
-            ClusterConditionStatus::True => self.display_short(),
+        match self.is_error() {
+            true => self.display_long(),
+            false => self.display_short(),
         }
     }
 }

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -143,28 +143,29 @@ impl std::fmt::Display for ClusterCondition {
 }
 
 impl ClusterCondition {
-    /// Returns if the [`ClusterCondition`] is considered to be an error.
-    pub fn is_error(&self) -> bool {
+    /// Returns if the [`ClusterCondition`] is considered to be in a good /
+    /// healthy state.
+    pub fn is_good(&self) -> bool {
         match self.type_ {
             ClusterConditionType::Available => match self.status {
-                ClusterConditionStatus::False | ClusterConditionStatus::Unknown => true,
-                ClusterConditionStatus::True => false,
-            },
-            ClusterConditionType::Degraded => match self.status {
                 ClusterConditionStatus::False | ClusterConditionStatus::Unknown => false,
                 ClusterConditionStatus::True => true,
             },
-            ClusterConditionType::Progressing => match self.status {
+            ClusterConditionType::Degraded => match self.status {
                 ClusterConditionStatus::False | ClusterConditionStatus::Unknown => true,
                 ClusterConditionStatus::True => false,
             },
+            ClusterConditionType::Progressing => match self.status {
+                ClusterConditionStatus::False | ClusterConditionStatus::Unknown => false,
+                ClusterConditionStatus::True => true,
+            },
             ClusterConditionType::ReconciliationPaused => match self.status {
-                ClusterConditionStatus::False | ClusterConditionStatus::True => false,
-                ClusterConditionStatus::Unknown => true,
+                ClusterConditionStatus::False | ClusterConditionStatus::True => true,
+                ClusterConditionStatus::Unknown => false,
             },
             ClusterConditionType::Stopped => match self.status {
-                ClusterConditionStatus::True | ClusterConditionStatus::Unknown => true,
-                ClusterConditionStatus::False => false,
+                ClusterConditionStatus::True | ClusterConditionStatus::Unknown => false,
+                ClusterConditionStatus::False => true,
             },
         }
     }
@@ -185,17 +186,16 @@ impl ClusterCondition {
         }
     }
 
-    /// Returns either a short ot long display string, This method additionally
-    /// checks if the status is either [`ClusterConditionStatus::False`] or
-    /// [`ClusterConditionStatus::Unknown`] and then returns the long display
-    /// string which contains the optional message to provide more context. In
-    /// case the status is [`ClusterConditionStatus::True`], it only returns
-    /// the short display string. Internally this method uses the
-    /// `display_short` and `display_long` methods.
+    /// Returns either a short or long display string, This method additionally
+    /// checks if the condition is considered to be in a good state and then
+    /// returns the short display string. In case the condition is considered
+    /// to be in an unhealthy state, the method returns a long display string
+    /// which contains the optional message to provide more context. Internally
+    /// this method uses the `display_short` and `display_long` methods.
     pub fn display_short_or_long(&self) -> String {
-        match self.is_error() {
-            true => self.display_long(),
-            false => self.display_short(),
+        match self.is_good() {
+            true => self.display_short(),
+            false => self.display_long(),
         }
     }
 }

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -108,6 +108,40 @@ pub struct ClusterCondition {
     pub type_: ClusterConditionType,
 }
 
+impl std::fmt::Display for ClusterCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let out = match self.type_ {
+            ClusterConditionType::Available => match self.status {
+                ClusterConditionStatus::True => "Available",
+                ClusterConditionStatus::False => "Unavailable",
+                ClusterConditionStatus::Unknown => "Availability unknown",
+            },
+            ClusterConditionType::Degraded => match self.status {
+                ClusterConditionStatus::True => "Degraded",
+                ClusterConditionStatus::False => "Not degraded",
+                ClusterConditionStatus::Unknown => "Degradation unknown",
+            },
+            ClusterConditionType::Progressing => match self.status {
+                ClusterConditionStatus::True => "Progressing",
+                ClusterConditionStatus::False => "Not progressing",
+                ClusterConditionStatus::Unknown => "Progression unknown",
+            },
+            ClusterConditionType::ReconciliationPaused => match self.status {
+                ClusterConditionStatus::True => "Reconciling",
+                ClusterConditionStatus::False => "Not reconciling",
+                ClusterConditionStatus::Unknown => "Reconciliation unknown",
+            },
+            ClusterConditionType::Stopped => match self.status {
+                ClusterConditionStatus::True => "Stopped",
+                ClusterConditionStatus::False => "Running",
+                ClusterConditionStatus::Unknown => "Stopped status unknown",
+            },
+        };
+
+        out.fmt(f)
+    }
+}
+
 #[derive(
     Clone,
     Copy,


### PR DESCRIPTION
This PR adds a `Display` impl for `ClusterCondition`. It might be worth a thought that we want to provide different `display_*` methods for various levels of verbosity.