### PR TITLE
chore: Add functionality to convert LogLevel to an OPA log level

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
 - Add functionality to convert LogLevel to an OPA log level ([#798])
 
 [#798]: https://github.com/stackabletech/operator-rs/pull/798

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add functionality to convert LogLevel to an OPA log level ([#798])
+
+[#798]: https://github.com/stackabletech/operator-rs/pull/798
+
 ## [0.68.0] - 2024-05-22
 
 - Support specifying externalTrafficPolicy in Services created by listener-operator ([#773], [#789], [#791]).

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add functionality to convert LogLevel to an OPA log level ([#798])
+- Add functionality to convert LogLevel to an OPA log level ([#798]).
 
 [#798]: https://github.com/stackabletech/operator-rs/pull/798
 

--- a/crates/stackable-operator/src/product_logging/spec.rs
+++ b/crates/stackable-operator/src/product_logging/spec.rs
@@ -377,6 +377,21 @@ impl LogLevel {
         self.to_log4j_literal()
     }
 
+    /// Convert the log level to a string understood by OPA
+    // based on https://www.openpolicyagent.org/docs/latest/cli/#options-10 opa has only log levels {debug,info,error}
+    pub fn to_opa_literal(&self) -> String {
+        match self {
+            LogLevel::TRACE => "debug",
+            LogLevel::DEBUG => "debug",
+            LogLevel::INFO => "info",
+            LogLevel::WARN => "error",
+            LogLevel::ERROR => "error",
+            LogLevel::FATAL => "error",
+            LogLevel::NONE => "error",
+        }
+        .into()
+    }
+
     /// Convert the log level to a Python expression
     pub fn to_python_expression(&self) -> String {
         match self {


### PR DESCRIPTION
# Description

This PR adds a function to `LogLevel` which converts the `LogLevel` to a log level String understood by OPA.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
