### PR TITLE
feat(stackable-telemetry): Add support for env_var per configured subscriber

### DIFF
--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for setting the environment variable for each configured tracing subscriber ([#801]).
+
+[#801]: https://github.com/stackabletech/operator-rs/pull/801
+
 ## [0.1.0] - 2024-05-08
 
 ### Changed

--- a/crates/stackable-telemetry/src/tracing.rs
+++ b/crates/stackable-telemetry/src/tracing.rs
@@ -48,9 +48,9 @@ pub enum Error {
 /// async fn main() -> Result<(), Error> {
 ///     let _tracing_guard = Tracing::builder()
 ///         .service_name("test")
-///         .with_console_output(LevelFilter::INFO)
-///         .with_otlp_log_exporter(LevelFilter::DEBUG)
-///         .with_otlp_trace_exporter(LevelFilter::TRACE)
+///         .with_console_output("TEST_CONSOLE", LevelFilter::INFO)
+///         .with_otlp_log_exporter("TEST_OTLP_LOG", LevelFilter::DEBUG)
+///         .with_otlp_trace_exporter("TEST_OTLP_LOG", LevelFilter::TRACE)
 ///         .build()
 ///         .init()?;
 ///

--- a/crates/stackable-telemetry/src/tracing.rs
+++ b/crates/stackable-telemetry/src/tracing.rs
@@ -50,7 +50,7 @@ pub enum Error {
 ///         .service_name("test")
 ///         .with_console_output("TEST_CONSOLE", LevelFilter::INFO)
 ///         .with_otlp_log_exporter("TEST_OTLP_LOG", LevelFilter::DEBUG)
-///         .with_otlp_trace_exporter("TEST_OTLP_LOG", LevelFilter::TRACE)
+///         .with_otlp_trace_exporter("TEST_OTLP_TRACE", LevelFilter::TRACE)
 ///         .build()
 ///         .init()?;
 ///
@@ -300,7 +300,6 @@ impl BuilderState for builder_state::Config {}
 #[derive(Default)]
 pub struct TracingBuilder<S: BuilderState> {
     service_name: Option<&'static str>,
-    env_var: Option<&'static str>,
     console_log_config: SubscriberConfig,
     otlp_log_config: SubscriberConfig,
     otlp_trace_config: SubscriberConfig,
@@ -349,7 +348,6 @@ impl TracingBuilder<builder_state::Config> {
     ) -> TracingBuilder<builder_state::Config> {
         TracingBuilder {
             service_name: self.service_name,
-            env_var: self.env_var,
             console_log_config: SubscriberConfig {
                 enabled: true,
                 env_var,
@@ -373,7 +371,6 @@ impl TracingBuilder<builder_state::Config> {
     ) -> TracingBuilder<builder_state::Config> {
         TracingBuilder {
             service_name: self.service_name,
-            env_var: self.env_var,
             console_log_config: self.console_log_config,
             otlp_log_config: SubscriberConfig {
                 enabled: true,
@@ -397,7 +394,6 @@ impl TracingBuilder<builder_state::Config> {
     ) -> TracingBuilder<builder_state::Config> {
         TracingBuilder {
             service_name: self.service_name,
-            env_var: self.env_var,
             console_log_config: self.console_log_config,
             otlp_log_config: self.otlp_log_config,
             otlp_trace_config: SubscriberConfig {


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/531

Now each tracing subscriber log level can be configured via the given environment variable.

```rust
let trace_guard = Tracing::builder()
    .service_name("hdfs_operator")
    .with_console_output("HDFS_OPERATOR_LOG", LevelFilter::INFO)
    .with_otlp_log_exporter("HDFS_OPERATOR_OTLP_LOG", LevelFilter::DEBUG)
    .with_otlp_trace_exporter("HDFS_OPERATOR_OTLP_TRACE", LevelFilter::TRACE)
    .build();
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
