### PR TITLE
chore: Release stackable-operator 0.69.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.69.1"
+version = "0.69.2"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.69.2]  2024-06-10
-
 ### Changed
 
 - Change `strum::Display` output format for `LogLevel` to uppercase ([#808]).

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.69.2]  2024-06-10
+
 ### Changed
 
 - Change `strum::Display` output format for `LogLevel` to uppercase ([#808]).

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.69.2]  2024-06-10
+## [0.69.2] - 2024-06-10
 
 ### Changed
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,14 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.69.2]  2024-06-10
+
+### Changed
+
+- Change `strum::Display` output format for `LogLevel` to uppercase ([#808]).
+
+[#808]: https://github.com/stackabletech/operator-rs/pull/808
+
 ## [0.69.1]  2024-06-10
 
 ### Added
 
-- Derive `strum::Display` for `LogLevel`([#805], [#808]).
+- Derive `strum::Display` for `LogLevel`([#805]).
 
 [#805]: https://github.com/stackabletech/operator-rs/pull/805
-[#808]: https://github.com/stackabletech/operator-rs/pull/808
 
 ## [0.69.0] - 2024-06-03
 

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.69.1"
+version = "0.69.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:
### Changed

- Change `strum::Display` output format for `LogLevel` to uppercase ([#808]).

[#808]: https://github.com/stackabletech/operator-rs/pull/808