### PR TITLE
feat: Add TryFromIterator trait and implement it for `Labels` and `Annotations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ All notable changes to this project will be documented in this file.
 
 - Add `TryFrom<[(K, V); N]>` implementation for `Annotations` and `Labels` ([#711]).
 - Add `parse_insert` associated function for `Annotations` and `Labels` ([#711]).
+- Add generic types for `TryFrom<BTreeMap<K, V>>` impl ([#714]).
+- Add `TryFromIterator` trait, which tries to construct `Self` from an iterator. It is a falliable version of
+  `FromIterator` ([]).
+- Add `TryFromIterator` impl for `Labels` and `Annotations` ([]).
 
 ### Changed
 
 - Adjust `try_insert` for `Annotations` and `Labels` slightly ([#711]).
 
 [#711]: https://github.com/stackabletech/operator-rs/pull/711
+[#714]: https://github.com/stackabletech/operator-rs/pull/714
 
 ## [0.60.1] - 2024-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to this project will be documented in this file.
 - Add `parse_insert` associated function for `Annotations` and `Labels` ([#711]).
 - Add generic types for `TryFrom<BTreeMap<K, V>>` impl ([#714]).
 - Add `TryFromIterator` trait, which tries to construct `Self` from an iterator. It is a falliable version of
-  `FromIterator` ([]).
-- Add `TryFromIterator` impl for `Labels` and `Annotations` ([]).
+  `FromIterator` ([#715]).
+- Add `TryFromIterator` impl for `Labels` and `Annotations` ([#715]).
 
 ### Changed
 
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 [#711]: https://github.com/stackabletech/operator-rs/pull/711
 [#714]: https://github.com/stackabletech/operator-rs/pull/714
+[#715]: https://github.com/stackabletech/operator-rs/pull/715
 
 ## [0.60.1] - 2024-01-04
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -45,6 +45,12 @@ where
     }
 }
 
+/// This is a fallible version of the std [`FromIterator`] trait.
+///
+/// The standard [`FromIterator`] trait specifies it must never fail. This trait
+/// makes it easier to work with iterators, which can fail during the creation
+/// `Self`. It will immediately return an error if processing failed and will
+/// not continue to process items.
 pub trait TryFromIterator<T>: Sized {
     type Error: std::error::Error;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -45,6 +45,12 @@ where
     }
 }
 
+pub trait TryFromIterator<T>: Sized {
+    type Error: std::error::Error;
+
+    fn try_from_iter<I: IntoIterator<Item = T>>(iter: I) -> Result<Self, Self::Error>;
+}
+
 #[cfg(test)]
 mod tests {
     use crate::iter::try_flatten;

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -139,6 +139,31 @@ impl Annotation {
 ///
 /// It provides selected associated functions to manipulate the set of
 /// annotations, like inserting or extending.
+///
+/// ## Examples
+///
+/// ### Converting a BTreeMap into a list of labels
+///
+/// ```
+/// # use std::collections::BTreeMap;
+/// # use stackable_operator::kvp::Annotations;
+/// let map = BTreeMap::from([
+///     ("stackable.tech/managed-by", "stackablectl"),
+///     ("stackable.tech/vendor", "Stäckable"),
+/// ]);
+///
+/// let labels = Annotations::try_from(map).unwrap();
+/// ```
+///
+/// ### Creating a list of labels from an array
+///
+/// ```
+/// # use stackable_operator::kvp::Annotations;
+/// let labels = Annotations::try_from([
+///     ("stackable.tech/managed-by", "stackablectl"),
+///     ("stackable.tech/vendor", "Stäckable"),
+/// ]).unwrap();
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct Annotations(KeyValuePairs<AnnotationValue>);
 
