### PR TITLE
[Merged by Bors] - Add a function for calculating the size limit of log volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add a function for calculating the size limit of log volumes ([#621]).
+
+[#621]: https://github.com/stackabletech/operator-rs/pull/621
+
 ## [0.43.0] - 2023-07-06
 
 ### Added

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -207,6 +207,14 @@ impl MemoryQuantity {
         }
     }
 
+    /// Ceils the value of this MemoryQuantity.
+    pub fn ceil(&self) -> Self {
+        Self {
+            value: self.value.ceil(),
+            unit: self.unit,
+        }
+    }
+
     /// If the MemoryQuantity value is smaller than 1 (starts with a zero), convert it to a smaller
     /// unit until the non fractional part of the value is not zero anymore.
     /// This can fail if the quantity is smaller than 1kB.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -13,6 +13,7 @@ use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use crate::error::{Error, OperatorResult};
 use std::{
     fmt::Display,
+    iter::Sum,
     ops::{Add, AddAssign, Div, Mul, Sub, SubAssign},
     str::FromStr,
 };
@@ -344,6 +345,18 @@ impl Add<MemoryQuantity> for MemoryQuantity {
             value: self.value + rhs.scale_to(self.unit).value,
             unit: self.unit,
         }
+    }
+}
+
+impl Sum<MemoryQuantity> for MemoryQuantity {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(
+            MemoryQuantity {
+                value: 0.0,
+                unit: BinaryMultiple::Kibi,
+            },
+            MemoryQuantity::add,
+        )
     }
 }
 

--- a/src/product_logging/framework.rs
+++ b/src/product_logging/framework.rs
@@ -42,6 +42,10 @@ pub const VECTOR_CONFIG_FILE: &str = "vector.toml";
 ///   a ZooKeeper log file with 4,127,151 bytes occupied 4,032 blocks. Then log entries were written
 ///   and the actual file size increased to 4,132,477 bytes which occupied 8,128 blocks.
 ///
+/// This function is meant to be used for log volumes up to a size of approximately 100 MiB. The
+/// overhead might not be acceptable for larger volumes, however this needs to be tested
+/// beforehand.
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
## Description

Add a function for calculating the size limit of log volumes.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Closes #620 

## Review Checklist
- [x] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
