### PR TITLE
chore: Add crate release helper scripts

### DIFF
--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -1,0 +1,15 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.12'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -6,12 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: '0'
-  CARGO_PROFILE_DEV_DEBUG: '0'
   RUST_TOOLCHAIN_VERSION: "1.79.0"
-  RUSTFLAGS: "-D warnings"
-  RUSTDOCFLAGS: "-D warnings"
-  RUST_LOG: "info"
 
 jobs:
   pre-commit:
@@ -24,4 +19,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          components: rustfmt,clippy
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -4,6 +4,15 @@ name: pre-commit
 on:
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: '0'
+  CARGO_PROFILE_DEV_DEBUG: '0'
+  RUST_TOOLCHAIN_VERSION: "1.79.0"
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
+  RUST_LOG: "info"
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -12,4 +21,7 @@ jobs:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -34,6 +34,14 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: reviewdog/action-shellcheck@52f34f737a16c65b8caa8c51ae1b23036afe5685 # v1.23.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   yamllint:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,9 @@ repos:
     rev: v0.31.1
     hooks:
       - id: markdownlint
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["--severity=info"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,12 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=info"]
+
+  - repo: local
+    hooks:
+      - id: .scripts/verify-crate-versions
+        name: .scripts/verify-crate-versions
+        language: system
+        entry: .scripts/verify_crate_versions.sh
+        stages: [commit, merge-commit, manual]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,26 +2,28 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.2.0
-      hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
-          - id: detect-aws-credentials
-            args: ["--allow-missing-credentials"]
-          - id: detect-private-key
-    - repo: https://github.com/doublify/pre-commit-rust
-      rev: v1.0
-      hooks:
-          - id: fmt
-            args: ["--all", "--", "--check"]
-          - id: clippy
-            args: ["--all-targets", "--", "-D", "warnings"]
-    - repo: https://github.com/adrienverge/yamllint
-      rev: v1.26.3
-      hooks:
-          - id: yamllint
-    - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.31.1
-      hooks:
-          - id: markdownlint
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
+      - id: detect-private-key
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        args: ["--all", "--", "--check"]
+      - id: clippy
+        args: ["--all-targets", "--", "-D", "warnings"]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.31.1
+    hooks:
+      - id: markdownlint

--- a/.scripts/tag_and_push_release.sh
+++ b/.scripts/tag_and_push_release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Tag the latest release based on the versions in the Cargo.toml files.
+# Do this after merging a release PR to main.
+#
+# This script will skip local tags (eg: if a crate release has already been
+# done). You will be prompted at the end whether to push the tags or not.
+#
+# To ensure crate versions match the latest version in the changelogs,
+# see verify_crate_versions.sh
+
+set -euo pipefail
+
+# You need fzf to run this
+type fzf &> /dev/null || (echo "This script requres fzf" >&2 && exit 1)
+
+# Update from remote
+git fetch origin
+
+# Select a commit (usually the first is the right one)
+SHORT_COMMIT_HASH=$(git log --color=always --oneline | fzf --ansi --layout=reverse --prompt="Select the commit to tag" | cut -d' ' -f1)
+
+# Get the latest versions
+LATEST_TAGS=$(find . -mindepth 2 -name CHANGELOG.md -exec sh -c 'grep -HoE "\[[0-9]+\.[0-9]+\.[0-9]+\]" "$1" | head -1 | sed -e "s|^./crates/\([a-z0-9_\-]\+\).*:\[\(.*\)\]$|\1-\2|"' shell {} \; | sort)
+LATEST_TAGS=$(find . -mindepth 2 -name CHANGELOG.md -exec sh -c 'grep -HoE "\[[0-9]+\.[0-9]+\.[0-9]+\]" "$1" | head -1 | sed -e "s|^./crates/\([a-z0-9_\-]\+\).*:\[\(.*\)\]$|\1-\2|"' shell {} \; | sort)
+ALL_TAGS=$(git tag | sort)
+
+# Only show tags that don't exist (if you need to overwrite tags, do it manually)
+AVAILABLE_TAGS=$(comm -23 <(echo -e "$LATEST_TAGS") <(echo -e "$ALL_TAGS"))
+
+# Select tags
+SELECTED_TAGS=$(echo -e "$AVAILABLE_TAGS" | fzf --reverse --multi --bind "ctrl-a:toggle-all" --bind "space:toggle" --prompt "Select multiple to release (use SPACE to select, CTRL+A to invert selection)")
+
+# Tag each selected to the selected commit
+echo -e "$SELECTED_TAGS" | xargs -I {} git tag -s -m "release/{}" {} "$SHORT_COMMIT_HASH"
+echo
+read -r -p "push the tags [y/N]? " PUSH
+if [ "${PUSH,,}" == "y" ]; then
+    echo -e "$SELECTED_TAGS" | xargs -I {} git push origin {}
+fi
+
+git log -1 --oneline

--- a/.scripts/tag_and_push_release.sh
+++ b/.scripts/tag_and_push_release.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 # You need fzf to run this
-type fzf &> /dev/null || (echo "This script requres fzf" >&2 && exit 1)
+type fzf &> /dev/null || (echo "This script requires fzf" >&2 && exit 1)
 
 # Update from remote
 git fetch origin

--- a/.scripts/verify_crate_versions.sh
+++ b/.scripts/verify_crate_versions.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Eg: makes a list like this based on the latest release in the CHANGELOG.md files:
+# k8s-version-0.1.1
+# stackable-certs-0.3.1
+# stackable-operator-0.70.0
+# stackable-operator-derive-0.3.1
+# stackable-telemetry-0.2.0
+# stackable-versioned-0.1.1
+# stackable-webhook-0.3.1
+
+for CRATE in $(find . -mindepth 2 -name Cargo.toml | sed -e 's|^./crates/\([a-z0-9_\-]\+\).*|\1|' | sort); do
+    # Get the version in Cargo.toml
+    CRATE_VERSION=$(grep 'version' "./crates/$CRATE/Cargo.toml" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    [ -n "$CRATE_VERSION" ] || (
+        echo "CRATE_VERSION for $CRATE is empty." >&2
+        echo "Please check ./crates/$CRATE/Cargo.toml" >&2
+        exit 21
+    )
+
+    # Special treatment of stackable-versioned-macros:
+    # - It has no changelog
+    # - The version should be the same as stackable-versioned
+    if [ "$CRATE" = "stackable-versioned-macros" ]; then
+        ASSOCIATED_CRATE="stackable-versioned"
+
+        # Get the version in Cargo.toml
+        ASSOCIATED_CRATE_VERSION=$(grep 'version' "./crates/$ASSOCIATED_CRATE/Cargo.toml" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        [ -n "$ASSOCIATED_CRATE_VERSION" ] || (
+            echo "ASSOCIATED_CRATE_VERSION for $ASSOCIATED_CRATE_VERSION is empty" >&2
+            echo "Please check ./crates/$ASSOCIATED_CRATE_VERSION/Cargo.toml" >&2
+            exit 22
+        )
+
+        # Ensure the versions match
+        [ "$CRATE_VERSION" == "$ASSOCIATED_CRATE_VERSION" ] || (
+            echo "Versions for $CRATE and $ASSOCIATED_CRATE do not match. $CHANGELOG_VERSION != $ASSOCIATED_CRATE_VERSION" >&2
+            echo "Ensure the version in ./crates/$CRATE/Cargo.toml matches the version in ./crates/$ASSOCIATED_CRATE/Cargo.toml" >&2
+            exit 23
+        )
+
+    else
+        # Get the latest documented version from the CHANGELOG.md
+        CHANGELOG_VERSION=$(grep -oE '\[[0-9]+\.[0-9]+\.[0-9]+\]' "./crates/$CRATE/CHANGELOG.md" | head -1 | tr -d '[]')
+        [ -n "$CHANGELOG_VERSION" ] || (
+            echo "CHANGELOG_VERSION for $CRATE is empty" >&2
+            echo "Please check the latest release version in ./crates/$CRATE/CHANGELOG.md" >&2
+            exit 24
+        )
+
+        # Ensure the versions match
+        [ "$CRATE_VERSION" == "$CHANGELOG_VERSION" ] || (
+            echo "Versions for $CRATE do not match. $CHANGELOG_VERSION != $CRATE_VERSION." >&2
+            echo "Ensure the version in ./crates/$CRATE/CHANGELOG.md matches the latest release version in ./crates/$CRATE/Cargo.toml" >&2
+            exit 25
+        )
+    fi
+
+    echo "${CRATE}-${CRATE_VERSION}"
+
+done


### PR DESCRIPTION
# Description

Added script to help with release crates:
- `.scripts/verify_crate_versions.sh` - used to ensure `CHANGELOG.md` versions match what is in `Cargo.toml`. Useful when creating a release PR.
- `.scripts/tag_and_push_release.sh` - used after a release PR has been merged. It will fetch the origin, and tag each _not yet tagged_ release to the selected commit, and optionally push the tags.

> [!TIP]
> Should we add `.scripts/verify_crate_versions.sh` to the pre-commit hooks? This can save a lot of time and human error.