@@ -149,9 +174,8 @@ where
 {
     type Error = AnnotationError;
 
-    fn try_from(value: BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(value)?;
-        Ok(Self(kvps))
+    fn try_from(map: BTreeMap<K, V>) -> Result<Self, Self::Error> {
+        Self::try_from_iter(map)
     }
 }
 
@@ -162,9 +186,8 @@ where
 {
     type Error = AnnotationError;
 
-    fn try_from(value: &BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(value)?;
-        Ok(Self(kvps))
+    fn try_from(map: &BTreeMap<K, V>) -> Result<Self, Self::Error> {
+        Self::try_from_iter(map)
     }
 }
 
@@ -175,9 +198,8 @@ where
 {
     type Error = AnnotationError;
 
-    fn try_from(value: [(K, V); N]) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(value)?;
-        Ok(Self(kvps))
+    fn try_from(array: [(K, V); N]) -> Result<Self, Self::Error> {
+        Self::try_from_iter(array)
     }
 }
 

--- a/src/kvp/annotation/mod.rs
+++ b/src/kvp/annotation/mod.rs
@@ -19,6 +19,7 @@ use delegate::delegate;
 
 use crate::{
     builder::SecretOperatorVolumeScope,
+    iter::TryFromIterator,
     kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs, KeyValuePairsError},
 };
 
@@ -184,6 +185,19 @@ impl FromIterator<KeyValuePair<AnnotationValue>> for Annotations {
     fn from_iter<T: IntoIterator<Item = KeyValuePair<AnnotationValue>>>(iter: T) -> Self {
         let kvps = KeyValuePairs::from_iter(iter);
         Self(kvps)
+    }
+}
+
+impl<K, V> TryFromIterator<(K, V)> for Annotations
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    type Error = AnnotationError;
+
+    fn try_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Result<Self, Self::Error> {
+        let kvps = KeyValuePairs::try_from_iter(iter)?;
+        Ok(Self(kvps))
     }
 }
 

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -140,6 +140,31 @@ impl Label {
 ///
 /// It provides selected associated functions to manipulate the set of labels,
 /// like inserting or extending.
+///
+/// ## Examples
+///
+/// ### Converting a BTreeMap into a list of labels
+///
+/// ```
+/// # use std::collections::BTreeMap;
+/// # use stackable_operator::kvp::Labels;
+/// let map = BTreeMap::from([
+///     ("stackable.tech/managed-by", "stackablectl"),
+///     ("stackable.tech/vendor", "Stackable"),
+/// ]);
+///
+/// let labels = Labels::try_from(map).unwrap();
+/// ```
+///
+/// ### Creating a list of labels from an array
+///
+/// ```
+/// # use stackable_operator::kvp::Labels;
+/// let labels = Labels::try_from([
+///     ("stackable.tech/managed-by", "stackablectl"),
+///     ("stackable.tech/vendor", "Stackable"),
+/// ]).unwrap();
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct Labels(KeyValuePairs<LabelValue>);
 
@@ -151,8 +176,7 @@ where
     type Error = LabelError;
 
     fn try_from(map: BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(map)?;
-        Ok(Self(kvps))
+        Self::try_from_iter(map)
     }
 }
 
@@ -164,8 +188,7 @@ where
     type Error = LabelError;
 
     fn try_from(map: &BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(map)?;
-        Ok(Self(kvps))
+        Self::try_from_iter(map)
     }
 }
 
@@ -176,9 +199,8 @@ where
 {
     type Error = LabelError;
 
-    fn try_from(value: [(K, V); N]) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from(value)?;
-        Ok(Self(kvps))
+    fn try_from(array: [(K, V); N]) -> Result<Self, Self::Error> {
+        Self::try_from_iter(array)
     }
 }
 

