### PR TITLE
feat: Add key/value pair QoL improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `TryFrom<[(K, V); N]>` implementation for `Annotations` and `Labels` ([#711]).
+- Add `parse_insert` associated function for `Annotations` and `Labels` ([#711]).
+
+### Changed
+
+- Adjust `try_insert` for `Annotations` and `Labels` slightly ([#711]).
+
+[#711]: https://github.com/stackabletech/operator-rs/pull/711
+
 ## [0.60.1] - 2024-01-04
 
 ### Fixed

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -189,7 +189,7 @@ impl Annotations {
 
     /// Tries to insert a new annotation by first parsing `annotation` as an
     /// [`Annotation`] and then inserting it into the list. This function will
-    /// overide any existing annotation already present.
+    /// overwrite any existing annotation already present.
     pub fn parse_insert(
         &mut self,
         annotation: impl TryInto<Annotation, Error = AnnotationError>,
@@ -198,7 +198,7 @@ impl Annotations {
         Ok(())
     }
 
-    /// Inserts a new [`Annotation`]. This function will overide any existing
+    /// Inserts a new [`Annotation`]. This function will overwrite any existing
     /// annotation already present.
     pub fn insert(&mut self, annotation: Annotation) -> &mut Self {
         self.0.insert(annotation.0);
@@ -213,7 +213,7 @@ impl Annotations {
         to self.0 {
             /// Tries to insert a new [`Annotation`]. It ensures there are no duplicate
             /// entries. Trying to insert duplicated data returns an error. If no such
-            /// check is required, use the `insert` function instead.
+            /// check is required, use [`Annotation::insert`] instead.
             pub fn try_insert(&mut self, #[newtype] annotation: Annotation) -> Result<(), AnnotationsError>;
 
             /// Extends `self` with `other`.

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -44,14 +44,14 @@ pub type AnnotationError = KeyValuePairError<Infallible>;
 #[derive(Debug)]
 pub struct Annotation(KeyValuePair<AnnotationValue>);
 
-impl<T, K> TryFrom<(T, K)> for Annotation
+impl<K, V> TryFrom<(K, V)> for Annotation
 where
-    T: AsRef<str>,
     K: AsRef<str>,
+    V: AsRef<str>,
 {
     type Error = AnnotationError;
 
-    fn try_from(value: (T, K)) -> Result<Self, Self::Error> {
+    fn try_from(value: (K, V)) -> Result<Self, Self::Error> {
         let kvp = KeyValuePair::try_from(value)?;
         Ok(Self(kvp))
     }
@@ -150,14 +150,14 @@ impl TryFrom<BTreeMap<String, String>> for Annotations {
     }
 }
 
-impl<const N: usize, T, K> TryFrom<[(T, K); N]> for Annotations
+impl<const N: usize, K, V> TryFrom<[(K, V); N]> for Annotations
 where
-    T: AsRef<str>,
     K: AsRef<str>,
+    V: AsRef<str>,
 {
     type Error = AnnotationError;
 
-    fn try_from(value: [(T, K); N]) -> Result<Self, Self::Error> {
+    fn try_from(value: [(K, V); N]) -> Result<Self, Self::Error> {
         let kvps = KeyValuePairs::try_from(value)?;
         Ok(Self(kvps))
     }

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -213,7 +213,7 @@ impl Annotations {
         to self.0 {
             /// Tries to insert a new [`Annotation`]. It ensures there are no duplicate
             /// entries. Trying to insert duplicated data returns an error. If no such
-            /// check is required, use [`Annotation::insert`] instead.
+            /// check is required, use [`Annotations::insert`] instead.
             pub fn try_insert(&mut self, #[newtype] annotation: Annotation) -> Result<(), AnnotationsError>;
 
             /// Extends `self` with `other`.

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -45,13 +45,14 @@ pub type AnnotationError = KeyValuePairError<Infallible>;
 #[derive(Debug)]
 pub struct Annotation(KeyValuePair<AnnotationValue>);
 
-impl<T> TryFrom<(T, T)> for Annotation
+impl<T, K> TryFrom<(T, K)> for Annotation
 where
     T: AsRef<str>,
+    K: AsRef<str>,
 {
     type Error = AnnotationError;
 
-    fn try_from(value: (T, T)) -> Result<Self, Self::Error> {
+    fn try_from(value: (T, K)) -> Result<Self, Self::Error> {
         let kvp = KeyValuePair::try_from(value)?;
         Ok(Self(kvp))
     }
@@ -145,6 +146,19 @@ impl TryFrom<BTreeMap<String, String>> for Annotations {
     type Error = AnnotationError;
 
     fn try_from(value: BTreeMap<String, String>) -> Result<Self, Self::Error> {
+        let kvps = KeyValuePairs::try_from(value)?;
+        Ok(Self(kvps))
+    }
+}
+
+impl<const N: usize, T, K> TryFrom<[(T, K); N]> for Annotations
+where
+    T: AsRef<str>,
+    K: AsRef<str>,
+{
+    type Error = AnnotationError;
+
+    fn try_from(value: [(T, K); N]) -> Result<Self, Self::Error> {
         let kvps = KeyValuePairs::try_from(value)?;
         Ok(Self(kvps))
     }

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -19,15 +19,12 @@ use delegate::delegate;
 
 use crate::{
     builder::SecretOperatorVolumeScope,
-    kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs, KeyValuePairsError},
+    kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs},
 };
 
 mod value;
 
 pub use value::*;
-
-/// A type alias for errors returned when construction of an annotation fails.
-pub type AnnotationsError = KeyValuePairsError<Infallible>;
 
 /// A type alias for errors returned when construction or manipulation of a set
 /// of annotations fails.
@@ -188,17 +185,19 @@ impl Annotations {
         Self(KeyValuePairs::new_with(pairs))
     }
 
-    /// Tries to insert a new [`Annotation`]. It ensures there are no duplicate
-    /// entries. Trying to insert duplicated data returns an error. If no such
-    /// check is required, use the `insert` function instead.
-    pub fn try_insert(&mut self, annotation: Annotation) -> Result<&mut Self, AnnotationsError> {
-        self.0.try_insert(annotation.0)?;
-        Ok(self)
+    /// Tries to insert a new annotation by first parsing `annotation` as an
+    /// [`Annotation`] and then inserting it into the list. This function will
+    /// overide any existing annotation already present.
+    pub fn try_insert(
+        &mut self,
+        annotation: impl TryInto<Annotation, Error = AnnotationError>,
+    ) -> Result<(), AnnotationError> {
+        self.0.insert(annotation.try_into()?.0);
+        Ok(())
     }
 
     /// Inserts a new [`Annotation`]. This function will overide any existing
-    /// annotation already present. If this behaviour is not desired, use the
-    /// `try_insert` function instead.
+    /// annotation already present.
     pub fn insert(&mut self, annotation: Annotation) -> &mut Self {
         self.0.insert(annotation.0);
         self

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -237,3 +237,23 @@ impl Annotations {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_insert() {
+        let mut annotations = Annotations::new();
+
+        annotations
+            .parse_insert(("stackable.tech/managed-by", "stackablectl"))
+            .unwrap();
+
+        annotations
+            .parse_insert(("stackable.tech/vendor", "Stäckable"))
+            .unwrap();
+
+        assert_eq!(annotations.len(), 2);
+    }
+}

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -19,12 +19,14 @@ use delegate::delegate;
 
 use crate::{
     builder::SecretOperatorVolumeScope,
-    kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs},
+    kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs, KeyValuePairsError},
 };
 
 mod value;
 
 pub use value::*;
+
+pub type AnnotationsError = KeyValuePairsError;
 
 /// A type alias for errors returned when construction or manipulation of a set
 /// of annotations fails.
@@ -188,7 +190,7 @@ impl Annotations {
     /// Tries to insert a new annotation by first parsing `annotation` as an
     /// [`Annotation`] and then inserting it into the list. This function will
     /// overide any existing annotation already present.
-    pub fn try_insert(
+    pub fn parse_insert(
         &mut self,
         annotation: impl TryInto<Annotation, Error = AnnotationError>,
     ) -> Result<(), AnnotationError> {
@@ -209,6 +211,11 @@ impl Annotations {
     // the need to write boilerplate code.
     delegate! {
         to self.0 {
+            /// Tries to insert a new [`Annotation`]. It ensures there are no duplicate
+            /// entries. Trying to insert duplicated data returns an error. If no such
+            /// check is required, use the `insert` function instead.
+            pub fn try_insert(&mut self, #[newtype] annotation: Annotation) -> Result<(), AnnotationsError>;
+
             /// Extends `self` with `other`.
             pub fn extend(&mut self, #[newtype] other: Self);
 

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -56,14 +56,14 @@ pub type LabelError = KeyValuePairError<LabelValueError>;
 #[derive(Clone, Debug)]
 pub struct Label(KeyValuePair<LabelValue>);
 
-impl<T, K> TryFrom<(T, K)> for Label
+impl<K, V> TryFrom<(K, V)> for Label
 where
-    T: AsRef<str>,
     K: AsRef<str>,
+    V: AsRef<str>,
 {
     type Error = LabelError;
 
-    fn try_from(value: (T, K)) -> Result<Self, Self::Error> {
+    fn try_from(value: (K, V)) -> Result<Self, Self::Error> {
         let kvp = KeyValuePair::try_from(value)?;
         Ok(Self(kvp))
     }
@@ -151,14 +151,14 @@ impl TryFrom<BTreeMap<String, String>> for Labels {
     }
 }
 
-impl<const N: usize, T, K> TryFrom<[(T, K); N]> for Labels
+impl<const N: usize, K, V> TryFrom<[(K, V); N]> for Labels
 where
-    T: AsRef<str>,
     K: AsRef<str>,
+    V: AsRef<str>,
 {
     type Error = LabelError;
 
-    fn try_from(value: [(T, K); N]) -> Result<Self, Self::Error> {
+    fn try_from(value: [(K, V); N]) -> Result<Self, Self::Error> {
         let kvps = KeyValuePairs::try_from(value)?;
         Ok(Self(kvps))
     }

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -324,3 +324,23 @@ impl Labels {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_insert() {
+        let mut labels = Labels::new();
+
+        labels
+            .parse_insert(("stackable.tech/managed-by", "stackablectl"))
+            .unwrap();
+
+        labels
+            .parse_insert(("stackable.tech/vendor", "Stackable"))
+            .unwrap();
+
+        assert_eq!(labels.len(), 2);
+    }
+}

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -302,7 +302,7 @@ impl Labels {
         to self.0 {
             /// Tries to insert a new [`Label`]. It ensures there are no duplicate
             /// entries. Trying to insert duplicated data returns an error. If no such
-            /// check is required, use the `insert` function instead.
+            /// check is required, use [`Labels::insert`] instead.
             pub fn try_insert(&mut self, #[newtype] label: Label) -> Result<(), LabelsError>;
 
             /// Extends `self` with `other`.

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -23,7 +23,7 @@ use crate::{
             K8S_APP_COMPONENT_KEY, K8S_APP_INSTANCE_KEY, K8S_APP_MANAGED_BY_KEY, K8S_APP_NAME_KEY,
             K8S_APP_ROLE_GROUP_KEY, K8S_APP_VERSION_KEY,
         },
-        Key, KeyValuePair, KeyValuePairError, KeyValuePairs, ObjectLabels,
+        Key, KeyValuePair, KeyValuePairError, KeyValuePairs, KeyValuePairsError, ObjectLabels,
     },
     utils::format_full_controller_name,
 };
@@ -33,6 +33,8 @@ mod value;
 
 pub use selector::*;
 pub use value::*;
+
+pub type LabelsError = KeyValuePairsError;
 
 /// A type alias for errors returned when construction or manipulation of a set
 /// of labels fails.
@@ -189,7 +191,7 @@ impl Labels {
     /// Tries to insert a new label by first parsing `label` as a [`Label`]
     /// and then inserting it into the list. This function will overide any
     /// existing label already present.
-    pub fn try_insert(
+    pub fn parse_insert(
         &mut self,
         label: impl TryInto<Label, Error = LabelError>,
     ) -> Result<(), LabelError> {
@@ -298,6 +300,11 @@ impl Labels {
     // need to write boilerplate code.
     delegate! {
         to self.0 {
+            /// Tries to insert a new [`Label`]. It ensures there are no duplicate
+            /// entries. Trying to insert duplicated data returns an error. If no such
+            /// check is required, use the `insert` function instead.
+            pub fn try_insert(&mut self, #[newtype] label: Label) -> Result<(), LabelsError>;
+
             /// Extends `self` with `other`.
             pub fn extend(&mut self, #[newtype] other: Self);
 

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -189,7 +189,7 @@ impl Labels {
     }
 
     /// Tries to insert a new label by first parsing `label` as a [`Label`]
-    /// and then inserting it into the list. This function will overide any
+    /// and then inserting it into the list. This function will overwrite any
     /// existing label already present.
     pub fn parse_insert(
         &mut self,
@@ -199,7 +199,7 @@ impl Labels {
         Ok(())
     }
 
-    /// Inserts a new [`Label`]. This function will overide any existing label
+    /// Inserts a new [`Label`]. This function will overwrite any existing label
     /// already present.
     pub fn insert(&mut self, label: Label) -> &mut Self {
         self.0.insert(label.0);

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -57,13 +57,14 @@ pub type LabelError = KeyValuePairError<LabelValueError>;
 #[derive(Clone, Debug)]
 pub struct Label(KeyValuePair<LabelValue>);
 
-impl<T> TryFrom<(T, T)> for Label
+impl<T, K> TryFrom<(T, K)> for Label
 where
     T: AsRef<str>,
+    K: AsRef<str>,
 {
     type Error = LabelError;
 
-    fn try_from(value: (T, T)) -> Result<Self, Self::Error> {
+    fn try_from(value: (T, K)) -> Result<Self, Self::Error> {
         let kvp = KeyValuePair::try_from(value)?;
         Ok(Self(kvp))
     }
@@ -146,6 +147,19 @@ impl TryFrom<BTreeMap<String, String>> for Labels {
     type Error = LabelError;
 
     fn try_from(value: BTreeMap<String, String>) -> Result<Self, Self::Error> {
+        let kvps = KeyValuePairs::try_from(value)?;
+        Ok(Self(kvps))
+    }
+}
+
+impl<const N: usize, T, K> TryFrom<[(T, K); N]> for Labels
+where
+    T: AsRef<str>,
+    K: AsRef<str>,
+{
+    type Error = LabelError;
+
+    fn try_from(value: [(T, K); N]) -> Result<Self, Self::Error> {
         let kvps = KeyValuePairs::try_from(value)?;
         Ok(Self(kvps))
     }

--- a/src/kvp/mod.rs
+++ b/src/kvp/mod.rs
@@ -170,6 +170,25 @@ where
     }
 }
 
+impl<const N: usize, T, K, V> TryFrom<[(T, K); N]> for KeyValuePairs<V>
+where
+    T: AsRef<str>,
+    K: AsRef<str>,
+    V: Value + std::default::Default,
+{
+    type Error = KeyValuePairError<V::Error>;
+
+    fn try_from(array: [(T, K); N]) -> Result<Self, Self::Error> {
+        let mut pairs = KeyValuePairs::new();
+
+        for item in array {
+            pairs.insert(KeyValuePair::try_from(item)?);
+        }
+
+        Ok(pairs)
+    }
+}
+
 impl<V> FromIterator<KeyValuePair<V>> for KeyValuePairs<V>
 where
     V: Value,
@@ -310,6 +329,17 @@ mod test {
         assert_eq!(label.value(), &LabelValue::from_str("Stackable").unwrap());
 
         assert_eq!(label.to_string(), "stackable.tech/vendor=Stackable");
+    }
+
+    #[test]
+    fn labels_from_array() {
+        let labels = Labels::try_from([
+            ("stackable.tech/managed-by", "stackablectl"),
+            ("stackable.tech/vendor", "Stackable"),
+        ])
+        .unwrap();
+
+        assert_eq!(labels.len(), 2);
     }
 
     #[test]

--- a/src/kvp/mod.rs
+++ b/src/kvp/mod.rs
@@ -85,45 +85,45 @@ where
 /// - <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>
 /// - <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct KeyValuePair<V>
+pub struct KeyValuePair<T>
 where
-    V: Value,
+    T: Value,
 {
     key: Key,
-    value: V,
+    value: T,
 }
 
-impl<T, K, V> TryFrom<(T, K)> for KeyValuePair<V>
+impl<K, V, T> TryFrom<(K, V)> for KeyValuePair<T>
 where
-    T: AsRef<str>,
     K: AsRef<str>,
-    V: Value,
+    V: AsRef<str>,
+    T: Value,
 {
-    type Error = KeyValuePairError<V::Error>;
+    type Error = KeyValuePairError<T::Error>;
 
-    fn try_from(value: (T, K)) -> Result<Self, Self::Error> {
+    fn try_from(value: (K, V)) -> Result<Self, Self::Error> {
         let key = Key::from_str(value.0.as_ref()).context(InvalidKeySnafu)?;
-        let value = V::from_str(value.1.as_ref()).context(InvalidValueSnafu)?;
+        let value = T::from_str(value.1.as_ref()).context(InvalidValueSnafu)?;
 
         Ok(Self { key, value })
     }
 }
 
-impl<V> Display for KeyValuePair<V>
+impl<T> Display for KeyValuePair<T>
 where
-    V: Value,
+    T: Value,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}={}", self.key, self.value)
     }
 }
 
-impl<V> KeyValuePair<V>
+impl<T> KeyValuePair<T>
 where
-    V: Value,
+    T: Value,
 {
     /// Creates a new [`KeyValuePair`] from a validated [`Key`] and value.
-    pub fn new(key: Key, value: V) -> Self {
+    pub fn new(key: Key, value: T) -> Self {
         Self { key, value }
     }
 
@@ -133,7 +133,7 @@ where
     }
 
     /// Returns an immutable reference to the pair's value.
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &T {
         &self.value
     }
 }
@@ -146,33 +146,33 @@ pub enum KeyValuePairsError {
 
 /// A validated set/list of Kubernetes key/value pairs.
 #[derive(Clone, Debug, Default)]
-pub struct KeyValuePairs<V: Value>(BTreeSet<KeyValuePair<V>>);
+pub struct KeyValuePairs<T: Value>(BTreeSet<KeyValuePair<T>>);
 
-impl<V> TryFrom<BTreeMap<String, String>> for KeyValuePairs<V>
+impl<T> TryFrom<BTreeMap<String, String>> for KeyValuePairs<T>
 where
-    V: Value,
+    T: Value,
 {
-    type Error = KeyValuePairError<V::Error>;
+    type Error = KeyValuePairError<T::Error>;
 
     fn try_from(map: BTreeMap<String, String>) -> Result<Self, Self::Error> {
         let pairs = map
             .into_iter()
             .map(KeyValuePair::try_from)
-            .collect::<Result<BTreeSet<_>, KeyValuePairError<V::Error>>>()?;
+            .collect::<Result<BTreeSet<_>, KeyValuePairError<T::Error>>>()?;
 
         Ok(Self(pairs))
     }
 }
 
-impl<const N: usize, T, K, V> TryFrom<[(T, K); N]> for KeyValuePairs<V>
+impl<const N: usize, K, V, T> TryFrom<[(K, V); N]> for KeyValuePairs<T>
 where
-    T: AsRef<str>,
     K: AsRef<str>,
-    V: Value + std::default::Default,
+    V: AsRef<str>,
+    T: Value + std::default::Default,
 {
-    type Error = KeyValuePairError<V::Error>;
+    type Error = KeyValuePairError<T::Error>;
 
-    fn try_from(array: [(T, K); N]) -> Result<Self, Self::Error> {
+    fn try_from(array: [(K, V); N]) -> Result<Self, Self::Error> {
         let mut pairs = KeyValuePairs::new();
 
         for item in array {
@@ -183,20 +183,20 @@ where
     }
 }
 
-impl<V> FromIterator<KeyValuePair<V>> for KeyValuePairs<V>
+impl<T> FromIterator<KeyValuePair<T>> for KeyValuePairs<T>
 where
-    V: Value,
+    T: Value,
 {
-    fn from_iter<T: IntoIterator<Item = KeyValuePair<V>>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = KeyValuePair<T>>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
     }
 }
 
-impl<V> From<KeyValuePairs<V>> for BTreeMap<String, String>
+impl<T> From<KeyValuePairs<T>> for BTreeMap<String, String>
 where
-    V: Value,
+    T: Value,
 {
-    fn from(value: KeyValuePairs<V>) -> Self {
+    fn from(value: KeyValuePairs<T>) -> Self {
         value
             .iter()
             .map(|pair| (pair.key().to_string(), pair.value().to_string()))
@@ -204,20 +204,20 @@ where
     }
 }
 
-impl<V> Deref for KeyValuePairs<V>
+impl<T> Deref for KeyValuePairs<T>
 where
-    V: Value,
+    T: Value,
 {
-    type Target = BTreeSet<KeyValuePair<V>>;
+    type Target = BTreeSet<KeyValuePair<T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<V> KeyValuePairs<V>
+impl<T> KeyValuePairs<T>
 where
-    V: Value + std::default::Default,
+    T: Value + std::default::Default,
 {
     /// Creates a new empty list of [`KeyValuePair`]s.
     pub fn new() -> Self {
@@ -225,7 +225,7 @@ where
     }
 
     /// Creates a new list of [`KeyValuePair`]s from `pairs`.
-    pub fn new_with(pairs: BTreeSet<KeyValuePair<V>>) -> Self {
+    pub fn new_with(pairs: BTreeSet<KeyValuePair<T>>) -> Self {
         Self(pairs)
     }
 
@@ -240,7 +240,7 @@ where
     /// overwriting existing pairs, either use [`KeyValuePairs::contains`] or
     /// [`KeyValuePairs::contains_key`] before inserting or try to insert
     /// fallible via [`KeyValuePairs::try_insert`].
-    pub fn insert(&mut self, kvp: KeyValuePair<V>) -> &mut Self {
+    pub fn insert(&mut self, kvp: KeyValuePair<T>) -> &mut Self {
         self.0.insert(kvp);
         self
     }
@@ -249,14 +249,14 @@ where
     ///
     /// If the list already had this pair present, nothing is updated, and an
     /// error is returned.
-    pub fn try_insert(&mut self, kvp: KeyValuePair<V>) -> Result<(), KeyValuePairsError> {
+    pub fn try_insert(&mut self, kvp: KeyValuePair<T>) -> Result<(), KeyValuePairsError> {
         ensure!(!self.0.contains(&kvp), PairAlreadyExistsSnafu);
         self.insert(kvp);
         Ok(())
     }
 
     /// Returns if the list contains a specific [`KeyValuePair`].
-    pub fn contains(&self, kvp: impl TryInto<KeyValuePair<V>>) -> bool {
+    pub fn contains(&self, kvp: impl TryInto<KeyValuePair<T>>) -> bool {
         let Ok(kvp) = kvp.try_into() else {return false};
         self.0.contains(&kvp)
     }

--- a/src/kvp/mod.rs
+++ b/src/kvp/mod.rs
@@ -236,8 +236,8 @@ where
 
     /// Inserts a new [`KeyValuePair`] into the list of pairs.
     ///
-    /// This function overides any existing key/value pair. To avoid overiding
-    /// existing pairs, either use [`KeyValuePairs::contains`] or
+    /// This function overwrites any existing key/value pair. To avoid
+    /// overwriting existing pairs, either use [`KeyValuePairs::contains`] or
     /// [`KeyValuePairs::contains_key`] before inserting or try to insert
     /// fallible via [`KeyValuePairs::try_insert`].
     pub fn insert(&mut self, kvp: KeyValuePair<V>) -> &mut Self {


### PR DESCRIPTION
This PR adds two QoL improvements to the key/value pair API:

- Add `TryFrom<[(K, V); N]>` impl for labels and annotations
- Add `Labels::parse_insert()` and `Annotations::parse_insert()` functions. They take `impl TryInto<_>` as a parameter.