### PR TITLE
fix(stackable-versioned): Validation error reporting

### DIFF
--- a/crates/stackable-versioned-macros/src/attrs/variant.rs
+++ b/crates/stackable-versioned-macros/src/attrs/variant.rs
@@ -52,7 +52,8 @@ impl VariantAttributes {
             .iter()
             .all(|r| r.from.is_case(Case::Pascal))
         {
-            errors.push(Error::custom("renamed variants must use PascalCase"));
+            errors
+                .push(Error::custom("renamed variants must use PascalCase").with_span(&self.ident));
         }
 
         errors.finish()?;

--- a/crates/stackable-versioned-macros/src/codegen/common/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/mod.rs
@@ -58,18 +58,26 @@ pub(crate) fn format_container_from_ident(ident: &Ident) -> Ident {
 ///
 /// See [`DEPRECATED_FIELD_PREFIX`].
 pub(crate) fn remove_deprecated_field_prefix(ident: &Ident) -> Ident {
-    remove_ident_prefix(ident, DEPRECATED_FIELD_PREFIX)
+    format_ident!(
+        "{}",
+        ident
+            .to_string()
+            .trim_start_matches(DEPRECATED_FIELD_PREFIX)
+    )
 }
 
 /// Removes the deprecated prefix from a variant ident.
 ///
 /// See [`DEPRECATED_VARIANT_PREFIX`].
 pub(crate) fn remove_deprecated_variant_prefix(ident: &Ident) -> Ident {
-    remove_ident_prefix(ident, DEPRECATED_VARIANT_PREFIX)
-}
-
-/// Removes the provided prefix from an ident and returns the newly created
-/// ident.
-pub(crate) fn remove_ident_prefix(ident: &Ident, prefix: &str) -> Ident {
-    format_ident!("{}", ident.to_string().trim_start_matches(prefix))
+    // NOTE (@Techassi): Currently Clippy only issues a warning for variants
+    // with underscores in their name. That's why we additionally remove the
+    // underscore from the ident to use the expected name during code generation.
+    format_ident!(
+        "{}",
+        ident
+            .to_string()
+            .trim_start_matches(DEPRECATED_VARIANT_PREFIX)
+            .trim_start_matches('_')
+    )
 }

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Report variant rename validation error at the correct span and trim underscores
+  from variants not using PascalCase (#[xxx]).
+
+[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
+
 ## [0.1.1] - 2024-07-10
 
 ### Added


### PR DESCRIPTION
This fixes two issues:

- Variant rename validation errors showed up at the wrong place. It now used the span of the variant ident.
- Variants not using PascalCase (for example: `My_Variant`) included the leading underscore in the generated variant name.

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Changelog updated
```