### PR TITLE
refactor: Use ProductImage::product_version internally

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added `ProductImage::product_version` utility function ([#817], [#XXX])
+- Added `ProductImage::product_version` utility function ([#817], [#818])
 
 ### Changed
 
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#811]: https://github.com/stackabletech/operator-rs/pull/811
 [#812]: https://github.com/stackabletech/operator-rs/pull/812
 [#817]: https://github.com/stackabletech/operator-rs/pull/817
+[#818]: https://github.com/stackabletech/operator-rs/pull/818
 
 ## [0.69.3] - 2024-06-12
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `ProductImage::product_version` utility function ([#817], [#XXX])
+
 ### Changed
 
 - BREAKING: Bump `kube` to 0.92.0. This required changes in a unit test, because
@@ -13,7 +17,6 @@ All notable changes to this project will be documented in this file.
   - [kube#1494](https://github.com/kube-rs/kube/pull/1494)
   - [kube#1504](https://github.com/kube-rs/kube/pull/1504)
 - Upgrade opentelemetry crates ([#811]).
-- Added `ProductImage.product_version()` utility function ([#817])
 
 ### Fixed
 


### PR DESCRIPTION
# Description

Follow-up of https://github.com/stackabletech/operator-rs/pull/817

This way we have a single point of responsibility, which makes it easier to plug in the recommended product version later on, while maintaining the ergonomic API from https://github.com/stackabletech/operator-rs/pull/817.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
