### PR TITLE
refactor!: Default TlsClientDetails to webPki

### DIFF
--- a/src/commons/authentication/ldap.rs
+++ b/src/commons/authentication/ldap.rs
@@ -226,8 +226,8 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(ldap.port(), 389);
-        assert!(!ldap.tls.uses_tls());
+        assert_eq!(ldap.port(), 636);
+        assert!(ldap.tls.uses_tls());
         assert_eq!(ldap.tls.tls_ca_cert_secret_class(), None);
     }
 

--- a/src/commons/authentication/oidc.rs
+++ b/src/commons/authentication/oidc.rs
@@ -283,7 +283,7 @@ mod test {
 
         assert_eq!(
             oidc.endpoint_url().unwrap().as_str(),
-            "http://my.keycloak.server:12345/my-root-path"
+            "https://my.keycloak.server:12345/my-root-path"
         );
     }
 
@@ -328,7 +328,7 @@ mod test {
 
         assert_eq!(
             oidc.endpoint_url().unwrap().as_str(),
-            "http://[2606:2800:220:1:248:1893:25c8:1946]:12345/my-root-path"
+            "https://[2606:2800:220:1:248:1893:25c8:1946]:12345/my-root-path"
         );
     }
 

--- a/src/commons/authentication/tls.rs
+++ b/src/commons/authentication/tls.rs
@@ -35,7 +35,16 @@ pub enum TlsClientDetailsError {
 #[serde(rename_all = "camelCase")]
 pub struct TlsClientDetails {
     /// Use a TLS connection. If not specified no TLS will be used.
+    #[serde(default = "default_tls")]
     pub tls: Option<Tls>,
+}
+
+fn default_tls() -> Option<Tls> {
+    Some(Tls {
+        verification: TlsVerification::Server(TlsServerVerification {
+            ca_cert: CaCert::WebPki {},
+        }),
+    })
 }
 
 impl TlsClientDetails {


### PR DESCRIPTION
# Description

DO NOT MERGE, demonstration purpose only. Also missing a Changelog entry, which warns all operators - which in turn need a BREAKING changelog entry as this is a gigabreaking change for them.

Diff e.g. in opa-operator:
```
--- a/deploy/helm/opa-operator/crds/crds.yaml
+++ b/deploy/helm/opa-operator/crds/crds.yaml
@@ -107,6 +107,11 @@ spec:
                                   description: Root HTTP path of the identity provider. Defaults to `/`.
                                   type: string
                                 tls:
+                                  default:
+                                    verification:
+                                      server:
+                                        caCert:
+                                          webPki: {}
                                   description: Use a TLS connection. If not specified no TLS will be used.
                                   nullable: true
                                   properties:
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
