### PR TITLE
fix: Pass through docs to derived Fragment structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Add descriptions to derived Fragment structs ([#675]).
+- stackable-operator-derive: Add descriptions to derived Fragment structs ([#675]).
 
 [#670]: https://github.com/stackabletech/operator-rs/pull/670
 [#675]: https://github.com/stackabletech/operator-rs/pull/675

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,12 @@ All notable changes to this project will be documented in this file.
 
 - Convert the format of the Vector configuration from TOML to YAML ([#670]).
 
+### Fixed
+
+- Add descriptions to derived Fragment structs ([#675]).
+
 [#670]: https://github.com/stackabletech/operator-rs/pull/670
+[#675]: https://github.com/stackabletech/operator-rs/pull/675
 
 ## [0.54.0] - 2023-10-10
 

--- a/src/product_logging/spec.rs
+++ b/src/product_logging/spec.rs
@@ -66,7 +66,9 @@ use serde::{Deserialize, Serialize};
     serde(
         bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>",),
         rename_all = "camelCase",
-    )
+    ),
+    // We don't want Rust code in public API descriptions
+    schemars(description = "Logging configuration")
 )]
 pub struct Logging<T>
 where
@@ -115,7 +117,6 @@ pub enum ContainerLogConfigChoice {
     Automatic(AutomaticContainerLogConfig),
 }
 
-/// Fragment derived from `ContainerLogConfigChoice`
 #[derive(Clone, Debug, Derivative, Deserialize, JsonSchema, Merge, PartialEq, Serialize)]
 #[derivative(Default)]
 #[merge(path_overrides(merge = "crate::config::merge"))]
@@ -259,8 +260,7 @@ impl AutomaticContainerLogConfig {
     serde(rename_all = "camelCase")
 )]
 pub struct LoggerConfig {
-    /// The log level threshold
-    ///
+    /// The log level threshold.
     /// Log events with a lower log level are discarded.
     pub level: LogLevel,
 }
@@ -283,8 +283,7 @@ pub struct LoggerConfig {
     serde(rename_all = "camelCase")
 )]
 pub struct AppenderConfig {
-    /// The log level threshold
-    ///
+    /// The log level threshold.
     /// Log events with a lower log level are discarded.
     pub level: Option<LogLevel>,
 }


### PR DESCRIPTION
# Description

Previously Fragments were missing descriptions in the CRDs, as the doccomments where only available on the original struct, but not the Fragment.
This PR fixes that.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
