### PR TITLE
[Merged by Bors] - fix: Display for ReconciliationPaused

### DIFF
--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -127,8 +127,8 @@ impl std::fmt::Display for ClusterCondition {
                 ClusterConditionStatus::Unknown => "Progression unknown",
             },
             ClusterConditionType::ReconciliationPaused => match self.status {
-                ClusterConditionStatus::True => "Reconciling",
-                ClusterConditionStatus::False => "Not reconciling",
+                ClusterConditionStatus::True => "Not reconciling",
+                ClusterConditionStatus::False => "Reconciling",
                 ClusterConditionStatus::Unknown => "Reconciliation unknown",
             },
             ClusterConditionType::Stopped => match self.status {


### PR DESCRIPTION
The display string for the `ReconciliationPaused` was swapped. This fixes the display impl introduced in #608.