--- a/src/kvp/label/mod.rs
+++ b/src/kvp/label/mod.rs
@@ -18,6 +18,7 @@ use delegate::delegate;
 use kube::{Resource, ResourceExt};
 
 use crate::{
+    iter::TryFromIterator,
     kvp::{
         consts::{
             K8S_APP_COMPONENT_KEY, K8S_APP_INSTANCE_KEY, K8S_APP_MANAGED_BY_KEY, K8S_APP_NAME_KEY,
@@ -185,6 +186,19 @@ impl FromIterator<KeyValuePair<LabelValue>> for Labels {
     fn from_iter<T: IntoIterator<Item = KeyValuePair<LabelValue>>>(iter: T) -> Self {
         let kvps = KeyValuePairs::from_iter(iter);
         Self(kvps)
+    }
+}
+
+impl<K, V> TryFromIterator<(K, V)> for Labels
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    type Error = LabelError;
+
+    fn try_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Result<Self, Self::Error> {
+        let kvps = KeyValuePairs::try_from_iter(iter)?;
+        Ok(Self(kvps))
     }
 }
 

--- a/src/kvp/mod.rs
+++ b/src/kvp/mod.rs
@@ -160,30 +160,7 @@ pub enum KeyValuePairsError {
 ///
 /// - `From<KeyValuePairs<T>> for BTreeMap<String, String>`
 ///
-/// ## Examples
-///
-/// ### Converting a BTreeMap into a list of labels
-///
-/// ```
-/// # use std::collections::BTreeMap;
-/// # use stackable_operator::kvp::Labels;
-/// let map = BTreeMap::from([
-///     ("stackable.tech/managed-by", "stackablectl"),
-///     ("stackable.tech/vendor", "Stackable"),
-/// ]);
-///
-/// let labels = Labels::try_from(map).unwrap();
-/// ```
-///
-/// ### Creating a list of labels from an array
-///
-/// ```
-/// # use stackable_operator::kvp::Labels;
-/// let labels = Labels::try_from([
-///     ("stackable.tech/managed-by", "stackablectl"),
-///     ("stackable.tech/vendor", "Stackable"),
-/// ]).unwrap();
-/// ```
+/// See [`Labels`] and [`Annotations`] on how these traits can be used.
 #[derive(Clone, Debug, Default)]
 pub struct KeyValuePairs<T: Value>(BTreeSet<KeyValuePair<T>>);
 
@@ -196,12 +173,7 @@ where
     type Error = KeyValuePairError<T::Error>;
 
     fn try_from(map: BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let pairs = map
-            .iter()
-            .map(KeyValuePair::try_from)
-            .collect::<Result<BTreeSet<_>, KeyValuePairError<T::Error>>>()?;
-
-        Ok(Self(pairs))
+        Self::try_from_iter(map)
     }
 }
 
@@ -214,12 +186,7 @@ where
     type Error = KeyValuePairError<T::Error>;
 
     fn try_from(map: &BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        let pairs = map
-            .iter()
-            .map(KeyValuePair::try_from)
-            .collect::<Result<BTreeSet<_>, KeyValuePairError<T::Error>>>()?;
-
-        Ok(Self(pairs))
+        Self::try_from_iter(map)
     }
 }
 
@@ -232,13 +199,7 @@ where
     type Error = KeyValuePairError<T::Error>;
 
     fn try_from(array: [(K, V); N]) -> Result<Self, Self::Error> {
-        let mut pairs = KeyValuePairs::new();
-
-        for item in array {
-            pairs.insert(KeyValuePair::try_from(item)?);
-        }
-
-        Ok(pairs)
+        Self::try_from_iter(array)
     }
 }
 
@@ -260,13 +221,12 @@ where
     type Error = KeyValuePairError<T::Error>;
 
     fn try_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Result<Self, Self::Error> {
-        let mut set = BTreeSet::new();
+        let pairs = iter
+            .into_iter()
+            .map(KeyValuePair::try_from)
+            .collect::<Result<BTreeSet<_>, KeyValuePairError<T::Error>>>()?;
 
-        for pair in iter {
-            set.insert(KeyValuePair::try_from(pair)?);
-        }
-
-        Ok(Self(set))
+        Ok(Self(pairs))
     }
 }
 


### PR DESCRIPTION
Fixes #713

It does not directly solve the issue, but `.collect()` only works on types which implement `FromIterator` which must never fail. Implementing `FromIterator for Result<Self, Error>` is also not an option, because we cannot implement a foreign trait on a foreign type. There are now two possible solutions.

#### Old

```rust
let map = BTreeMap::from([
    ("stackable.tech/managed-by", "stackablectl"),
    ("stackable.tech/vendor", "Stackable"),
]);

let labels = map
    .iter()
    .map(|p| Label::try_from(p))
    .collect::<Result<Vec<Label>, LabelError>>()
    .unwrap();

let labels = Labels::from_iter(labels);
```

#### New

```rust
let map = BTreeMap::from([
    ("stackable.tech/managed-by", "stackablectl"),
    ("stackable.tech/vendor", "Stackable"),
]);

// Works on any iterator, like Vec<(String, String)> or &[(&str, &str)]
let labels = Labels::try_from_iter(map).unwrap();
```