### PR TITLE
Add ListenerOperatorVolumeSourceBuilder::build_pvc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added `Option::as_ref_or_else` to `utils` ([#717]).
+- Added `ListenerOperatorVolumeSourceBuilder::build_pvc` ([#719]).
 
 ### Changed
 
 - Split `utils` into submodules ([#717]).
+- Renamed `ListenerOperatorVolumeSourceBuilder::build` to `::build_ephemeral` ([#719]).
 
 [#717]: https://github.com/stackabletech/operator-rs/pull/717
+[#719]: https://github.com/stackabletech/operator-rs/pull/719
 
 ## [0.61.0] - 2024-01-15
 

--- a/src/builder/pod/mod.rs
+++ b/src/builder/pod/mod.rs
@@ -351,7 +351,7 @@ impl PodBuilder {
     ) -> Result<&mut Self> {
         let listener_reference = ListenerReference::ListenerClass(listener_class.to_string());
         let volume = ListenerOperatorVolumeSourceBuilder::new(&listener_reference)
-            .build()
+            .build_ephemeral()
             .context(ListenerVolumeSnafu { name: volume_name })?;
 
         self.add_volume(Volume {
@@ -440,7 +440,7 @@ impl PodBuilder {
     ) -> Result<&mut Self> {
         let listener_reference = ListenerReference::ListenerName(listener_name.to_string());
         let volume = ListenerOperatorVolumeSourceBuilder::new(&listener_reference)
-            .build()
+            .build_ephemeral()
             .context(ListenerVolumeSnafu { name: volume_name })?;
 
         self.add_volume(Volume {


### PR DESCRIPTION
# Description

Persistent analogue of `::build()` that is suitable for deploying directly, or for adding to a StatefulSet. Also renamed `::build()` to `::build_ephemeral()` for parity (and to clarify that it isn't, and shouldn't be, the default).

Extracted from https://github.com/stackabletech/hdfs-operator/pull/450.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
