### PR TITLE
Add operator_image argument to ProductOperatorRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Add `stackble_operator::kvp` module and types to allow validated construction of key/value pairs, like labels and
   annotations. Most users want to use the exported type aliases `Label` and `Annotation` ([#684]).
+- BREAKING: Add mandatory operator argument `--operator-image`, which can also be set via the `OPERATOR_IMAGE` env var.
 
 ### Changed
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,8 @@ pub struct ProductOperatorRun {
     /// Tracing log collector system
     #[arg(long, env, default_value_t, value_enum)]
     pub tracing_target: TracingTarget,
+    #[arg(long, env)]
+    pub operator_image: String,
 }
 
 /// A path to a [`ProductConfigManager`] spec file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,6 +274,7 @@ mod tests {
     const DEPLOY_FILE_PATH: &str = "deploy_config_spec_properties.yaml";
     const DEFAULT_FILE_PATH: &str = "default_file_path_properties.yaml";
     const WATCH_NAMESPACE: &str = "WATCH_NAMESPACE";
+    const OPERATOR_IMAGE: &str = "OPERATOR_IMAGE";
 
     #[test]
     fn verify_cli() {
@@ -360,6 +361,7 @@ mod tests {
     fn test_product_operator_run_watch_namespace() {
         // clean env var to not interfere if already set
         env::remove_var(WATCH_NAMESPACE);
+        env::remove_var(OPERATOR_IMAGE);
 
         // cli with namespace
         let opts = ProductOperatorRun::parse_from([
@@ -368,6 +370,8 @@ mod tests {
             "bar",
             "--watch-namespace",
             "foo",
+            "--operator-image",
+            "baz",
         ]);
         assert_eq!(
             opts,
@@ -375,22 +379,31 @@ mod tests {
                 product_config: ProductConfigPath::from("bar".as_ref()),
                 watch_namespace: WatchNamespace::One("foo".to_string()),
                 tracing_target: TracingTarget::None,
+                operator_image: "baz".to_string(),
             }
         );
 
         // no cli / no env
-        let opts = ProductOperatorRun::parse_from(["run", "--product-config", "bar"]);
+        let opts = ProductOperatorRun::parse_from([
+            "run",
+            "--product-config",
+            "bar",
+            "--operator-image",
+            "baz",
+        ]);
         assert_eq!(
             opts,
             ProductOperatorRun {
                 product_config: ProductConfigPath::from("bar".as_ref()),
                 watch_namespace: WatchNamespace::All,
                 tracing_target: TracingTarget::None,
+                operator_image: "baz".to_string(),
             }
         );
 
-        // env with namespace
+        // env with namespace and operator image
         env::set_var(WATCH_NAMESPACE, "foo");
+        env::set_var(OPERATOR_IMAGE, "baz");
         let opts = ProductOperatorRun::parse_from(["run", "--product-config", "bar"]);
         assert_eq!(
             opts,
@@ -398,6 +411,7 @@ mod tests {
                 product_config: ProductConfigPath::from("bar".as_ref()),
                 watch_namespace: WatchNamespace::One("foo".to_string()),
                 tracing_target: TracingTarget::None,
+                operator_image: "baz".to_string(),
             }
         );
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,13 +159,14 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 /// use clap::Parser;
 /// use stackable_operator::logging::TracingTarget;
 /// use stackable_operator::namespace::WatchNamespace;
-/// let opts = Command::<Run>::parse_from(["foobar-operator", "run", "--name", "foo", "--product-config", "bar", "--watch-namespace", "foobar"]);
+/// let opts = Command::<Run>::parse_from(["foobar-operator", "run", "--name", "foo", "--product-config", "bar", "--watch-namespace", "foobar", "--operator-image", "baz"]);
 /// assert_eq!(opts, Command::Run(Run {
 ///     name: "foo".to_string(),
 ///     common: ProductOperatorRun {
 ///         product_config: ProductConfigPath::from("bar".as_ref()),
 ///         watch_namespace: WatchNamespace::One("foobar".to_string()),
-///         tracing_target: TracingTarget::None
+///         tracing_target: TracingTarget::None,
+///         operator_image: "baz".to_string(),
 ///     },
 /// }));
 /// ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,8 @@ pub struct ProductOperatorRun {
     /// Tracing log collector system
     #[arg(long, env, default_value_t, value_enum)]
     pub tracing_target: TracingTarget,
+    /// The full name of the operator image. This env var is set by the helm-charts and should
+    /// therefore always be present.
     #[arg(long, env)]
     pub operator_image: String,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -191,12 +191,15 @@ pub struct ProductOperatorRun {
     /// Provides the path to a product-config file
     #[arg(long, short = 'p', value_name = "FILE", default_value = "", env)]
     pub product_config: ProductConfigPath,
+
     /// Provides a specific namespace to watch (instead of watching all namespaces)
     #[arg(long, env, default_value = "")]
     pub watch_namespace: WatchNamespace,
+
     /// Tracing log collector system
     #[arg(long, env, default_value_t, value_enum)]
     pub tracing_target: TracingTarget,
+
     /// The full name of the operator image. This env var is set by the helm-charts and should
     /// therefore always be present.
     #[arg(long, env)]


### PR DESCRIPTION
# Description

Add the operator_image argument to ProductOperatorRun for all operators to use.
This change came from this comment chain: https://github.com/stackabletech/opa-operator/pull/433#discussion_r1371496911

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
