### PR TITLE
feat: Add constants for configOverrides file header and footer keys

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - BREAKING: Replace `lazy_static` with `std::cell::LazyCell` (the original implementation was done in [#827] and reverted in [#835]) ([#840]).
+- Add two new constants `CONFIG_OVERRIDE_FILE_HEADER_KEY` and `CONFIG_OVERRIDE_FILE_FOOTER_KEY` ([#843])
+
+[#843]: https://github.com/stackabletech/operator-rs/pull/843
 
 ### Added
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,16 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- BREAKING: Replace `lazy_static` with `std::cell::LazyCell` (the original implementation was done in [#827] and reverted in [#835]) ([#840]).
-- Add two new constants `CONFIG_OVERRIDE_FILE_HEADER_KEY` and `CONFIG_OVERRIDE_FILE_FOOTER_KEY` ([#843])
-
-[#843]: https://github.com/stackabletech/operator-rs/pull/843
-
 ### Added
 
 - `iter::reverse_if` helper ([#838]).
+- Add two new constants `CONFIG_OVERRIDE_FILE_HEADER_KEY` and `CONFIG_OVERRIDE_FILE_FOOTER_KEY` ([#843]).
+
+### Changed
+
+- BREAKING: Replace `lazy_static` with `std::cell::LazyCell` (the original implementation was done in [#827] and reverted in [#835]) ([#840]).
 
 [#838]: https://github.com/stackabletech/operator-rs/pull/838
+[#843]: https://github.com/stackabletech/operator-rs/pull/843
 
 ## [0.73.0] - 2024-08-09
 

--- a/crates/stackable-operator/src/config/fragment.rs
+++ b/crates/stackable-operator/src/config/fragment.rs
@@ -18,9 +18,6 @@ use crate::role_utils::{Role, RoleGroup};
 use k8s_openapi::api::core::v1::PodTemplateSpec;
 use snafu::Snafu;
 
-pub const FILE_HEADER_KEY: &str = "EXPERIMENTAL_FILE_HEADER";
-pub const FILE_FOOTER_KEY: &str = "EXPERIMENTAL_FILE_FOOTER";
-
 pub use stackable_operator_derive::Fragment;
 
 /// Contains context used for generating validation errors

--- a/crates/stackable-operator/src/config/fragment.rs
+++ b/crates/stackable-operator/src/config/fragment.rs
@@ -18,6 +18,9 @@ use crate::role_utils::{Role, RoleGroup};
 use k8s_openapi::api::core::v1::PodTemplateSpec;
 use snafu::Snafu;
 
+pub const FILE_HEADER_VARIABLE: &str = "EXPERIMENTAL_FILE_HEADER";
+pub const FILE_FOOTER_VARIABLE: &str = "EXPERIMENTAL_FILE_FOOTER";
+
 pub use stackable_operator_derive::Fragment;
 
 /// Contains context used for generating validation errors

--- a/crates/stackable-operator/src/config/fragment.rs
+++ b/crates/stackable-operator/src/config/fragment.rs
@@ -18,8 +18,8 @@ use crate::role_utils::{Role, RoleGroup};
 use k8s_openapi::api::core::v1::PodTemplateSpec;
 use snafu::Snafu;
 
-pub const FILE_HEADER_VARIABLE: &str = "EXPERIMENTAL_FILE_HEADER";
-pub const FILE_FOOTER_VARIABLE: &str = "EXPERIMENTAL_FILE_FOOTER";
+pub const FILE_HEADER_KEY: &str = "EXPERIMENTAL_FILE_HEADER";
+pub const FILE_FOOTER_KEY: &str = "EXPERIMENTAL_FILE_FOOTER";
 
 pub use stackable_operator_derive::Fragment;
 

--- a/crates/stackable-operator/src/product_config_utils.rs
+++ b/crates/stackable-operator/src/product_config_utils.rs
@@ -8,8 +8,8 @@ use tracing::{debug, error, warn};
 
 use crate::role_utils::{CommonConfiguration, Role};
 
-pub const FILE_HEADER_KEY: &str = "EXPERIMENTAL_FILE_HEADER";
-pub const FILE_FOOTER_KEY: &str = "EXPERIMENTAL_FILE_FOOTER";
+pub const CONFIG_OVERRIDE_FILE_HEADER_KEY: &str = "EXPERIMENTAL_FILE_HEADER";
+pub const CONFIG_OVERRIDE_FILE_FOOTER_KEY: &str = "EXPERIMENTAL_FILE_FOOTER";
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/crates/stackable-operator/src/product_config_utils.rs
+++ b/crates/stackable-operator/src/product_config_utils.rs
@@ -8,6 +8,9 @@ use tracing::{debug, error, warn};
 
 use crate::role_utils::{CommonConfiguration, Role};
 
+pub const FILE_HEADER_KEY: &str = "EXPERIMENTAL_FILE_HEADER";
+pub const FILE_FOOTER_KEY: &str = "EXPERIMENTAL_FILE_FOOTER";
+
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, PartialEq, Snafu)]


### PR DESCRIPTION
# Description

Introducing
```
pub const CONFIG_OVERRIDE_FILE_HEADER_KEY
pub const CONFIG_OVERRIDE_FILE_FOOTER_KEY
```

To be used in Superset and Airflow to have unified key names.

Will be used in https://github.com/stackabletech/superset-operator/pull/530, once merged and released

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
