### PR TITLE
Update the Vector configuration to be compatible with Vector version 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the log level filter for the Vector container. If the level of the
+  ROOT logger was set to TRACE and the level of the file logger was set
+  to DEBUG then TRACE logs were written anyway.
+
 ## [0.44.0] - 2023-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: Update `product_logging::framework::create_vector_config` to
+  be compatible with Vector version 0.31.0. The product image must
+  contain Vector 0.31.x ([#625]).
+
 ### Fixed
 
 - Fix the log level filter for the Vector container. If the level of the
   ROOT logger was set to TRACE and the level of the file logger was set
-  to DEBUG then TRACE logs were written anyway.
+  to DEBUG then TRACE logs were written anyway ([#625]).
+
+[#625]: https://github.com/stackabletech/operator-rs/pull/625
 
 ## [0.44.0] - 2023-07-13
 

--- a/src/product_logging/framework.rs
+++ b/src/product_logging/framework.rs
@@ -695,7 +695,7 @@ where
 
     let vector_log_level_filter_expression = match vector_log_level {
         LogLevel::TRACE => "true",
-        LogLevel::DEBUG => r#".level != "TRACE""#,
+        LogLevel::DEBUG => r#".metadata.level != "TRACE""#,
         LogLevel::INFO => r#"!includes(["TRACE", "DEBUG"], .metadata.level)"#,
         LogLevel::WARN => r#"!includes(["TRACE", "DEBUG", "INFO"], .metadata.level)"#,
         LogLevel::ERROR => r#"!includes(["TRACE", "DEBUG", "INFO", "WARN"], .metadata.level)"#,

--- a/src/product_logging/framework.rs
+++ b/src/product_logging/framework.rs
@@ -820,7 +820,7 @@ event = parsed_event.root.event
 
 epoch_milliseconds = to_int(event.@timestamp) ?? 0
 if epoch_milliseconds != 0 {{
-    .timestamp = to_timestamp(epoch_milliseconds, "milliseconds") ?? null
+    .timestamp = from_unix_timestamp(epoch_milliseconds, "milliseconds") ?? null
 }}
 if is_null(.timestamp) {{
     .timestamp = now()
@@ -844,13 +844,13 @@ instant = parsed_event.Instant
 if instant != null {{
     epoch_nanoseconds = to_int(instant.@epochSecond) * 1_000_000_000 + to_int(instant.@nanoOfSecond) ?? null
     if epoch_nanoseconds != null {{
-        .timestamp = to_timestamp(epoch_nanoseconds, "nanoseconds") ?? null
+        .timestamp = from_unix_timestamp(epoch_nanoseconds, "nanoseconds") ?? null
     }}
 }}
 if .timestamp == null && parsed_event.@timeMillis != null {{
     epoch_milliseconds = to_int(parsed_event.@timeMillis) ?? null
     if epoch_milliseconds != null {{
-        .timestamp = to_timestamp(epoch_milliseconds, "milliseconds") ?? null
+        .timestamp = from_unix_timestamp(epoch_milliseconds, "milliseconds") ?? null
     }}
 }}
 if .timestamp == null {{


### PR DESCRIPTION
## Description

### Changed

- BREAKING: Update `product_logging::framework::create_vector_config` to be compatible with Vector version 0.31.0. The product image must contain Vector 0.31.x.

### Fixed

- Fix the log level filter for the Vector container. If the level of the ROOT logger was set to TRACE and the level of the file logger was set to DEBUG then TRACE logs were written anyway ([#625]).

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
