### PR TITLE
fix: Docker image tag parsing when user specifies custom image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Docker image tag parsing when user specifies custom image ([#677]).
+
+[#677]: https://github.com/stackabletech/operator-rs/pull/677
+
 ## [0.55.0] - 2023-10-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.3.19", features = ["derive", "cargo", "env"] }
 const_format = "0.2.31"
 derivative = "2.2.0"
+dockerfile-parser = "0.8.0"
 either = "1.9.0"
 futures = "0.3.28"
 json-patch = "1.0.0"


### PR DESCRIPTION
# Description

Fixes the problem reported in Slack by @Jimvin 
> For info, the thing that triggered this error for us was using a custom image from a local docker repo which had the port number in the url. I am assuming that it tried to parse everything after the first : character using SemVer, but the error isn’t all that helpful in pointing out what was being parsed.
This seems to be a bug in the parsing of custom image locations with port numbers in the location.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
