### PR TITLE
chore: derive strum::Display for LogLevel

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Derive `Display` for `LogLevel`.
+
 ## [0.69.0] - 2024-06-03
 
 ### Added

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Derive `Display` for `LogLevel`([#805]).
+- Derive `strum::Display` for `LogLevel`([#805]).
 
 [#805]: https://github.com/stackabletech/operator-rs/pull/805
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Derive `Display` for `LogLevel`.
+- Derive `Display` for `LogLevel`([#805]).
+
+[#805]: https://github.com/stackabletech/operator-rs/pull/805
 
 ## [0.69.0] - 2024-06-03
 

--- a/crates/stackable-operator/src/product_logging/spec.rs
+++ b/crates/stackable-operator/src/product_logging/spec.rs
@@ -313,8 +313,10 @@ pub struct AppenderConfig {
     PartialEq,
     PartialOrd,
     Serialize,
+    strum::Display,
 )]
 #[derivative(Default)]
+#[strum(serialize_all = "lowercase")]
 pub enum LogLevel {
     TRACE,
     DEBUG,


### PR DESCRIPTION
# Description

Adds the `Display` derive macro to `LogLevel`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
