### PR TITLE
feat(stackable-versioned): Add support for type changes of fields

### DIFF
--- a/crates/stackable-versioned-macros/src/attrs/common/item.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/item.rs
@@ -97,6 +97,11 @@ pub(crate) enum ItemType {
     Variant,
 }
 
+// TODO (@Techassi): Shower thought: Track actions as a Vec of an ActionAttribute
+// enum and implement Ord on it. This would allow us to order the items by type
+// of action (added < changed < deprecated) as well as sort changed action to
+// each other by specified version (which already implements Ord)
+
 /// These attributes are meant to be used in super structs, which add
 /// [`Field`](syn::Field) or [`Variant`](syn::Variant) specific attributes via
 /// darling's flatten feature. This struct only provides shared attributes.

--- a/crates/stackable-versioned-macros/src/attrs/common/item.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/item.rs
@@ -1,7 +1,7 @@
 use darling::{util::SpannedValue, Error, FromMeta};
 use k8s_version::Version;
 use proc_macro2::Span;
-use syn::{spanned::Spanned, Attribute, Ident, Path};
+use syn::{spanned::Spanned, Attribute, Ident, Path, Type};
 
 use crate::{
     attrs::common::ContainerAttributes,
@@ -55,14 +55,14 @@ where
             }
         }
 
