### PR TITLE
chore(deps): Bump Rust dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 - Remove `resources` key from `DynamicValues` struct ([#734]).
+- Bump `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-jaeger`, and `tracing-opentelemetry` Rust dependencies.
+
+[#734]: https://github.com/stackabletech/operator-rs/pull/734
 
 ## Fixed
 
 - Fixed incorrect time calculation ([#735]).
 
-[#734]: https://github.com/stackabletech/operator-rs/pull/734
 [#735]: https://github.com/stackabletech/operator-rs/pull/735
 
 ## [0.64.0] - 2024-01-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 - Remove `resources` key from `DynamicValues` struct ([#734]).
-- Bump `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-jaeger`, and `tracing-opentelemetry` Rust dependencies.
+- Bump `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-jaeger`, and `tracing-opentelemetry` Rust dependencies
+  ([#753]).
 
 [#734]: https://github.com/stackabletech/operator-rs/pull/734
+[#753]: https://github.com/stackabletech/operator-rs/pull/753
 
 ## Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ k8s-openapi = { version = "0.21.0", default-features = false, features = ["schem
 # We use rustls instead of openssl for easier portablitly, e.g. so that we can build stackablectl without the need to vendor (build from source) openssl
 kube = { version = "0.88.1", default-features = false, features = ["client","jsonpatch","runtime","derive","rustls-tls"] }
 lazy_static = "1.4.0"
-opentelemetry = "0.21.0"
-opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.20.0", features = ["rt-tokio"] }
+opentelemetry = "0.22.0"
+opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.21.0", features = ["rt-tokio"] }
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 proc-macro2 = "1.0.66"
 quote = "1.0.32"
@@ -57,12 +57,12 @@ tempfile = "3.7.1"
 thiserror = "1.0.44"
 time = { version = "0.3.29" }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "fs"] }
-tokio-rustls = "0.25.0"
+tokio-rustls = "0.26.0"
 tokio-test = "0.4.3"
 tower = "0.4.13"
 tower-http = { version = "0.5.1", features = ["trace"] }
 tracing = "0.1.37"
-tracing-opentelemetry = "0.22.0"
+tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.4.1"
 x509-cert = { version = "0.2.5", features = ["builder"] }

--- a/crates/stackable-operator/src/logging/mod.rs
+++ b/crates/stackable-operator/src/logging/mod.rs
@@ -35,6 +35,8 @@ pub fn initialize_logging(env: &str, app_name: &str, tracing_target: TracingTarg
     match tracing_target {
         TracingTarget::None => registry.init(),
         TracingTarget::Jaeger => {
+            // FIXME (@Techassi): Replace with opentelemetry_otlp
+            #[allow(deprecated)]
             let jaeger = opentelemetry_jaeger::new_agent_pipeline()
                 .with_service_name(app_name)
                 .install_batch(opentelemetry_sdk::runtime::Tokio)

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib",
     "Unlicense",
+    "OpenSSL"
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
This PR bumps various Rust dependencies. The changes pass the tests and `cargo check`.

The `opentelemetry-jaeger` crate was recently deprecated for `opentelemetry-otlp`, because Jaeger now natively supports the OTEL protocol. This requires a follow-up PR implementing the required changes.
