### PR TITLE
chore: Release 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.55.0] - 2023-10-16
+
 ### Added
 
 - Mark the following functions as `const` ([#674]):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Stackable GmbH <info@stackable.de>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This PR bumps the version to `0.55.0`.
