### PR TITLE
chore: Bump k8s compilation version to 1.29. Also bump all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stackabletech/operator-rs"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.6.0" }
 
 axum = "0.7.5"
-chrono = { version = "0.4.37", default-features = false }
+chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.4", features = ["derive", "cargo", "env"] }
 const_format = "0.2.32"
 const-oid = "0.9.6"
@@ -21,15 +21,15 @@ delegate = "0.12.0"
 derivative = "2.2.0"
 dockerfile-parser = "0.8.0"
 ecdsa = { version = "0.16.9", features = ["digest", "pem"] }
-either = "1.10.0"
+either = "1.11.0"
 futures = "0.3.30"
 futures-util = "0.3.30"
-hyper = { version = "1.2.0", features = ["full"] }
+hyper = { version = "1.3.1", features = ["full"] }
 hyper-util = "0.1.3"
 json-patch = "1.2.0"
-k8s-openapi = { version = "0.21.1", default-features = false, features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.21.1", default-features = false, features = ["schemars", "v1_29"] }
 # We use rustls instead of openssl for easier portablitly, e.g. so that we can build stackablectl without the need to vendor (build from source) openssl
-kube = { version = "0.89.0", default-features = false, features = ["client", "jsonpatch", "runtime", "derive", "rustls-tls"] }
+kube = { version = "0.90.0", default-features = false, features = ["client", "jsonpatch", "runtime", "derive", "rustls-tls"] }
 lazy_static = "1.4.0"
 opentelemetry = "0.22.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
@@ -39,27 +39,27 @@ opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.14.0"
 p256 = { version = "0.13.2", features = ["ecdsa"] }
 pin-project = "1.1.5"
-proc-macro2 = "1.0.79"
-quote = "1.0.35"
+proc-macro2 = "1.0.81"
+quote = "1.0.36"
 rand = "0.8.5"
 rand_core = "0.6.4"
 regex = "1.10.4"
 rsa = { version = "0.9.6", features = ["sha2"] }
-rstest = "0.18.2"
+rstest = "0.19.0"
 schemars = { version = "0.8.16", features = ["url"] }
 semver = "1.0.22"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.115"
-serde_yaml = "0.9.34"
+serde = { version = "1.0.198", features = ["derive"] }
+serde_json = "1.0.116"
+serde_yaml = "0.9.34" # This is the last available version, see https://github.com/dtolnay/serde-yaml/releases/tag/0.9.34 for details
 sha2 = { version = "0.10.8", features = ["oid"] }
 signature = "2.2.0"
 snafu = "0.8.2"
 stackable-operator-derive = { path = "stackable-operator-derive" }
 strum = { version = "0.26.2", features = ["derive"] }
-syn = "2.0.55"
+syn = "2.0.60"
 tempfile = "3.10.1"
-time = { version = "0.3.34" }
-tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread", "fs"] }
+time = { version = "0.3.36" }
+tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-rustls = "0.26.0"
 tokio-test = "0.4.4"
 tower = "0.4.13"
@@ -69,7 +69,7 @@ tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = { version = "2.5.0", features = ["serde"] }
 x509-cert = { version = "0.2.5", features = ["builder"] }
-zeroize = "1.7.0"
+zeroize = "1.8.0"
 
 # Use O3 in tests to improve the RSA key generation speed in the stackable-certs crate
 [profile.test.package.stackable-certs]

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
+- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
 
 [#762]: https://github.com/stackabletech/operator-rs/pull/762
+[#769]: https://github.com/stackabletech/operator-rs/pull/769
 
 ## [0.2.0] - 2024-03-26
 

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
-- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
+- BREAKING: Bump k8s compilation version to `1.29`. Also bump all dependencies.
+  There are some breaking changes in k8s-openapi, e.g. PVCs now have `VolumeResourceRequirements` instead of `ResourceRequirements`,
+  and `PodAffinityTerm` has two new fields `match_label_keys` and `mismatch_label_keys` ([#769]).
 
 [#762]: https://github.com/stackabletech/operator-rs/pull/762
 [#769]: https://github.com/stackabletech/operator-rs/pull/769

--- a/crates/stackable-operator-derive/CHANGELOG.md
+++ b/crates/stackable-operator-derive/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- Bump kube to 0.89.0 and update all dependencies ([#762]).
-
-[#762]: https://github.com/stackabletech/operator-rs/pull/762
-
 ## [0.2.0] - 2024-03-26
 
 ### Changed

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
-- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
+- BREAKING: Bump k8s compilation version to `1.29`. Also bump all dependencies.
+  There are some breaking changes in k8s-openapi, e.g. PVCs now have `VolumeResourceRequirements` instead of `ResourceRequirements`,
+  and `PodAffinityTerm` has two new fields `match_label_keys` and `mismatch_label_keys` ([#769]).
 
 ### Removed
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
+- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
 
 ### Removed
 
@@ -14,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 [#761]: https://github.com/stackabletech/operator-rs/pull/761
 [#762]: https://github.com/stackabletech/operator-rs/pull/762
+[#769]: https://github.com/stackabletech/operator-rs/pull/769
 
 ## [0.66.0] - 2024-03-26
 

--- a/crates/stackable-operator/src/builder/pod/volume.rs
+++ b/crates/stackable-operator/src/builder/pod/volume.rs
@@ -3,8 +3,8 @@ use k8s_openapi::{
         CSIVolumeSource, ConfigMapVolumeSource, DownwardAPIVolumeSource, EmptyDirVolumeSource,
         EphemeralVolumeSource, HostPathVolumeSource, PersistentVolumeClaim,
         PersistentVolumeClaimSpec, PersistentVolumeClaimTemplate,
-        PersistentVolumeClaimVolumeSource, ProjectedVolumeSource, ResourceRequirements,
-        SecretVolumeSource, Volume, VolumeMount,
+        PersistentVolumeClaimVolumeSource, ProjectedVolumeSource, SecretVolumeSource, Volume,
+        VolumeMount, VolumeResourceRequirements,
     },
     apimachinery::pkg::api::resource::Quantity,
 };
@@ -358,9 +358,9 @@ impl SecretOperatorVolumeSourceBuilder {
                 metadata: Some(ObjectMetaBuilder::new().annotations(annotations).build()),
                 spec: PersistentVolumeClaimSpec {
                     storage_class_name: Some("secrets.stackable.tech".to_string()),
-                    resources: Some(ResourceRequirements {
+                    resources: Some(VolumeResourceRequirements {
                         requests: Some([("storage".to_string(), Quantity("1".to_string()))].into()),
-                        ..ResourceRequirements::default()
+                        ..Default::default()
                     }),
                     access_modes: Some(vec!["ReadWriteOnce".to_string()]),
                     ..PersistentVolumeClaimSpec::default()
@@ -465,9 +465,9 @@ impl ListenerOperatorVolumeSourceBuilder {
     fn build_spec(&self) -> PersistentVolumeClaimSpec {
         PersistentVolumeClaimSpec {
             storage_class_name: Some("listeners.stackable.tech".to_string()),
-            resources: Some(ResourceRequirements {
+            resources: Some(VolumeResourceRequirements {
                 requests: Some([("storage".to_string(), Quantity("1".to_string()))].into()),
-                ..ResourceRequirements::default()
+                ..Default::default()
             }),
             access_modes: Some(vec!["ReadWriteMany".to_string()]),
             ..PersistentVolumeClaimSpec::default()

--- a/crates/stackable-operator/src/commons/affinity.rs
+++ b/crates/stackable-operator/src/commons/affinity.rs
@@ -85,6 +85,8 @@ pub fn affinity_between_role_pods(
             namespace_selector: None,
             namespaces: None,
             topology_key: TOPOLOGY_KEY_HOSTNAME.to_string(),
+            match_label_keys: None,
+            mismatch_label_keys: None,
         },
         weight,
     }
@@ -110,6 +112,8 @@ pub fn affinity_between_cluster_pods(
             namespace_selector: None,
             namespaces: None,
             topology_key: TOPOLOGY_KEY_HOSTNAME.to_string(),
+            match_label_keys: None,
+            mismatch_label_keys: None,
         },
         weight,
     }
@@ -183,9 +187,8 @@ mod tests {
                                 }]),
                                 match_labels: None,
                             }),
-                            namespace_selector: None,
-                            namespaces: None,
                             topology_key: "".to_string(),
+                            ..Default::default()
                         }
                     ])
                 }),
@@ -207,9 +210,8 @@ mod tests {
                                         )
                                     ]))
                                 }),
-                                namespace_selector: None,
-                                namespaces: None,
                                 topology_key: TOPOLOGY_KEY_HOSTNAME.to_string(),
+                                ..Default::default()
                             },
                             weight: 70
                         }
@@ -293,9 +295,8 @@ mod tests {
                                     )
                                 ]))
                             }),
