### PR TITLE
chore: Release stackable-operator 0.68.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.68.0"
+version = "0.68.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.68.1] - 2024-06-03
+
 ### Added
 
 - Add functionality to convert LogLevel to an OPA log level ([#798]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.68.0"
+version = "0.68.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Release stackable-operator 0.68.1 which includes these changes:

- Add functionality to convert LogLevel to an OPA log level ([#798]).
- Add labels to listener volume builder ([#799]).

[#798]: https://github.com/stackabletech/operator-rs/pull/798
[#799]: https://github.com/stackabletech/operator-rs/pull/799