### PR TITLE
chore: implement PartialEq for most Snafu Error enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 - Remove `resources` key from `DynamicValues` struct ([#734]).
+- Implement `PartialEq` for most _Snafu_ Error enums ([#757]).
 
 ## Fixed
 
@@ -22,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 [#734]: https://github.com/stackabletech/operator-rs/pull/734
 [#735]: https://github.com/stackabletech/operator-rs/pull/735
+[#757]: https://github.com/stackabletech/operator-rs/pull/757
 
 ## [0.64.0] - 2024-01-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ futures-util = "0.3.30"
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = "0.1.3"
 json-patch = "1.0.0"
-k8s-openapi = { version = "0.21.0", default-features = false, features = ["schemars","v1_28"] }
+k8s-openapi = { version = "0.21.0", default-features = false, features = ["schemars", "v1_28"] }
 # We use rustls instead of openssl for easier portablitly, e.g. so that we can build stackablectl without the need to vendor (build from source) openssl
-kube = { version = "0.88.1", default-features = false, features = ["client","jsonpatch","runtime","derive","rustls-tls"] }
+kube = { version = "0.88.1", default-features = false, features = ["client", "jsonpatch", "runtime", "derive", "rustls-tls"] }
 lazy_static = "1.4.0"
 opentelemetry = "0.21.0"
 opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio"] }
@@ -51,7 +51,7 @@ sha2 = { version = "0.10.8", features = ["oid"] }
 signature = "2.2.0"
 snafu = "0.8.0"
 stackable-operator-derive = { path = "stackable-operator-derive" }
-strum = { version = "0.26.1", features = ["derive"] }
+strum = { version = "0.26.2", features = ["derive"] }
 syn = "2.0.28"
 tempfile = "3.7.1"
 thiserror = "1.0.44"

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -32,7 +32,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Defines all error variants which can occur when creating a CA and/or leaf
 /// certificates.
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("failed to generate RSA signing key"))]
     GenerateRsaSigningKey { source: rsa::Error },
@@ -70,7 +70,7 @@ pub enum Error {
 
 /// Defines all error variants which can occur when loading a CA from a
 /// Kubernetes [`Secret`].
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum SecretError<E>
 where
     E: std::error::Error + 'static,

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -32,7 +32,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Defines all error variants which can occur when creating a CA and/or leaf
 /// certificates.
-#[derive(Debug, PartialEq, Snafu)]
+#[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("failed to generate RSA signing key"))]
     GenerateRsaSigningKey { source: rsa::Error },
@@ -68,9 +68,51 @@ pub enum Error {
     ParseAuthorityKeyIdentifier { source: x509_cert::der::Error },
 }
 
+/// Custom implementation of [`std::cmp::PartialEq`] because some inner types
+/// don't implement it.
+///
+/// Note that this implementation is restritced to testing because there is a
+/// variant that is impossible to compare, and will cause a panic if it
+/// attemped.
+#[cfg(test)]
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::CreateCertificateBuilder { source: lhs_source },
+                Self::CreateCertificateBuilder { source: rhs_source },
+            )
+            | (
+                Self::AddCertificateExtension { source: lhs_source },
+                Self::AddCertificateExtension { source: rhs_source },
+            )
+            | (
+                Self::BuildCertificate { source: lhs_source },
+                Self::BuildCertificate { source: rhs_source },
+            ) => match (lhs_source, rhs_source) {
+                (x509_cert::builder::Error::Asn1(lhs), x509_cert::builder::Error::Asn1(rhs)) => {
+                    lhs == rhs
+                }
+                (
+                    x509_cert::builder::Error::PublicKey(lhs),
+                    x509_cert::builder::Error::PublicKey(rhs),
+                ) => lhs == rhs,
+                (
+                    x509_cert::builder::Error::Signature(_),
+                    x509_cert::builder::Error::Signature(_),
+                ) => panic!(
+                    "it is impossible to compare the opaque Error contained witin signature::error::Error"
+                ),
+                _ => false,
+            },
+            (lhs, rhs) => lhs == rhs,
+        }
+    }
+}
+
 /// Defines all error variants which can occur when loading a CA from a
 /// Kubernetes [`Secret`].
-#[derive(Debug, PartialEq, Snafu)]
+#[derive(Debug, Snafu)]
 pub enum SecretError<E>
 where
     E: std::error::Error + 'static,

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -72,7 +72,7 @@ pub enum Error {
 /// don't implement it.
 ///
 /// Note that this implementation is restritced to testing because there is a
-/// variant that is impossible to compare, and will cause a panic if it
+/// variant that is impossible to compare, and will cause a panic if it is
 /// attemped.
 #[cfg(test)]
 impl PartialEq for Error {

--- a/crates/stackable-certs/src/keys/ecdsa.rs
+++ b/crates/stackable-certs/src/keys/ecdsa.rs
@@ -10,7 +10,7 @@ use crate::keys::CertificateKeypair;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(context(false))]
     SerializeKeyToPem { source: x509_cert::spki::Error },

--- a/crates/stackable-certs/src/keys/rsa.rs
+++ b/crates/stackable-certs/src/keys/rsa.rs
@@ -13,7 +13,7 @@ const KEY_SIZE: usize = 4096;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("failed to create RSA key"))]
     CreateKey { source: rsa::Error },

--- a/crates/stackable-certs/src/lib.rs
+++ b/crates/stackable-certs/src/lib.rs
@@ -39,7 +39,7 @@ pub mod keys;
 
 /// Error variants which can be encountered when creating a new
 /// [`CertificatePair`].
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum CertificatePairError<E>
 where
     E: std::error::Error + 'static,

--- a/crates/stackable-operator/src/builder/meta.rs
+++ b/crates/stackable-operator/src/builder/meta.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 // NOTE (Techassi): Think about that name
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum ObjectMetaBuilderError {
     #[snafu(display("failed to set recommended labels"))]
     RecommendedLabels { source: LabelError },

--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -33,7 +33,7 @@ pub mod resources;
 pub mod security;
 pub mod volume;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("termination grace period is too long (got {duration}, maximum allowed is {max})", max = Duration::from_secs(i64::MAX as u64)))]
     TerminationGracePeriodTooLong {

--- a/crates/stackable-operator/src/builder/pod/volume.rs
+++ b/crates/stackable-operator/src/builder/pod/volume.rs
@@ -262,7 +262,7 @@ impl VolumeMountBuilder {
     }
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum SecretOperatorVolumeSourceBuilderError {
     #[snafu(display("failed to parse secret operator volume annotation"))]
     ParseAnnotation { source: AnnotationError },
@@ -414,7 +414,7 @@ impl ListenerReference {
 
 // NOTE (Techassi): We might want to think about these names and how long they
 // are getting.
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum ListenerOperatorVolumeSourceBuilderError {
     #[snafu(display("failed to convert listener reference into Kubernetes annotation"))]
     ListenerReferenceAnnotation { source: AnnotationError },

--- a/crates/stackable-operator/src/commons/authentication/ldap.rs
+++ b/crates/stackable-operator/src/commons/authentication/ldap.rs
@@ -17,7 +17,7 @@ use crate::{
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display(
         "failed to convert bind credentials (secret class volume) into named Kubernetes volume"

--- a/crates/stackable-operator/src/commons/authentication/oidc.rs
+++ b/crates/stackable-operator/src/commons/authentication/oidc.rs
@@ -19,7 +19,7 @@ pub const DEFAULT_OIDC_WELLKNOWN_PATH: &str = ".well-known/openid-configuration"
 pub const CLIENT_ID_SECRET_KEY: &str = "clientId";
 pub const CLIENT_SECRET_SECRET_KEY: &str = "clientSecret";
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("failed to parse OIDC endpoint url"))]
     ParseOidcEndpointUrl { source: ParseError },

--- a/crates/stackable-operator/src/commons/authentication/tls.rs
+++ b/crates/stackable-operator/src/commons/authentication/tls.rs
@@ -23,7 +23,7 @@ pub struct AuthenticationProvider {
     pub client_cert_secret_class: Option<String>,
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum TlsClientDetailsError {
     #[snafu(display("failed to convert secret class volume into named Kubernetes volume"))]
     SecretClassVolume { source: SecretClassVolumeError },

--- a/crates/stackable-operator/src/commons/secret_class.rs
+++ b/crates/stackable-operator/src/commons/secret_class.rs
@@ -7,7 +7,7 @@ use crate::builder::{
     SecretOperatorVolumeSourceBuilder, SecretOperatorVolumeSourceBuilderError, VolumeBuilder,
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum SecretClassVolumeError {
     #[snafu(display("failed to build secret operator volume"))]
     SecretOperatorVolume {

--- a/crates/stackable-operator/src/config/fragment.rs
+++ b/crates/stackable-operator/src/config/fragment.rs
@@ -58,7 +58,7 @@ impl<'a> Validator<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct FieldPath {
     idents: Vec<String>,
 }
@@ -74,7 +74,7 @@ impl Display for FieldPath {
     }
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 #[snafu(display("failed to validate {path}"))]
 /// An error that occurred when validating an object.
 ///
@@ -85,7 +85,7 @@ pub struct ValidationError {
     problem: ValidationProblem,
 }
 /// A problem that was discovered during validation, with no additional context.
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 enum ValidationProblem {
     #[snafu(display("field is required"))]
     FieldRequired,

--- a/crates/stackable-operator/src/kvp/mod.rs
+++ b/crates/stackable-operator/src/kvp/mod.rs
@@ -150,7 +150,7 @@ where
     }
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum KeyValuePairsError {
     #[snafu(display("key/value pair already exists"))]
     PairAlreadyExists,

--- a/crates/stackable-operator/src/product_config_utils.rs
+++ b/crates/stackable-operator/src/product_config_utils.rs
@@ -11,7 +11,7 @@ use crate::{
     role_utils::{CommonConfiguration, Role},
 };
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum ConfigError {
     #[snafu(display("Invalid configuration found: {reason}"))]
     InvalidConfiguration { reason: String },

--- a/crates/stackable-operator/src/time/duration.rs
+++ b/crates/stackable-operator/src/time/duration.rs
@@ -25,7 +25,7 @@ use schemars::JsonSchema;
 use snafu::{OptionExt, ResultExt, Snafu};
 use strum::IntoEnumIterator;
 
-#[derive(Debug, Snafu, PartialEq)]
+#[derive(Debug, PartialEq, Snafu)]
 #[snafu(module)]
 pub enum DurationParseError {
     #[snafu(display("empty input"))]

--- a/crates/stackable-webhook/src/lib.rs
+++ b/crates/stackable-webhook/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) trait StatefulWebhookHandler<Req, Res, S> {
     fn call(self, req: Req, state: S) -> Res;
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("failed to create TLS server"))]
     CreateTlsServer { source: tls::Error },

--- a/crates/stackable-webhook/src/lib.rs
+++ b/crates/stackable-webhook/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) trait StatefulWebhookHandler<Req, Res, S> {
     fn call(self, req: Req, state: S) -> Res;
 }
 
-#[derive(Debug, PartialEq, Snafu)]
+#[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("failed to create TLS server"))]
     CreateTlsServer { source: tls::Error },

--- a/crates/stackable-webhook/src/tls.rs
+++ b/crates/stackable-webhook/src/tls.rs
@@ -16,7 +16,7 @@ use tracing::{error, instrument, warn};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display("failed to construct TLS server config, bad certificate/key"))]
     InvalidTlsPrivateKey { source: tokio_rustls::rustls::Error },


### PR DESCRIPTION
# Description

This change is to encourage testing error variants by type rather than text contents.

- Bump strum to 0.26.2
- Derive `PartialEq` on most _Snafu_ Error enums.
- Add custom implementations of `PartialEq` for _Snafu_ error enums that use types that are not directly comparable.

>[!IMPORTANT] 
> Some variants are impossible to compare, so these implementations are restricted to `#[cfg(test)]` because they cause panics.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