-                            namespace_selector: None,
-                            namespaces: None,
                             topology_key: "topology.kubernetes.io/zone".to_string(),
+                            ..Default::default()
                         }
                     ]),
                 }),
@@ -330,9 +331,8 @@ mod tests {
                             )
                         ]))
                     }),
-                    namespace_selector: None,
-                    namespaces: None,
                     topology_key: TOPOLOGY_KEY_HOSTNAME.to_string(),
+                    ..Default::default()
                 },
                 weight: 70
             }
@@ -359,9 +359,8 @@ mod tests {
                             )
                         ]))
                     }),
-                    namespace_selector: None,
-                    namespaces: None,
                     topology_key: TOPOLOGY_KEY_HOSTNAME.to_string(),
+                    ..Default::default()
                 },
                 weight: 20
             }

--- a/crates/stackable-operator/src/commons/resources.rs
+++ b/crates/stackable-operator/src/commons/resources.rs
@@ -79,6 +79,7 @@ use crate::{
 use derivative::Derivative;
 use k8s_openapi::api::core::v1::{
     Container, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec, ResourceRequirements,
+    VolumeResourceRequirements,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
@@ -316,7 +317,7 @@ impl PvcConfig {
                     .map(|modes| modes.into_iter().map(String::from).collect()),
                 selector: self.selectors.clone(),
                 storage_class_name: self.storage_class.clone(),
-                resources: Some(ResourceRequirements {
+                resources: Some(VolumeResourceRequirements {
                     requests: Some({
                         let mut map = BTreeMap::new();
                         if let Some(capacity) = &self.capacity {
@@ -324,7 +325,7 @@ impl PvcConfig {
                         }
                         map
                     }),
-                    ..ResourceRequirements::default()
+                    ..Default::default()
                 }),
                 ..PersistentVolumeClaimSpec::default()
             }),

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -12,10 +12,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
+- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
 
 [#758]: https://github.com/stackabletech/operator-rs/pull/758
 [#762]: https://github.com/stackabletech/operator-rs/pull/762
 [#767]: https://github.com/stackabletech/operator-rs/pull/767
+[#769]: https://github.com/stackabletech/operator-rs/pull/769
 
 ## [0.2.0] - 2024-03-26
 

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump kube to 0.89.0 and update all dependencies ([#762]).
-- Bump k8s compilation version to `1.29`. Also bump all dependencies ([#769]).
+- BREAKING: Bump k8s compilation version to `1.29`. Also bump all dependencies.
+  There are some breaking changes in k8s-openapi, e.g. PVCs now have `VolumeResourceRequirements` instead of `ResourceRequirements`,
+  and `PodAffinityTerm` has two new fields `match_label_keys` and `mismatch_label_keys` ([#769]).
 
 [#758]: https://github.com/stackabletech/operator-rs/pull/758
 [#762]: https://github.com/stackabletech/operator-rs/pull/762


### PR DESCRIPTION
# Description

We need to go throw the breaking change https://github.com/kubernetes/kubernetes/pull/118653, which should not break the API (only the internally used structs)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
