### PR TITLE
[Merged by Bors] - Strip out documentation from pod override templates

### DIFF
--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -81,7 +81,7 @@
 //! Each resource can have more operator specific labels.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap},
     fmt::{Debug, Display},
 };
 

--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -130,6 +130,10 @@ pub struct CommonConfiguration<T> {
 /// Often times the user want's to overwrite/add stuff not related to a container
 /// (e.g. tolerations or a ServiceAccount), so it's annoying that he always needs to
 /// specify an empty array for `containers`.
+///
+/// Additionally all docs are removed, as the resulting Stackable CRD objects where to big for Kubernetes.
+/// E.g. the HdfsCluster CRD increased to ~3.2 MB (which is over the limit of 3MB), after stripping
+/// the docs it went down to ~1.3 MiB.
 fn pod_overrides_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
     let mut schema = PodTemplateSpec::json_schema(gen);
     SimplifyOverrideSchema.visit_schema(&mut schema);


### PR DESCRIPTION
## Description

We were running into object size limitations before. In my (quite unscientific) measurements this should take the CRD overhead from ~900kiB per role to ~300kiB.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
