### PR TITLE
instant -= duration should actually.. subtract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Remove `resources` key from `DynamicValues` struct ([#734]).
 
+## Fixed
+
+- Fixed incorrect time calculation ([#735]).
+
 [#734]: https://github.com/stackabletech/operator-rs/pull/734
+[#735]: https://github.com/stackabletech/operator-rs/pull/735
 
 ## [0.64.0] - 2024-01-31
 

--- a/src/time/duration.rs
+++ b/src/time/duration.rs
@@ -233,19 +233,19 @@ impl Add<Duration> for std::time::Instant {
     type Output = Self;
 
     fn add(self, rhs: Duration) -> Self::Output {
-        self.add(rhs.0)
+        self + rhs.0
     }
 }
 
 impl AddAssign for Duration {
     fn add_assign(&mut self, rhs: Self) {
-        self.0.add_assign(rhs.0)
+        self.0 += rhs.0
     }
 }
 
 impl AddAssign<Duration> for std::time::Instant {
     fn add_assign(&mut self, rhs: Duration) {
-        self.add_assign(rhs.0)
+        *self += rhs.0
     }
 }
 
@@ -261,19 +261,19 @@ impl Sub<Duration> for std::time::Instant {
     type Output = Self;
 
     fn sub(self, rhs: Duration) -> Self::Output {
-        self.sub(rhs.0)
+        self - rhs.0
     }
 }
 
 impl SubAssign for Duration {
     fn sub_assign(&mut self, rhs: Self) {
-        self.0.sub_assign(rhs.0)
+        self.0 -= rhs.0
     }
 }
 
 impl SubAssign<Duration> for std::time::Instant {
     fn sub_assign(&mut self, rhs: Duration) {
-        self.sub_assign(rhs.0)
+        *self -= rhs.0
     }
 }
 

--- a/src/time/duration.rs
+++ b/src/time/duration.rs
@@ -273,7 +273,7 @@ impl SubAssign for Duration {
 
 impl SubAssign<Duration> for std::time::Instant {
     fn sub_assign(&mut self, rhs: Duration) {
-        self.add_assign(rhs.0)
+        self.sub_assign(rhs.0)
     }
 }
 


### PR DESCRIPTION
# Description

`instant -= duration` is currently defined as `instant += duration`, which is clearly the opposite of what the user requested.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
