### PR TITLE
chore: Pre 24.7 releases

### DIFF
--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Bump rust-toolchain to 1.79.0 ([#822])
 
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.1.0] - 2024-05-08
 

--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2024-07-09
+
 ### Changed
 
 - Bump rust-toolchain to 1.79.0 ([#822])

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-07-09
+
 ### Changed
 
 - Bump rust-toolchain to 1.79.0 ([#822])

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Bump rust-toolchain to 1.79.0 ([#822])
 
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-operator-derive/CHANGELOG.md
+++ b/crates/stackable-operator-derive/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-07-09
+
 ### Changed
 
 - Bump rust-toolchain to 1.79.0 ([#822])

--- a/crates/stackable-operator-derive/CHANGELOG.md
+++ b/crates/stackable-operator-derive/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Bump rust-toolchain to 1.79.0 ([#822])
 
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 [#817]: https://github.com/stackabletech/operator-rs/pull/817
 [#818]: https://github.com/stackabletech/operator-rs/pull/818
 [#819]: https://github.com/stackabletech/operator-rs/pull/819
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.69.3] - 2024-06-12
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.70.0] - 2024-07-09
+
 ### Added
 
 - Added `ProductImage::product_version` utility function ([#817], [#818])

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 [#801]: https://github.com/stackabletech/operator-rs/pull/801
 [#811]: https://github.com/stackabletech/operator-rs/pull/811
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.1.0] - 2024-05-08
 

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-07-09
+
 ### Changed
 
-- Add support for setting the environment variable for each configured tracing subscriber ([#801]).
+- BREAKING: Add support for setting the environment variable for each configured tracing subscriber ([#801]).
 - Use OpenTelemetry Context in Axum instrumentation layer, adjust log and span level, simplify trace config ([#811]).
   - tracing: Upgrade opentelemetry crates, simplify trace config, fix shutdown conditions, use new way to shutdown LoggerProvider.
   - instrumentation/axum: demote event severity for errors easily caused by clients, replace parent span context if given in http header and link to previous trace contexts.

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -15,12 +15,14 @@ All notable changes to this project will be documented in this file.
 - Change from derive macro to attribute macro to be able to generate code
   _in place_ instead of _appending_ new code ([#793]).
 - Improve action chain generation ([#784]).
+- Bump rust-toolchain to 1.79.0 ([#822])
 
 [#784]: https://github.com/stackabletech/operator-rs/pull/784
 [#790]: https://github.com/stackabletech/operator-rs/pull/790
 [#793]: https://github.com/stackabletech/operator-rs/pull/793
 [#804]: https://github.com/stackabletech/operator-rs/pull/804
 [#813]: https://github.com/stackabletech/operator-rs/pull/813
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.1.0] - 2024-05-08
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2024-07-09
+
 ### Added
 
 - Add support for versioned enums ([#813]).

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-07-09
+
 ## Changed
 
 - Remove instrumentation of long running functions, add more granular instrumentation of futures. Adjust span and event levels ([#811]).

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 [#806]: https://github.com/stackabletech/operator-rs/pull/806
 [#811]: https://github.com/stackabletech/operator-rs/pull/811
 [#815]: https://github.com/stackabletech/operator-rs/pull/815
-[#822]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#822]: https://github.com/stackabletech/operator-rs/pull/822
 
 ## [0.3.0] - 2024-05-08
 


### PR DESCRIPTION
# Description

Create releases for:
- `k8s-version` @ `0.1.1`
- `stackable-certs` @ `0.3.1`
- `stackable-operator-derive` @ `0.3.1`
- `stackable-operator` @ `0.70.0`
- `stackable-telemetry` @ `0.2.0`
- `stackable-versioned` @ `0.1.1`
- `stackable-webhook` @ `0.3.1`
