### PR TITLE
feat: Add re-export for ConversionReview type in `stackable-webhook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ## Added
 
 - Add `stackable_webhook` crate which provides utilities to create webhooks with TLS termination ([#730]).
+- Add `ConversionReview` re-export in `stackable_webhook` crate ([#749]).
 
 [#730]: https://github.com/stackabletech/operator-rs/pull/730
+[#730]: https://github.com/stackabletech/operator-rs/pull/749
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add `ConversionReview` re-export in `stackable_webhook` crate ([#749]).
 
 [#730]: https://github.com/stackabletech/operator-rs/pull/730
-[#730]: https://github.com/stackabletech/operator-rs/pull/749
+[#749]: https://github.com/stackabletech/operator-rs/pull/749
 
 ## Changed
 

--- a/stackable-webhook/src/lib.rs
+++ b/stackable-webhook/src/lib.rs
@@ -35,7 +35,7 @@ pub mod servers;
 pub mod tls;
 
 // Selected re-exports
-pub use crate::{options::Options, servers::ConversionWebhookServer};
+pub use crate::options::Options;
 
 /// A result type alias with the library-level [`Error`] type as teh default
 /// error type.

--- a/stackable-webhook/src/servers/conversion.rs
+++ b/stackable-webhook/src/servers/conversion.rs
@@ -3,7 +3,10 @@ use std::fmt::Debug;
 use axum::{extract::State, routing::post, Json, Router};
 use tracing::{debug, instrument};
 
-// Selected re-exports
+// Re-export this type because users of the conversion webhook server require
+// this type to write the handler function. Instead of importing this type from
+// kube directly, consumers can use this type instead. This also eliminates
+// keeping the kube dependency version in sync between here and the operator.
 pub use kube::core::conversion::ConversionReview;
 
 use crate::{options::Options, StatefulWebhookHandler, WebhookHandler, WebhookServer};

--- a/stackable-webhook/src/servers/conversion.rs
+++ b/stackable-webhook/src/servers/conversion.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use axum::{extract::State, routing::post, Json, Router};
-use kube::core::conversion::ConversionReview;
+pub use kube::core::conversion::ConversionReview;
 use tracing::{debug, instrument};
 
 use crate::{options::Options, StatefulWebhookHandler, WebhookHandler, WebhookServer};

--- a/stackable-webhook/src/servers/conversion.rs
+++ b/stackable-webhook/src/servers/conversion.rs
@@ -1,8 +1,10 @@
 use std::fmt::Debug;
 
 use axum::{extract::State, routing::post, Json, Router};
-pub use kube::core::conversion::ConversionReview;
 use tracing::{debug, instrument};
+
+// Selected re-exports
+pub use kube::core::conversion::ConversionReview;
 
 use crate::{options::Options, StatefulWebhookHandler, WebhookHandler, WebhookServer};
 
@@ -39,13 +41,16 @@ impl ConversionWebhookServer {
     ///
     /// Each request is handled by the provided `handler` function. Any function
     /// with the signature `(ConversionReview) -> ConversionReview` can be
-    /// provided.
+    /// provided. The [`ConversionReview`] type can be imported via a re-export at
+    /// [`stackable_webhook::server::ConversionReview`].
     ///
     /// # Example
     ///
     /// ```
-    /// use stackable_webhook::{servers::ConversionWebhookServer, Options};
-    /// use kube::core::conversion::ConversionReview;
+    /// use stackable_webhook::{
+    ///     servers::{ConversionReview, ConversionWebhookServer},
+    ///     Options
+    /// };
     ///
     /// // Construct the conversion webhook server
     /// let server = ConversionWebhookServer::new(handler, Options::default());
@@ -77,7 +82,8 @@ impl ConversionWebhookServer {
     ///
     /// Each request is handled by the provided `handler` function. Any function
     /// with the signature `(ConversionReview, S) -> ConversionReview` can be
-    /// provided.
+    /// provided. The [`ConversionReview`] type can be imported via a re-export at
+    /// [`stackable_webhook::server::ConversionReview`].
     ///
     /// It is recommended to wrap the state in an [`Arc`][std::sync::Arc] if it
     /// needs to be mutable, see
@@ -88,8 +94,10 @@ impl ConversionWebhookServer {
     /// ```
     /// use std::sync::Arc;
     ///
-    /// use stackable_webhook::{servers::ConversionWebhookServer, Options};
-    /// use kube::core::conversion::ConversionReview;
+    /// use stackable_webhook::{
+    ///     servers::{ConversionReview, ConversionWebhookServer},
+    ///     Options
+    /// };
     ///
     /// #[derive(Debug, Clone)]
     /// struct State {}


### PR DESCRIPTION
This adds a little more convenience when using `ConversionWebhookServer`. Users now don't need an additional explicit dependency on `kube` to import the required type.

Came up in https://github.com/stackabletech/documentation/pull/561