### PR TITLE
chore: Release crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-certs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.67.0"
+version = "0.67.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum 0.7.5",
  "futures-util",

--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-05-08
+
 ### Changed
 
 - Bump Rust dependencies and GitHub Actions ([#782]).

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-05-08
+
 ### Changed
 
 - Bump Rust dependencies and GitHub Actions ([#782]).

--- a/crates/stackable-certs/Cargo.toml
+++ b/crates/stackable-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-certs"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator-derive/CHANGELOG.md
+++ b/crates/stackable-operator-derive/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-05-08
+
 ### Changed
 
 - Bump Rust dependencies and GitHub Actions ([#782]).

--- a/crates/stackable-operator-derive/Cargo.toml
+++ b/crates/stackable-operator-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator-derive"
 description = "Derive macros for the Stackable Operator Framework"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.67.1] - 2024-05-08
+
 ### Added
 
 - Add `InvalidProductSpecificConfiguration` variant in

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.67.0"
+version = "0.67.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-05-08
+
 ### Changed
 
 - Bump Rust dependencies and GitHub Actions ([#782]).

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-05-08
+
 ### Changed
 
 - Bump Rust dependencies and GitHub Actions ([#782]).

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-05-08
+
 ### Added
 
 - Instrument `WebhookServer` with `AxumTraceLayer`, add static healthcheck without instrumentation ([#758]).

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Release these crates:

- k8s-version 0.1.0
- stackable-certs 0.3.0
- stackable-operator 0.67.1
- stackable-operator-derive 0.3.0
- stackable-telemetry 0.1.0
- stackable-versioned 0.1.0
- stackable-webhook 0.3.0
