### PR TITLE
fix(stackable-telemetry): Disable export of h2 events via OTLP

### DIFF
--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -12,5 +12,11 @@ All notable changes to this project will be documented in this file.
 - Bump GitHub workflow actions ([#772]).
 - Revert `zeroize` version bump ([#772]).
 
+### Fixed
+
+- Prevent infinite events being exported via OTLP, as described in [open-telemetry/opentelemetry-rust#761] ([#796]).
+
 [#772]: https://github.com/stackabletech/operator-rs/pull/772
 [#782]: https://github.com/stackabletech/operator-rs/pull/782
+[#796]: https://github.com/stackabletech/operator-rs/pull/796
+[open-telemetry/opentelemetry-rust#761]: https://github.com/open-telemetry/opentelemetry-rust/issues/761

--- a/crates/stackable-telemetry/src/tracing.rs
+++ b/crates/stackable-telemetry/src/tracing.rs
@@ -149,7 +149,9 @@ impl Tracing {
         if self.otlp_log_config.enabled {
             let env_filter_layer = EnvFilter::builder()
                 .with_default_directive(self.otlp_log_config.level_filter.into()) // TODO (@NickLarsenNZ): support Directives
-                .from_env_lossy();
+                .from_env_lossy()
+                // TODO (@NickLarsenNZ): Remove this directive once https://github.com/open-telemetry/opentelemetry-rust/issues/761 is resolved
+                .add_directive("h2=off".parse().expect("invalid directive"));
 
             let log_exporter = opentelemetry_otlp::new_exporter().tonic();
             let otel_log =
@@ -173,13 +175,9 @@ impl Tracing {
         if self.otlp_trace_config.enabled {
             let env_filter_layer = EnvFilter::builder()
                 .with_default_directive(self.otlp_trace_config.level_filter.into()) // TODO (@NickLarsenNZ): support Directives
-                .from_env_lossy();
-            // .add_directive("hyper=info".parse().expect("invalid directive"))
-            // .add_directive("tonic=warn".parse().expect("invalid directive"))
-            // .add_directive("tokio_util=warn".parse().expect("invalid directive"))
-            // .add_directive("hyper=info".parse().expect("invalid directive"))
-            // .add_directive("h2=info".parse().expect("invalid directive"))
-            // .add_directive("tower=info".parse().expect("invalid directive"));
+                .from_env_lossy()
+                // TODO (@NickLarsenNZ): Remove this directive once https://github.com/open-telemetry/opentelemetry-rust/issues/761 is resolved
+                .add_directive("h2=off".parse().expect("invalid directive"));
 
             let trace_exporter = opentelemetry_otlp::new_exporter().tonic();
             let otel_tracer = opentelemetry_otlp::new_pipeline()


### PR DESCRIPTION
It causes infinite cascading events to be emitted. 

See https://github.com/open-telemetry/opentelemetry-rust/issues/761
