### PR TITLE
Derive Hash and Ord instances for AuthenticationClassProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ All notable changes to this project will be documented in this file.
 
 - Add Serde `Deserialize` and `Serialize` support for `CpuQuantity` and `MemoryQuantity` ([#724]).
 - Add `DynamicValues` struct to work with operator `values.yaml` files during runtime ([#723]).
+- Derive `Hash` and `Ord` instances for `AuthenticationClassProvider`,
+  so that duplicates can be detected ([#731]).
 
 [#723]: https://github.com/stackabletech/operator-rs/pull/723
 [#724]: https://github.com/stackabletech/operator-rs/pull/724
+[#731]: https://github.com/stackabletech/operator-rs/pull/731
 
 ### Changed
 

--- a/src/commons/authentication/ldap.rs
+++ b/src/commons/authentication/ldap.rs
@@ -31,7 +31,9 @@ pub enum Error {
     AddLdapTlsClientDetailsVolumes { source: TlsClientDetailsError },
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticationProvider {
     /// Hostname of the LDAP server, for example: `my.ldap.server`.
@@ -155,7 +157,9 @@ impl AuthenticationProvider {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldNames {
     /// The name of the username field

--- a/src/commons/authentication/mod.rs
+++ b/src/commons/authentication/mod.rs
@@ -20,7 +20,19 @@ pub(crate) const SECRET_BASE_PATH: &str = "/stackable/secrets";
 /// Multiple different authentication providers are supported.
 /// Learn more in the [authentication concept documentation](DOCS_BASE_URL_PLACEHOLDER/concepts/authentication) and the
 /// [Authentication with OpenLDAP tutorial](DOCS_BASE_URL_PLACEHOLDER/tutorials/authentication_with_openldap).
-#[derive(Clone, CustomResource, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone,
+    CustomResource,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    JsonSchema,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+)]
 #[kube(
     group = "authentication.stackable.tech",
     version = "v1alpha1",
@@ -38,7 +50,9 @@ pub struct AuthenticationClassSpec {
     pub provider: AuthenticationClassProvider,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Display, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum AuthenticationClassProvider {

--- a/src/commons/authentication/oidc.rs
+++ b/src/commons/authentication/oidc.rs
@@ -35,7 +35,9 @@ pub enum Error {
 /// (IdP) `hostname` and the TLS configuration. The `port` is selected
 /// automatically if not configured otherwise. The `rootPath` defaults
 /// to `/`.
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticationProvider {
     /// Hostname of the identity provider, e.g. `my.keycloak.corp`.
@@ -206,14 +208,18 @@ impl AuthenticationProvider {
 /// in the product operator. Some products require special handling of
 /// authentication related config options. This hint can be used to enable such
 /// special handling.
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "PascalCase")]
 pub enum IdentityProviderHint {
     Keycloak,
 }
 
 /// OIDC specific config options. These are set on the product config level.
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientAuthenticationOptions<T = ()> {
     /// A reference to the OIDC client credentials secret. The secret contains

--- a/src/commons/authentication/static_.rs
+++ b/src/commons/authentication/static_.rs
@@ -22,7 +22,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticationProvider {
     /// Secret providing the usernames and passwords.
@@ -31,7 +33,9 @@ pub struct AuthenticationProvider {
     pub user_credentials_secret: UserCredentialsSecretRef,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct UserCredentialsSecretRef {
     /// Name of the Secret.

--- a/src/commons/authentication/tls.rs
+++ b/src/commons/authentication/tls.rs
@@ -11,7 +11,9 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticationProvider {
     /// See [ADR017: TLS authentication](DOCS_BASE_URL_PLACEHOLDER/contributor/adr/adr017-tls_authentication).
@@ -27,7 +29,9 @@ pub enum TlsClientDetailsError {
     SecretClassVolume { source: SecretClassVolumeError },
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsClientDetails {
     /// Use a TLS connection. If not specified no TLS will be used.
@@ -119,14 +123,18 @@ impl TlsClientDetails {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct Tls {
     /// The verification method used to verify the certificates of the server and/or the client.
     pub verification: TlsVerification,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum TlsVerification {
     /// Use TLS but don't verify certificates.
@@ -136,14 +144,18 @@ pub enum TlsVerification {
     Server(TlsServerVerification),
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsServerVerification {
     /// CA cert to verify the server.
     pub ca_cert: CaCert,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum CaCert {
     /// Use TLS and the CA certificates trusted by the common web browsers to verify the server.

--- a/src/commons/secret_class.rs
+++ b/src/commons/secret_class.rs
@@ -15,7 +15,9 @@ pub enum SecretClassVolumeError {
     },
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretClassVolume {
     /// [SecretClass](DOCS_BASE_URL_PLACEHOLDER/secret-operator/secretclass) containing the LDAP bind credentials.
@@ -63,7 +65,9 @@ impl SecretClassVolume {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, Hash, JsonSchema, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretClassVolumeScope {
     /// The pod scope is resolved to the name of the Kubernetes Pod.


### PR DESCRIPTION
# Description

Derive `Hash` and `Ord` instances for `AuthenticationClassProvider`, so that duplicates can be detected.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
