### PR TITLE
refactor: Remove `resources` key from DynamicValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Changed
+
+- Remove `resources` key from `DynamicValues` struct ([#734]).
+
+[#734]: https://github.com/stackabletech/operator-rs/pull/734
+
 ## [0.64.0] - 2024-01-31
 
 ### Added

--- a/fixtures/helm/input-additional.yaml
+++ b/fixtures/helm/input-additional.yaml
@@ -10,13 +10,6 @@ serviceAccount:
   create: true
   annotations: {}
   name: ''
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
 labels:
   stackable.tech/vendor: Stackable
   stackable.tech/managed-by: stackablectl

--- a/fixtures/helm/input-required.yaml
+++ b/fixtures/helm/input-required.yaml
@@ -10,13 +10,6 @@ serviceAccount:
   create: true
   annotations: {}
   name: ''
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
 labels:
   stackable.tech/vendor: Stackable
   stackable.tech/managed-by: stackablectl

--- a/fixtures/helm/output.yaml
+++ b/fixtures/helm/output.yaml
@@ -9,13 +9,6 @@ serviceAccount:
   create: true
   annotations: {}
   name: ''
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
 labels:
   stackable.tech/demo: logging
   stackable.tech/managed-by: stackablectl

--- a/src/helm/mod.rs
+++ b/src/helm/mod.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::core::v1::LocalObjectReference;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    commons::product_image_selection::PullPolicy, cpu::CpuQuantity, memory::MemoryQuantity,
-};
+use crate::commons::product_image_selection::PullPolicy;
 
 static EMPTY_MAP: BTreeMap<String, String> = BTreeMap::new();
 
@@ -21,7 +19,6 @@ pub struct DynamicValues {
     pub name_override: String,
     pub fullname_override: String,
     pub service_account: ServiceAccountValues,
-    pub resources: ResourceValues,
 
     // TODO(Techassi): Here we could use direct Serialize and Deserialize support
     pub labels: Option<BTreeMap<String, String>>,
@@ -74,20 +71,6 @@ pub struct ServiceAccountValues {
     /// If this is not set and `create` is true, a name is generated using the
     /// fullname template.
     pub name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ResourceValues {
-    limits: ComputeResourceValues,
-    requests: ComputeResourceValues,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ComputeResourceValues {
-    cpu: CpuQuantity,
-    memory: MemoryQuantity,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/188, discussed in today's (2024-02-01) meeting, see https://github.com/stackabletech/issues/issues/188#issuecomment-1920967373.