### PR TITLE
Fix: Release bump in Cargo.TOMLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -225,7 +225,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1239,9 +1239,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1292,7 +1292,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.1.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1310,7 +1310,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "log",
  "rustls",
@@ -1327,7 +1327,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1339,7 +1339,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1357,7 +1357,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "k8s-version"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "darling",
  "lazy_static",
@@ -1571,7 +1571,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-http-proxy",
  "hyper-rustls",
  "hyper-timeout 0.5.1",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-certs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.69.3"
+version = "0.70.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum 0.7.5",
  "futures-util",
@@ -2960,14 +2960,14 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "stackable-versioned-macros",
 ]
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "convert_case",
  "darling",
@@ -2981,11 +2981,11 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum 0.7.5",
  "futures-util",
- "hyper 1.4.0",
+ "hyper 1.4.1",
  "hyper-util",
  "k8s-openapi",
  "kube",
@@ -3297,7 +3297,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",

--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.1] - 2024-07-09
+## [0.1.1] - 2024-07-10
 
 ### Changed
 

--- a/crates/k8s-version/Cargo.toml
+++ b/crates/k8s-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-version"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.1] - 2024-07-09
+## [0.3.1] - 2024-07-10
 
 ### Changed
 

--- a/crates/stackable-certs/Cargo.toml
+++ b/crates/stackable-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-certs"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator-derive/CHANGELOG.md
+++ b/crates/stackable-operator-derive/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.1] - 2024-07-09
+## [0.3.1] - 2024-07-10
 
 ### Changed
 

--- a/crates/stackable-operator-derive/Cargo.toml
+++ b/crates/stackable-operator-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator-derive"
 description = "Derive macros for the Stackable Operator Framework"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.70.0] - 2024-07-09
+## [0.70.0] - 2024-07-10
 
 ### Added
 

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.69.3"
+version = "0.70.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [99.0.0] - 1970-01-01
-
 ## [0.2.0] - 2024-07-09
 
 ### Changed

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.2.0] - 2024-07-09
+## [0.2.0] - 2024-07-10
 
 ### Changed
 

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [99.0.0] - 1970-01-01
+
 ## [0.2.0] - 2024-07-09
 
 ### Changed

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.1] - 2024-07-09
+## [0.1.1] - 2024-07-10
 
 ### Added
 

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.3.1] - 2024-07-09
+## [0.3.1] - 2024-07-10
 
 ## Changed
 

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.3.0"
+version = "0.3.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

This was forgotten in #823.

> [!IMPORTANT]
> After merging, the remote tags need deleting:
> ```sh
> git push --delete origin k8s-version-0.1.1
> git push --delete origin stackable-certs-0.3.1
> git push --delete origin stackable-operator-0.70.0
> git push --delete origin stackable-operator-derive-0.3.1
> git push --delete origin stackable-telemetry-0.2.0
> git push --delete origin stackable-versioned-0.1.1
> git push --delete origin stackable-webhook-0.3.1
> ```
>
> And anyone who has the tags already can remove them with:
> ```sh
> git tag --delete k8s-version-0.1.1
> git tag --delete stackable-certs-0.3.1
> git tag --delete stackable-operator-0.70.0
> git tag --delete stackable-operator-derive-0.3.1
> git tag --delete stackable-telemetry-0.2.0
> git tag --delete stackable-versioned-0.1.1
> git tag --delete stackable-webhook-0.3.1
> ```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
