### PR TITLE
fix(stackable-webhook): Move certificate generation to the blocking thread

### DIFF
--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -14,9 +14,11 @@ All notable changes to this project will be documented in this file.
   the `Host` info (data about the server) in the `AxumTraceLayer`. This was
   previously not extracted correctly and thus not included in the OpenTelemetry
   compatible traces ([#806]).
+- Spawn blocking code on a blocking thread ([#815]).
 
 [#806]: https://github.com/stackabletech/operator-rs/pull/806
 [#811]: https://github.com/stackabletech/operator-rs/pull/811
+[#815]: https://github.com/stackabletech/operator-rs/pull/815
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-webhook/src/tls.rs
+++ b/crates/stackable-webhook/src/tls.rs
@@ -97,6 +97,12 @@ pub struct TlsServer {
 impl TlsServer {
     #[instrument(name = "create_tls_server", skip(router))]
     pub async fn new(socket_addr: SocketAddr, router: Router) -> Result<Self> {
+        // NOTE(@NickLarsenNZ): This code is not async, and does take some
+        // non-negligable amount of time to complete (moreso in debug ).
+        // We run this in a thread reserved for blocking code so that the Tokio
+        // executor is able to make progress on other futures instead of being
+        // blocked.
+        // See https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
         let task = tokio::task::spawn_blocking(move || {
             let mut certificate_authority =
                 CertificateAuthority::new_rsa().context(CreateCertificateAuthoritySnafu)?;


### PR DESCRIPTION
> [!NOTE]
> Easier to review with whitespace hidden: https://github.com/stackabletech/operator-rs/pull/815/files?diff=split&w=1

# Description

As per https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html,

> In general, issuing a blocking call or performing a lot of compute in a future without yielding is problematic, as it may prevent the executor from driving other futures forward. This function runs the provided closure on a thread dedicated to blocking operations. See the [CPU-bound tasks and blocking code](https://docs.rs/tokio/latest/tokio/index.html#cpu-bound-tasks-and-blocking-code) section for more information.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes


```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```