### PR TITLE
bump: kube to 0.86.0 and k8s version to 1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `kube` to `0.86.0` and Kubernetes version to `1.28` ([#648]).
+
+[#648]: https://github.com/stackabletech/operator-rs/pull/648
+
 ## [0.48.0] - 2023-08-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ derivative = "2.2.0"
 either = "1.9.0"
 futures = "0.3.28"
 json-patch = "1.0.0"
-k8s-openapi = { version = "0.19.0", default-features = false, features = ["schemars", "v1_27"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
 # We use rustls instead of openssl for easier portablitly, e.g. so that we can build stackablectl without the need to vendor (build from source) openssl
-kube = { version = "0.85.0", default-features = false, features = ["client", "jsonpatch", "runtime", "derive", "rustls-tls"] }
+kube = { version = "0.86.0", default-features = false, features = ["client", "jsonpatch", "runtime", "derive", "rustls-tls"] }
 lazy_static = "1.4.0"
 opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.19.0", features = ["rt-tokio"] }
@@ -41,7 +41,7 @@ strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.44"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.37"
-tracing-opentelemetry = "0.20.0"
+tracing-opentelemetry = "0.21.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

https://github.com/kube-rs/kube/releases/tag/0.86.0

We already use the rustls stack :rocket: 
Tested using trino-operator, no breaking change there.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes


```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
