### PR TITLE
feat: Mark various functions as const

### DIFF
--- a/src/cluster_resources.rs
+++ b/src/cluster_resources.rs
@@ -149,7 +149,7 @@ impl ClusterResourceApplyStrategy {
     }
 
     /// Indicates if orphaned resources should be deleted depending on the strategy.
-    fn delete_orphans(&self) -> bool {
+    const fn delete_orphans(&self) -> bool {
         match self {
             ClusterResourceApplyStrategy::NoApply
             | ClusterResourceApplyStrategy::ReconciliationPaused => false,

--- a/src/commons/authentication/ldap.rs
+++ b/src/commons/authentication/ldap.rs
@@ -31,7 +31,7 @@ pub struct LdapAuthenticationProvider {
 }
 
 impl LdapAuthenticationProvider {
-    pub fn default_port(&self) -> u16 {
+    pub const fn default_port(&self) -> u16 {
         match self.tls {
             None => 389,
             Some(_) => 636,
@@ -91,7 +91,7 @@ impl LdapAuthenticationProvider {
     }
 
     /// Whether TLS is configured
-    pub fn use_tls(&self) -> bool {
+    pub const fn use_tls(&self) -> bool {
         self.tls.is_some()
     }
 

--- a/src/commons/listener.rs
+++ b/src/commons/listener.rs
@@ -96,7 +96,7 @@ pub struct ListenerSpec {
 }
 
 impl ListenerSpec {
-    fn default_publish_not_ready_addresses() -> Option<bool> {
+    const fn default_publish_not_ready_addresses() -> Option<bool> {
         Some(true)
     }
 }

--- a/src/commons/opa.rs
+++ b/src/commons/opa.rs
@@ -66,7 +66,7 @@ pub enum OpaApiVersion {
 
 impl OpaApiVersion {
     /// Returns the OPA data API path for the selected version
-    pub fn get_data_api(&self) -> &'static str {
+    pub const fn get_data_api(&self) -> &'static str {
         match self {
             Self::V1 => "v1/data",
         }

--- a/src/commons/pdb.rs
+++ b/src/commons/pdb.rs
@@ -20,7 +20,7 @@ pub struct PdbConfig {
     pub max_unavailable: Option<u16>,
 }
 
-fn default_pdb_enabled() -> bool {
+const fn default_pdb_enabled() -> bool {
     true
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -20,7 +20,7 @@ pub struct CpuQuantity {
 }
 
 impl CpuQuantity {
-    pub fn from_millis(millis: usize) -> Self {
+    pub const fn from_millis(millis: usize) -> Self {
         Self { millis }
     }
 
@@ -28,7 +28,7 @@ impl CpuQuantity {
         self.millis as f32 / 1000.
     }
 
-    pub fn as_milli_cpus(&self) -> usize {
+    pub const fn as_milli_cpus(&self) -> usize {
         self.millis
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -42,7 +42,7 @@ impl BinaryMultiple {
 
     /// The exponential scale factor used when converting a `BinaryMultiple`
     /// to another one.
-    fn exponential_scale_factor(&self) -> i32 {
+    const fn exponential_scale_factor(&self) -> i32 {
         match self {
             BinaryMultiple::Kibi => 1,
             BinaryMultiple::Mebi => 2,
@@ -53,7 +53,7 @@ impl BinaryMultiple {
         }
     }
 
-    pub fn get_smallest() -> Self {
+    pub const fn get_smallest() -> Self {
         Self::Kibi
     }
 }
@@ -160,14 +160,14 @@ pub struct MemoryQuantity {
 }
 
 impl MemoryQuantity {
-    pub fn from_gibi(gibi: f32) -> Self {
+    pub const fn from_gibi(gibi: f32) -> Self {
         Self {
             value: gibi,
             unit: BinaryMultiple::Gibi,
         }
     }
 
-    pub fn from_mebi(mebi: f32) -> Self {
+    pub const fn from_mebi(mebi: f32) -> Self {
         Self {
             value: mebi,
             unit: BinaryMultiple::Mebi,

--- a/src/status/condition/mod.rs
+++ b/src/status/condition/mod.rs
@@ -145,7 +145,7 @@ impl std::fmt::Display for ClusterCondition {
 impl ClusterCondition {
     /// Returns if the [`ClusterCondition`] is considered to be in a good /
     /// healthy state.
-    pub fn is_good(&self) -> bool {
+    pub const fn is_good(&self) -> bool {
         match self.type_ {
             ClusterConditionType::Available => match self.status {
                 ClusterConditionStatus::False | ClusterConditionStatus::Unknown => false,

--- a/src/status/condition/operations.rs
+++ b/src/status/condition/operations.rs
@@ -18,7 +18,7 @@ impl<'a> ConditionBuilder for ClusterOperationsConditionBuilder<'a> {
 }
 
 impl<'a> ClusterOperationsConditionBuilder<'a> {
-    pub fn new(cluster_operation: &'a ClusterOperation) -> Self {
+    pub const fn new(cluster_operation: &'a ClusterOperation) -> Self {
         Self { cluster_operation }
     }
 


### PR DESCRIPTION
This PR marks various function across `operator-rs` as `const`. This is purely a QoL change. Some downstream code can benefit from this, for example: https://github.com/stackabletech/superset-operator/blob/main/rust/crd/src/lib.rs#L39-L41