### PR TITLE
fix: Invalid CRD schema for StackableAffinity contents

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Rollout tracker for `StatefulSet` ([#833]).
 
+### Fixed
+
+- Invalid CRD schema for `StackableAffinity` contents. This was caused by the fields being optional and defaulting to `null`, while the custom schema marked the field as required ([XXX]).
+
 [#833]: https://github.com/stackabletech/operator-rs/pull/833
 
 ## [0.72.0] - 2024-08-05

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Invalid CRD schema for `StackableAffinity` contents. This was caused by the fields being optional and defaulting to `null`, while the custom schema marked the field as required ([836]).
+- Invalid CRD schema for `StackableAffinity` contents. This was caused by the fields being optional and defaulting to `null`, while the custom schema marked the field as required ([#836]).
 
 [#833]: https://github.com/stackabletech/operator-rs/pull/833
 [#836]: https://github.com/stackabletech/operator-rs/pull/836

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Invalid CRD schema for `StackableAffinity` contents. This was caused by the fields being optional and defaulting to `null`, while the custom schema marked the field as required ([XXX]).
+- Invalid CRD schema for `StackableAffinity` contents. This was caused by the fields being optional and defaulting to `null`, while the custom schema marked the field as required ([836]).
 
 [#833]: https://github.com/stackabletech/operator-rs/pull/833
+[#836]: https://github.com/stackabletech/operator-rs/pull/836
 
 ## [0.72.0] - 2024-08-05
 

--- a/crates/stackable-operator/src/commons/affinity.rs
+++ b/crates/stackable-operator/src/commons/affinity.rs
@@ -13,7 +13,7 @@ use stackable_operator_derive::Fragment;
 use crate::{
     config::merge::{Atomic, Merge},
     kvp::consts::{K8S_APP_COMPONENT_KEY, K8S_APP_INSTANCE_KEY, K8S_APP_NAME_KEY},
-    utils::crds::raw_object_schema,
+    utils::crds::raw_optional_object_schema,
 };
 
 pub const TOPOLOGY_KEY_HOSTNAME: &str = "kubernetes.io/hostname";
@@ -38,15 +38,15 @@ pub const TOPOLOGY_KEY_HOSTNAME: &str = "kubernetes.io/hostname";
 )]
 pub struct StackableAffinity {
     /// Same as the `spec.affinity.podAffinity` field on the Pod, see the [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node)
-    #[fragment_attrs(schemars(schema_with = "raw_object_schema"))]
+    #[fragment_attrs(schemars(schema_with = "raw_optional_object_schema"))]
     pub pod_affinity: Option<PodAffinity>,
 
     /// Same as the `spec.affinity.podAntiAffinity` field on the Pod, see the [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node)
-    #[fragment_attrs(schemars(schema_with = "raw_object_schema"))]
+    #[fragment_attrs(schemars(schema_with = "raw_optional_object_schema"))]
     pub pod_anti_affinity: Option<PodAntiAffinity>,
 
     /// Same as the `spec.affinity.nodeAffinity` field on the Pod, see the [Kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node)
-    #[fragment_attrs(schemars(schema_with = "raw_object_schema"))]
+    #[fragment_attrs(schemars(schema_with = "raw_optional_object_schema"))]
     pub node_affinity: Option<NodeAffinity>,
 
     // This schema isn't big, so it can stay

--- a/crates/stackable-operator/src/utils/crds.rs
+++ b/crates/stackable-operator/src/utils/crds.rs
@@ -8,6 +8,15 @@ pub fn raw_object_schema(_: &mut schemars::gen::SchemaGenerator) -> Schema {
     .expect("Failed to parse JSON of custom raw object schema")
 }
 
+pub fn raw_optional_object_schema(_: &mut schemars::gen::SchemaGenerator) -> Schema {
+    serde_json::from_value(serde_json::json!({
+        "type": "object",
+        "nullable": true,
+        "x-kubernetes-preserve-unknown-fields": true,
+    }))
+    .expect("Failed to parse JSON of custom optional raw object schema")
+}
+
 pub fn raw_object_list_schema(_: &mut schemars::gen::SchemaGenerator) -> Schema {
     serde_json::from_value(serde_json::json!({
         "type": "array",


### PR DESCRIPTION
# Description

Fixup of https://github.com/stackabletech/operator-rs/pull/821

Before
```
The CustomResourceDefinition "druidclusters.druid.stackable.tech" is invalid: 
* spec.validation.openAPIV3Schema.properties[spec].properties[coordinators].properties[config].properties[affinity].default.podAffinity: Invalid value: "null": podAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[coordinators].properties[config].properties[affinity].default.podAntiAffinity: Invalid value: "null": podAntiAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[coordinators].properties[config].properties[affinity].default.nodeAffinity: Invalid value: "null": nodeAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[historicals].properties[config].properties[affinity].default.nodeAffinity: Invalid value: "null": nodeAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[historicals].properties[config].properties[affinity].default.podAffinity: Invalid value: "null": podAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[historicals].properties[config].properties[affinity].default.podAntiAffinity: Invalid value: "null": podAntiAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[middleManagers].properties[config].properties[affinity].default.podAntiAffinity: Invalid value: "null": podAntiAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[middleManagers].properties[config].properties[affinity].default.nodeAffinity: Invalid value: "null": nodeAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[middleManagers].properties[config].properties[affinity].default.podAffinity: Invalid value: "null": podAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[routers].properties[config].properties[affinity].default.podAffinity: Invalid value: "null": podAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[routers].properties[config].properties[affinity].default.podAntiAffinity: Invalid value: "null": podAntiAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[routers].properties[config].properties[affinity].default.nodeAffinity: Invalid value: "null": nodeAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[brokers].properties[config].properties[affinity].default.nodeAffinity: Invalid value: "null": nodeAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[brokers].properties[config].properties[affinity].default.podAffinity: Invalid value: "null": podAffinity in body must be of type object: "null"
* spec.validation.openAPIV3Schema.properties[spec].properties[brokers].properties[config].properties[affinity].default.podAntiAffinity: Invalid value: "null": podAntiAffinity in body must be of type object: "null"
```

After
```
customresourcedefinition.apiextensions.k8s.io/druidclusters.druid.stackable.tech created
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
