### PR TITLE
Fix the regular expression for OPA bundle builder logs

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -21,12 +21,15 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Product image selection pull request version override now only applies to pull requests ([#812]).
+- OPA bundle builder logs without a log message are marked with the
+  error "Message not found." instead of "Log event not parsable" ([#819]).
 
 [#804]: https://github.com/stackabletech/operator-rs/pull/804
 [#811]: https://github.com/stackabletech/operator-rs/pull/811
 [#812]: https://github.com/stackabletech/operator-rs/pull/812
 [#817]: https://github.com/stackabletech/operator-rs/pull/817
 [#818]: https://github.com/stackabletech/operator-rs/pull/818
+[#819]: https://github.com/stackabletech/operator-rs/pull/819
 
 ## [0.69.3] - 2024-06-12
 

--- a/crates/stackable-operator/src/product_logging/framework.rs
+++ b/crates/stackable-operator/src/product_logging/framework.rs
@@ -778,7 +778,7 @@ transforms:
       .message = ""
       .errors = []
 
-      event, err = parse_regex(strip_whitespace(strip_ansi_escape_codes(raw_message)), r'(?P<timestamp>[0-9-:.TZ]+)[ ]+(?P<level>\w+)[ ]+(?P<logger>.+):[ ]+(?P<message>.*)')
+      event, err = parse_regex(strip_whitespace(strip_ansi_escape_codes(raw_message)), r'(?P<timestamp>[0-9-:.TZ]+)[ ]+(?P<level>\w+)[ ]+(?P<logger>.+):[ ]*(?P<message>.*)')
       if err != null {{
         error = "Log event not parsable: " + err
         .errors = push(.errors, error)


### PR DESCRIPTION
# Description

Fix the regular expression for OPA bundle builder logs

The following log entry does not contain a log message:

```
[2m2024-01-01T00:00:00.000000Z[0m [32m INFO[0m [2mbundle[0m[2m:[0m
```

It did not match the regular expression, all fields like the timestamp, level and logger were ignored and the following error was added to the event:

> Log event not parsable: function call error for "parse_regex" at (122:276): could not find any pattern matches

This pull request changes the regular expression to allow an empty message. All other fields are processed correctly and the log event is marked with "Message not found.".

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (only locally tested)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
