### PR TITLE
chore: set strum::Display for LogLevel to uppercase

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Derive `strum::Display` for `LogLevel`([#805]).
+- Derive `strum::Display` for `LogLevel`([#805], [#808]).
 
 [#805]: https://github.com/stackabletech/operator-rs/pull/805
+[#808]: https://github.com/stackabletech/operator-rs/pull/808
 
 ## [0.69.0] - 2024-06-03
 

--- a/crates/stackable-operator/src/product_logging/spec.rs
+++ b/crates/stackable-operator/src/product_logging/spec.rs
@@ -301,6 +301,7 @@ pub struct AppenderConfig {
 }
 
 /// Log levels
+// Caution: Changing the output format for strum::Display might break operators relying on this trait.
 #[derive(
     Clone,
     Copy,
@@ -316,7 +317,6 @@ pub struct AppenderConfig {
     strum::Display,
 )]
 #[derivative(Default)]
-#[strum(serialize_all = "lowercase")]
 pub enum LogLevel {
     TRACE,
     DEBUG,


### PR DESCRIPTION
# Description

Set strum::Display for LogLevel to uppercase and add warning.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
