### PR TITLE
chore: Release stackable-operator 0.69.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.69.1]  2024-06-10
+
 ### Added
 
 - Derive `strum::Display` for `LogLevel`([#805]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.69.0"
+version = "0.69.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

### Added

- Derive `strum::Display` for `LogLevel`([#805]).

[#805]: https://github.com/stackabletech/operator-rs/pull/805