### PR TITLE
chore: Move k8s-openapi dependency in `stackable-webhook`

### DIFF
--- a/stackable-webhook/Cargo.toml
+++ b/stackable-webhook/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 
 [dependencies]
 axum = "0.7.4"
+k8s-openapi = { version = "0.21.0", default-features = false, features = [
+  "v1_28",
+] }
 kube = { version = "0.88.1", default-features = false }
 tokio-rustls = "0.25.0"
 serde_json = "1.0.104"
@@ -21,8 +24,3 @@ rustls-pemfile = "2.0.0"
 futures-util = "0.3.30"
 hyper-util = "0.1.3"
 hyper = { version = "1.0.0", features = ["full"] }
-
-[dev-dependencies]
-k8s-openapi = { version = "0.21.0", default-features = false, features = [
-  "v1_28",
-] }


### PR DESCRIPTION
Moving the dependency from `dev-dependencies` to `dependencies` resolves issues when using the library in downstream projects, like the product operators.

This came up while writing the webhooks implementation guide (see https://github.com/stackabletech/documentation/pull/561).