### PR TITLE
Add iter::reverse_if helper

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `iter::reverse_if` helper ([#838]).
+
+[#838]: https://github.com/stackabletech/operator-rs/pull/838
+
 ## [0.73.0] - 2024-08-09
 
 ### Added


### PR DESCRIPTION
# Description

This is an alternative to

```rust
if cond {
    // must collect here, since foo.rev() is a distinct type from foo
    foo.rev().collect::<Vec<_>>()
} else {
    foo.collect()
}
```

That is both much more convenient to use and avoids the buffering and allocation.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