-        for rename in &*self.common_attributes().renames {
+        for change in &*self.common_attributes().changes {
             if !container_attrs
                 .versions
                 .iter()
-                .any(|v| v.name == *rename.since)
+                .any(|v| v.name == *change.since)
             {
                 errors.push(
-                   Error::custom("variant action `renamed` uses version which was not declared via #[versioned(version)]")
+                   Error::custom("variant action `changed` uses version which was not declared via #[versioned(version)]")
                    .with_span(item)
                );
             }
@@ -104,8 +104,8 @@ pub(crate) enum ItemType {
 /// ### Shared Item Rules
 ///
 /// - An item can only ever be added once at most. An item not marked as 'added'
-///   is part of the container in every version until renamed or deprecated.
-/// - An item can be renamed many times. That's why renames are stored in a
+///   is part of the container in every version until changed or deprecated.
+/// - An item can be changed many times. That's why changes are stored in a
 ///   [`Vec`].
 /// - An item can only be deprecated once. A field or variant not marked as
 ///   'deprecated' will be included up until the latest version.
@@ -115,10 +115,10 @@ pub(crate) struct ItemAttributes {
     /// only be present at most once.
     pub(crate) added: Option<AddedAttributes>,
 
-    /// This parses the `renamed` attribute on items (fields or variants). It
+    /// This parses the `changed` attribute on items (fields or variants). It
     /// can be present 0..n times.
-    #[darling(multiple, rename = "renamed")]
-    pub(crate) renames: Vec<RenamedAttributes>,
+    #[darling(multiple, rename = "changed")]
+    pub(crate) changes: Vec<ChangedAttributes>,
 
     /// This parses the `deprecated` attribute on items (fields or variants). It
     /// can only be present at most once.
@@ -175,34 +175,34 @@ impl ItemAttributes {
     ///   cannot be marked as added in a particular version and then marked as
     ///   deprecated immediately after. Fields and variants must be included for
     ///   at least one version before being marked deprecated.
-    /// - `added` and `renamed` using the same version: The same reasoning from
+    /// - `added` and `changed` using the same version: The same reasoning from
     ///   above applies here as well. Fields and variants must be included for
-    ///   at least one version before being renamed.
-    /// - `renamed` and `deprecated` using the same version: Again, the same
+    ///   at least one version before being changed.
+    /// - `changed` and `deprecated` using the same version: Again, the same
     ///   rules from above apply here as well.
     fn validate_action_combinations(
         &self,
         item_ident: &Ident,
         item_type: &ItemType,
     ) -> Result<(), Error> {
-        match (&self.added, &self.renames, &self.deprecated) {
+        match (&self.added, &self.changes, &self.deprecated) {
             (Some(added), _, Some(deprecated)) if *added.since == *deprecated.since => {
                 Err(Error::custom(format!(
                     "{item_type} cannot be marked as `added` and `deprecated` in the same version"
                 ))
                 .with_span(item_ident))
             }
-            (Some(added), renamed, _) if renamed.iter().any(|r| *r.since == *added.since) => {
+            (Some(added), changed, _) if changed.iter().any(|r| *r.since == *added.since) => {
                 Err(Error::custom(format!(
-                    "{item_type} cannot be marked as `added` and `renamed` in the same version"
+                    "{item_type} cannot be marked as `added` and `changed` in the same version"
                 ))
                 .with_span(item_ident))
             }
-            (_, renamed, Some(deprecated))
-                if renamed.iter().any(|r| *r.since == *deprecated.since) =>
+            (_, changed, Some(deprecated))
+                if changed.iter().any(|r| *r.since == *deprecated.since) =>
             {
                 Err(Error::custom(
-                    format!("{item_type} cannot be marked as `deprecated` and `renamed` in the same version"),
+                    format!("{item_type} cannot be marked as `deprecated` and `changed` in the same version"),
                 )
                 .with_span(item_ident))
             }
@@ -220,7 +220,7 @@ impl ItemAttributes {
     ///   ensures that these versions are chronologically sound, that means,
     ///   that the version of the deprecated action must be greater than the
     ///   version of the added action.
-    /// - All `renamed` actions must use a greater version than `added` but a
+    /// - All `changed` actions must use a greater version than `added` but a
     ///   lesser version than `deprecated`.
     fn validate_action_order(&self, item_ident: &Ident, item_type: &ItemType) -> Result<(), Error> {
         let added_version = self.added.as_ref().map(|a| *a.since);
@@ -238,14 +238,14 @@ impl ItemAttributes {
             }
         }
 
-        // Now, iterate over all renames and ensure that their versions are
+        // Now, iterate over all changes and ensure that their versions are
         // between the added and deprecated version.
-        if !self.renames.iter().all(|r| {
+        if !self.changes.iter().all(|r| {
             added_version.map_or(true, |a| a < *r.since)
                 && deprecated_version.map_or(true, |d| d > *r.since)
         }) {
             return Err(Error::custom(
-                "all renames must use versions higher than `added` and lower than `deprecated`",
+                "all changes must use versions higher than `added` and lower than `deprecated`",
             )
             .with_span(item_ident));
         }
@@ -320,19 +320,24 @@ pub(crate) struct AddedAttributes {
 
 fn default_default_fn() -> SpannedValue<Path> {
     SpannedValue::new(
-        syn::parse_str("std::default::Default::default").expect("internal error: path must parse"),
+        syn::parse_str("::std::default::Default::default")
+            .expect("internal error: path must parse"),
         Span::call_site(),
     )
 }
 
-/// For the renamed() action
+/// For the changed() action
 ///
 /// Example usage:
-/// - `renamed(since = "...", from = "...")`
+/// - `changed(since = "...", from_name = "...")`
+/// - `changed(since = "...", from_name = "..." from_type="...")`
 #[derive(Clone, Debug, FromMeta)]
-pub(crate) struct RenamedAttributes {
+pub(crate) struct ChangedAttributes {
     pub(crate) since: SpannedValue<Version>,
-    pub(crate) from: SpannedValue<String>,
+    pub(crate) from_name: Option<SpannedValue<String>>,
+
+    #[allow(dead_code)]
+    pub(crate) from_type: Option<SpannedValue<Type>>,
 }
 
 /// For the deprecated() action

--- a/crates/stackable-versioned-macros/src/attrs/common/item.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/item.rs
@@ -143,20 +143,6 @@ impl ItemAttributes {
 
         let mut errors = Error::accumulator();
 
-        // TODO (@Techassi): Make the field or variant 'note' optional, because
-        // in the future, the macro will generate parts of the deprecation note
-        // automatically. The user-provided note will then be appended to the
-        // auto-generated one.
-
-        if let Some(deprecated) = &self.deprecated {
-            if deprecated.note.is_empty() {
-                errors.push(
-                    Error::custom("deprecation note must not be empty")
-                        .with_span(&deprecated.note.span()),
-                );
-            }
-        }
-
         // Semantic validation
         errors.handle(self.validate_action_combinations(item_ident, item_type));
         errors.handle(self.validate_action_order(item_ident, item_type));
@@ -348,9 +334,10 @@ pub(crate) struct ChangedAttributes {
 /// For the deprecated() action
 ///
 /// Example usage:
+/// - `deprecated(since = "...")`
 /// - `deprecated(since = "...", note = "...")`
 #[derive(Clone, Debug, FromMeta)]
 pub(crate) struct DeprecatedAttributes {
     pub(crate) since: SpannedValue<Version>,
-    pub(crate) note: SpannedValue<String>,
+    pub(crate) note: Option<SpannedValue<String>>,
 }

--- a/crates/stackable-versioned-macros/src/attrs/common/item.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/item.rs
@@ -327,7 +327,6 @@ pub(crate) struct ChangedAttributes {
     pub(crate) since: SpannedValue<Version>,
     pub(crate) from_name: Option<SpannedValue<String>>,
 
-    #[allow(dead_code)]
     pub(crate) from_type: Option<SpannedValue<Type>>,
 }
 

--- a/crates/stackable-versioned-macros/src/attrs/field.rs
+++ b/crates/stackable-versioned-macros/src/attrs/field.rs
@@ -50,8 +50,8 @@ impl FieldAttributes {
             .ident
             .as_ref()
             .expect("internal error: field must have an ident");
-        self.common.validate(ident, &ItemType::Field, &self.attrs)?;
 
+        self.common.validate(ident, &ItemType::Field, &self.attrs)?;
         Ok(self)
     }
 }

--- a/crates/stackable-versioned-macros/src/attrs/variant.rs
+++ b/crates/stackable-versioned-macros/src/attrs/variant.rs
@@ -55,12 +55,14 @@ impl VariantAttributes {
         );
 
         // Validate names of renames
-        for rename in &self.common.renames {
-            if !rename.from.is_case(Case::Pascal) {
-                errors.push(
-                    Error::custom("renamed variant must use PascalCase")
-                        .with_span(&rename.from.span()),
-                )
+        for change in &self.common.changes {
+            if let Some(from_name) = &change.from_name {
+                if !from_name.is_case(Case::Pascal) {
+                    errors.push(
+                        Error::custom("renamed variant must use PascalCase")
+                            .with_span(&from_name.span()),
+                    )
+                }
             }
         }
 

--- a/crates/stackable-versioned-macros/src/codegen/chain.rs
+++ b/crates/stackable-versioned-macros/src/codegen/chain.rs
@@ -91,7 +91,7 @@ mod test {
     #[case(2, (Some(&"test1"), Some(&"test3")))]
     #[case(3, (Some(&"test1"), None))]
     #[case(4, (Some(&"test3"), None))]
-    fn test(#[case] key: i32, #[case] expected: (Option<&&str>, Option<&&str>)) {
+    fn neighbors(#[case] key: i32, #[case] expected: (Option<&&str>, Option<&&str>)) {
         let map = BTreeMap::from([(1, "test1"), (3, "test3")]);
         let neigbors = map.get_neighbors(&key);
 

--- a/crates/stackable-versioned-macros/src/codegen/common/item.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/item.rs
@@ -153,7 +153,6 @@ where
             );
 
             for change in common_attributes.changes.iter().rev() {
-                dbg!(&ty, &change.since);
                 let from_ident = if let Some(from) = change.from_name.as_deref() {
                     format_ident!("{from}")
                 } else {

--- a/crates/stackable-versioned-macros/src/codegen/common/item.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/item.rs
@@ -148,7 +148,7 @@ where
                 ItemStatus::Deprecation {
                     previous_ident: ident.clone(),
                     ident: deprecated_ident.clone(),
-                    note: deprecated.note.to_string(),
+                    note: deprecated.note.as_deref().cloned(),
                 },
             );
 
@@ -363,8 +363,8 @@ pub(crate) enum ItemStatus {
     },
     Deprecation {
         previous_ident: Ident,
+        note: Option<String>,
         ident: Ident,
-        note: String,
     },
     NoChange(Ident),
     NotPresent,

--- a/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
@@ -1,9 +1,9 @@
 use std::ops::{Deref, DerefMut};
 
 use darling::FromVariant;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Ident, Variant};
+use syn::{token::Not, Ident, Type, TypeNever, Variant};
 
 use crate::{
     attrs::{
@@ -13,8 +13,8 @@ use crate::{
     codegen::{
         chain::BTreeMapExt,
         common::{
-            remove_deprecated_variant_prefix, Attributes, ContainerVersion, Item, ItemStatus,
-            Named, VersionedItem,
+            remove_deprecated_variant_prefix, Attributes, ContainerVersion, InnerItem, Item,
+            ItemStatus, Named, VersionedItem,
         },
     },
 };
@@ -61,6 +61,17 @@ impl Attributes for VariantAttributes {
 
     fn original_attributes(&self) -> &Vec<syn::Attribute> {
         &self.attrs
+    }
+}
+
+impl InnerItem for Variant {
+    fn ty(&self) -> syn::Type {
+        // FIXME (@Techassi): As we currently don't support enum variants with
+        // data, we just return the Never type as the code generation code for
+        // enum variants won't use this type information.
+        Type::Never(TypeNever {
+            bang_token: Not([Span::call_site()]),
+        })
     }
 }
 

--- a/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
@@ -102,15 +102,15 @@ impl VersionedVariant {
                     container_version.inner
                 )
             }) {
-                ItemStatus::Added { ident, .. } => Some(quote! {
+                ItemStatus::Addition { ident, .. } => Some(quote! {
                     #(#original_attributes)*
                     #ident,
                 }),
-                ItemStatus::Renamed { to, .. } => Some(quote! {
+                ItemStatus::Change { to_ident, .. } => Some(quote! {
                     #(#original_attributes)*
-                    #to,
+                    #to_ident,
                 }),
-                ItemStatus::Deprecated { ident, .. } => Some(quote! {
+                ItemStatus::Deprecation { ident, .. } => Some(quote! {
                     #(#original_attributes)*
                     #[deprecated]
                     #ident,
@@ -149,7 +149,7 @@ impl VersionedVariant {
                 chain.get_expect(&version.inner),
                 chain.get_expect(&next_version.inner),
             ) {
-                (_, ItemStatus::Added { .. }) => quote! {},
+                (_, ItemStatus::Addition { .. }) => quote! {},
                 (old, next) => {
                     let old_variant_ident = old
                         .get_ident()

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
@@ -115,15 +115,15 @@ impl VersionedField {
                         container_version.inner
                     )
                 }) {
-                    ItemStatus::Added { ident, .. } => Some(quote! {
+                    ItemStatus::Addition { ident, .. } => Some(quote! {
                         #(#original_attributes)*
                         pub #ident: #field_type,
                     }),
-                    ItemStatus::Renamed { to, .. } => Some(quote! {
+                    ItemStatus::Change { to_ident, .. } => Some(quote! {
                         #(#original_attributes)*
-                        pub #to: #field_type,
+                        pub #to_ident: #field_type,
                     }),
-                    ItemStatus::Deprecated {
+                    ItemStatus::Deprecation {
                         ident: field_ident,
                         note,
                         ..
@@ -170,7 +170,7 @@ impl VersionedField {
                         .get(&next_version.inner)
                         .expect("internal error: chain must contain container version"),
                 ) {
-                    (_, ItemStatus::Added { ident, default_fn }) => quote! {
+                    (_, ItemStatus::Addition { ident, default_fn }) => quote! {
                         #ident: #default_fn(),
                     },
                     (old, next) => {

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
@@ -202,6 +202,25 @@ impl VersionedField {
                     ) => quote! {
                         #ident: #default_fn(),
                     },
+                    (
+                        _,
+                        ItemStatus::Change {
+                            from_ident: old_field_ident,
+                            to_ident,
+                            from_type,
+                            to_type,
+                        },
+                    ) => {
+                        if from_type == to_type {
+                            quote! {
+                                #to_ident: #from_ident.#old_field_ident,
+                            }
+                        } else {
+                            quote! {
+                                #to_ident: #from_ident.#old_field_ident.into(),
+                            }
+                        }
+                    }
                     (old, next) => {
                         let old_field_ident = old
                             .get_ident()

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -27,7 +27,7 @@ mod consts;
 ///     /// My docs
 ///     #[versioned(
 ///         added(since = "v1beta1"),
-///         renamed(since = "v1", from = "gau"),
+///         changed(since = "v1", from_name = "gau"),
 ///         deprecated(since = "v2", note = "not empty")
 ///     )]
 ///     deprecated_bar: usize,

--- a/crates/stackable-versioned-macros/tests/good/attributes_enum.rs
+++ b/crates/stackable-versioned-macros/tests/good/attributes_enum.rs
@@ -36,8 +36,8 @@ fn main() {
         Baz,
 
         /// This is will keep changing over time.
-        #[versioned(renamed(since = "v1beta1", from = "Qoox"))]
-        #[versioned(renamed(since = "v1", from = "Qaax"))]
+        #[versioned(changed(since = "v1beta1", from_name = "Qoox"))]
+        #[versioned(changed(since = "v1", from_name = "Qaax"))]
         Quux,
     }
 }

--- a/crates/stackable-versioned-macros/tests/good/attributes_struct.rs
+++ b/crates/stackable-versioned-macros/tests/good/attributes_struct.rs
@@ -31,8 +31,8 @@ fn main() {
         baz: String,
 
         /// This is will keep changing over time.
-        #[versioned(renamed(since = "v1beta1", from = "qoox"))]
-        #[versioned(renamed(since = "v1", from = "qaax"))]
+        #[versioned(changed(since = "v1beta1", from_name = "qoox"))]
+        #[versioned(changed(since = "v1", from_name = "qaax"))]
         quux: String,
     }
 

--- a/crates/stackable-versioned-macros/tests/good/basic.rs
+++ b/crates/stackable-versioned-macros/tests/good/basic.rs
@@ -9,7 +9,8 @@ use stackable_versioned_macros::versioned;
     version(name = "v1beta1"),
     version(name = "v1"),
     version(name = "v2"),
-    version(name = "v3")
+    version(name = "v3"),
+    options(skip(from))
 )]
 pub(crate) struct Foo {
     #[versioned(

--- a/crates/stackable-versioned-macros/tests/good/basic.rs
+++ b/crates/stackable-versioned-macros/tests/good/basic.rs
@@ -9,8 +9,7 @@ use stackable_versioned_macros::versioned;
     version(name = "v1beta1"),
     version(name = "v1"),
     version(name = "v2"),
-    version(name = "v3"),
-    options(skip(from))
+    version(name = "v3")
 )]
 pub(crate) struct Foo {
     #[versioned(

--- a/crates/stackable-versioned-macros/tests/good/basic.rs
+++ b/crates/stackable-versioned-macros/tests/good/basic.rs
@@ -11,10 +11,11 @@ use stackable_versioned_macros::versioned;
     version(name = "v2"),
     version(name = "v3")
 )]
-struct Foo {
+pub(crate) struct Foo {
     #[versioned(
         added(since = "v1alpha1"),
-        renamed(since = "v1beta1", from = "jjj"),
+        changed(since = "v1beta1", from_name = "jjj", from_type = "u8"),
+        changed(since = "v1", from_type = "u16"),
         deprecated(since = "v2", note = "not empty")
     )]
     /// Test

--- a/crates/stackable-versioned-macros/tests/good/rename.rs
+++ b/crates/stackable-versioned-macros/tests/good/rename.rs
@@ -7,7 +7,7 @@ fn main() {
         version(name = "v1")
     )]
     struct Foo {
-        #[versioned(renamed(since = "v1beta1", from = "bat"))]
+        #[versioned(changed(since = "v1beta1", from_name = "bat"))]
         bar: usize,
         baz: bool,
     }

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -6,11 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add `changed()` action and support for the `ty` parameter in the `renamed()`
-  action ([#844]).
+- Add new `from_type` parameter to `changed()` action ([#844]).
 - Pass through container and item attributes (including doc-comments). Add
   attribute for version specific docs ([#847]).
 - Forward container visibility to generated modules ([#850]).
+
+### Changed
+
+- BREAKING: Rename `renamed()` action to `changed()` and renamed `from`
+  parameter to `from_name` ([#844]).
 
 ### Fixed
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `changed()` action and support for the `ty` parameter in the `renamed()`
-  action ([#xxx]).
+  action ([#844]).
 
-[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#844]: https://github.com/stackabletech/operator-rs/pull/844
 
 ### Fixed
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `changed()` action and support for the `ty` parameter in the `renamed()`
+  action ([#xxx]).
+
+[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
+
 ### Fixed
 
 - Report variant rename validation error at the correct span and trim underscores

--- a/crates/stackable-versioned/src/lib.rs
+++ b/crates/stackable-versioned/src/lib.rs
@@ -19,7 +19,7 @@
 //!     /// My docs
 //!     #[versioned(
 //!         added(since = "v1beta1"),
-//!         renamed(since = "v1", from = "gau"),
+//!         changed(since = "v1", from_name = "gau"),
 //!         deprecated(since = "v2", note = "not empty")
 //!     )]
 //!     deprecated_bar: usize,


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

This PR adds support for type changes of struct fields. This is done by renaming the `renamed()` action to `changed()` and adding a new parameter `from_type` to it. Additionally, `from` will be renamed to `from_name`. 

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
