### PR TITLE
test: Improve `stackable-certs` test speeds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.0"
 x509-cert = { version = "0.2.5", features = ["builder"] }
 zeroize = "1.7.0"
+
+# Use O2 in tests to improve the RSA key generation speed in the stackable-certs crate
+[profile.test.package.stackable-certs]
+opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,4 +69,7 @@ zeroize = "1.7.0"
 
 # Use O2 in tests to improve the RSA key generation speed in the stackable-certs crate
 [profile.test.package.stackable-certs]
-opt-level = 2
+opt-level = 3
+
+[profile.test.package."rsa"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,8 @@ url = "2.5.0"
 x509-cert = { version = "0.2.5", features = ["builder"] }
 zeroize = "1.7.0"
 
-# Use O2 in tests to improve the RSA key generation speed in the stackable-certs crate
+# Use O3 in tests to improve the RSA key generation speed in the stackable-certs crate
 [profile.test.package.stackable-certs]
 opt-level = 3
-
 [profile.test.package."rsa"]
 opt-level = 3

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -477,14 +477,16 @@ mod test {
     use super::*;
 
     #[tokio::test]
-    async fn test() {
+    async fn test_rsa_key_generation() {
         let mut ca = CertificateAuthority::new_rsa().unwrap();
-        ca.generate_leaf_certificate(
-            rsa::SigningKey::new().unwrap(),
-            "Airflow",
-            "pod",
-            Duration::from_secs(3600),
-        )
-        .unwrap();
+        ca.generate_rsa_leaf_certificate("Airflow", "pod", Duration::from_secs(3600))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_key_generation() {
+        let mut ca = CertificateAuthority::new_ecdsa().unwrap();
+        ca.generate_ecdsa_leaf_certificate("Airflow", "pod", Duration::from_secs(3600))
+            .unwrap();
     }
 }

--- a/crates/stackable-certs/src/keys/mod.rs
+++ b/crates/stackable-certs/src/keys/mod.rs
@@ -9,7 +9,7 @@
 //! [`ecdsa`], which provides primitives and traits, and [`p256`] which
 //! implements the NIST P-256 elliptic curve and supports ECDSA.
 //!
-//! ```
+//! ```ignore
 //! use stackable_certs::keys::ecdsa::SigningKey;
 //! let key = SigningKey::new().unwrap();
 //! ```
@@ -18,7 +18,7 @@
 //!
 //! In order to work with RSA keys, this crate requires the [`rsa`] dependency.
 //!
-//! ```
+//! ```ignore
 //! use stackable_certs::keys::rsa::SigningKey;
 //! let key = SigningKey::new().unwrap();
 //! ```

--- a/crates/stackable-certs/src/keys/rsa.rs
+++ b/crates/stackable-certs/src/keys/rsa.rs
@@ -13,7 +13,7 @@ use crate::keys::CertificateKeypair;
 const KEY_SIZE: usize = 4096;
 
 #[cfg(test)]
-const KEY_SIZE: usize = 2048;
+const KEY_SIZE: usize = 512;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/crates/stackable-certs/src/keys/rsa.rs
+++ b/crates/stackable-certs/src/keys/rsa.rs
@@ -9,7 +9,11 @@ use tracing::instrument;
 
 use crate::keys::CertificateKeypair;
 
+#[cfg(not(test))]
 const KEY_SIZE: usize = 4096;
+
+#[cfg(test)]
+const KEY_SIZE: usize = 2048;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
Both me and @sbernauer stumbled over these performance issues during tests.

This PR increases the optimization level for the `rsa` and `stackable-certs` crates during test runs to O3 to speed up the RSA key generation. Additionally, it only uses 512 bit long keys instead of 4096 used in release builds. Further, it also disables two doc tests.
