### PR TITLE
fix: Remove duplicate authority key identifier extension

### DIFF
--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -304,8 +304,6 @@ where
         // The leaf certificate can be used for WWW client and server
         // authentication. This is a base requirement for TLS certs.
         let eku = ExtendedKeyUsage(vec![ID_KP_CLIENT_AUTH, ID_KP_SERVER_AUTH]);
-        let aki = AuthorityKeyIdentifier::try_from(spki.owned_to_ref())
-            .context(ParseAuthorityKeyIdentifierSnafu)?;
 
         let signer = self.certificate_pair.key_pair.signing_key();
         let mut builder = CertificateBuilder::new(
@@ -330,9 +328,6 @@ where
         // Again, add the extension created above.
         builder
             .add_extension(&eku)
-            .context(AddCertificateExtensionSnafu)?;
-        builder
-            .add_extension(&aki)
             .context(AddCertificateExtensionSnafu)?;
 
         debug!("create and sign leaf certificate");


### PR DESCRIPTION
Without removing this duplicate extension, the Go X.509 parsing code would error out stating that the "certificate contains duplicate extensions", which was indeed correct.

We accidentally included the authority key identifier twice, once in the leaf profile and once by manually adding the extension after building the cert.

We now removed the manually added extension. This resolved the Go error and the HTTP client was able to establish a TLS-secured connection to the dummy webhook.

See merge: https://go-review.googlesource.com/c/go/+/383215
See code: https://github.com/golang/go/blob/315b6ae682a2a4e7718924a45b8b311a0fe10043/src/crypto/x509/parser.go#L965-L968

---

To be able to access the OID of the duplicate extension, it was required to change Go's standard library. I will provide an upstream patch to improve the error message.

Also see the follow-up issue #694 to add tests / assertions around correct certificate generation.