### PR TITLE
[Merged by Bors] - Make pod overrides usable without roles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Make pod overrides usable independently of roles (like in the case of the Spark operator) ([#xxx])
+- Make pod overrides usable independently of roles (like in the case of the Spark operator) ([#616])
 
 [#610]: https://github.com/stackabletech/operator-rs/pull/610
+[#616]: https://github.com/stackabletech/operator-rs/pull/616
 
 ## [0.42.2] - 2023-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Secrets can now be requested in a custom format ([#610]).
 
+### Changed
+
+- Make pod overrides usable independently of roles (like in the case of the Spark operator) ([#xxx])
+
 [#610]: https://github.com/stackabletech/operator-rs/pull/610
 
 ## [0.42.2] - 2023-06-27

--- a/src/config/fragment.rs
+++ b/src/config/fragment.rs
@@ -15,6 +15,7 @@ use super::merge::Merge;
 #[cfg(doc)]
 use crate::role_utils::{Role, RoleGroup};
 
+use k8s_openapi::api::core::v1::PodTemplateSpec;
 use snafu::Snafu;
 
 pub use stackable_operator_derive::Fragment;
@@ -190,6 +191,17 @@ impl<T: FromFragment> FromFragment for Option<T> {
         } else {
             Ok(None)
         }
+    }
+}
+impl FromFragment for PodTemplateSpec {
+    type Fragment = PodTemplateSpec;
+    type RequiredFragment = PodTemplateSpec;
+
+    fn from_fragment(
+        fragment: Self::Fragment,
+        _validator: Validator,
+    ) -> Result<Self, ValidationError> {
+        Ok(fragment)
     }
 }
 

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,6 +1,7 @@
 use k8s_openapi::{
     api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity, PodTemplateSpec},
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
+    DeepMerge,
 };
 use std::{
     collections::{btree_map, hash_map, BTreeMap, HashMap},
@@ -83,6 +84,11 @@ impl<K: Hash + Eq + Clone, V: Merge + Clone> Merge for HashMap<K, V> {
         }
     }
 }
+impl Merge for PodTemplateSpec {
+    fn merge(&mut self, defaults: &Self) {
+        self.merge_from(defaults.clone())
+    }
+}
 
 /// Moving version of [`Merge::merge`], to produce slightly nicer test output
 pub fn merge<T: Merge>(mut overrides: T, defaults: &T) -> T {
@@ -140,8 +146,6 @@ impl Atomic for LabelSelector {}
 impl Atomic for PodAffinity {}
 impl Atomic for PodAntiAffinity {}
 impl Atomic for NodeAffinity {}
-/// Needed for the Spark operator where pod_overrides are used directly and not via the roles.
-impl Atomic for PodTemplateSpec {}
 
 impl<T: Atomic> Merge for Option<T> {
     fn merge(&mut self, defaults: &Self) {

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,5 +1,5 @@
 use k8s_openapi::{
-    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity},
+    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity, PodTemplateSpec},
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
 };
 use std::{
@@ -140,6 +140,8 @@ impl Atomic for LabelSelector {}
 impl Atomic for PodAffinity {}
 impl Atomic for PodAntiAffinity {}
 impl Atomic for NodeAffinity {}
+/// Needed for the Spark operator where pod_overrides are used directly and not via the roles.
+impl Atomic for PodTemplateSpec {}
 
 impl<T: Atomic> Merge for Option<T> {
     fn merge(&mut self, defaults: &Self) {

--- a/src/role_utils.rs
+++ b/src/role_utils.rs
@@ -134,7 +134,7 @@ pub struct CommonConfiguration<T> {
 /// Additionally all docs are removed, as the resulting Stackable CRD objects where to big for Kubernetes.
 /// E.g. the HdfsCluster CRD increased to ~3.2 MB (which is over the limit of 3MB), after stripping
 /// the docs it went down to ~1.3 MiB.
-fn pod_overrides_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
+pub fn pod_overrides_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
     let mut schema = PodTemplateSpec::json_schema(gen);
     SimplifyOverrideSchema.visit_schema(&mut schema);
     if let Schema::Object(schema) = &mut schema {


### PR DESCRIPTION
Required for: https://github.com/stackabletech/spark-k8s-operator/pull/256

- Make pub_overrides_schema public.
- Make PodTemplateSpec implement Atomic.
- Update CHANGELOG.md
