### PR TITLE
feat(stackable-versioned-macros): Handle attribute forwarding

### DIFF
--- a/crates/stackable-versioned-macros/src/attrs/common/container.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/container.rs
@@ -96,11 +96,13 @@ impl ContainerAttributes {
 /// - `name` of the version, like `v1alpha1`.
 /// - `deprecated` flag to mark that version as deprecated.
 /// - `skip` option to skip generating various pieces of code.
+/// - `doc` option to add version-specific documentation.
 #[derive(Clone, Debug, FromMeta)]
 pub(crate) struct VersionAttributes {
     pub(crate) deprecated: Flag,
     pub(crate) name: Version,
     pub(crate) skip: Option<SkipOptions>,
+    pub(crate) doc: Option<String>,
 }
 
 /// This struct contains supported container options.

--- a/crates/stackable-versioned-macros/src/attrs/common/item.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/item.rs
@@ -202,7 +202,7 @@ impl ItemAttributes {
                 if renamed.iter().any(|r| *r.since == *deprecated.since) =>
             {
                 Err(Error::custom(
-                    "cannot be marked as `deprecated` and `renamed` in the same version",
+                    format!("{item_type} cannot be marked as `deprecated` and `renamed` in the same version"),
                 )
                 .with_span(item_ident))
             }
@@ -260,8 +260,8 @@ impl ItemAttributes {
     /// The following naming rules apply:
     ///
     /// - Fields or variants marked as deprecated need to include the
-    ///   'deprecated_' prefix in their name. The prefix must not be included
-    ///   for fields or variants which are not deprecated.
+    ///   deprecation prefix in their name. The prefix must not be included for
+    ///   fields or variants which are not deprecated.
     fn validate_item_name(&self, item_ident: &Ident, item_type: &ItemType) -> Result<(), Error> {
         let prefix = match item_type {
             ItemType::Field => DEPRECATED_FIELD_PREFIX,
@@ -290,14 +290,14 @@ impl ItemAttributes {
     ///
     /// The following naming rules apply:
     ///
-    /// - `deprecated` must not be set on items. Instead, the
-    ///   stackable-versioned method of deprecating items should be used.
+    /// - `deprecated` must not be set on items. Instead, use the `deprecated()`
+    ///   action of the `#[versioned()]` macro.
     fn validate_item_attributes(&self, item_attrs: &Vec<Attribute>) -> Result<(), Error> {
         for attr in item_attrs {
             for segment in &attr.path().segments {
                 if segment.ident == "deprecated" {
                     return Err(Error::custom("deprecation must be done using #[versioned(deprecated(since = \"VERSION\"))]")
-                        .with_span(&segment.ident.span()));
+                        .with_span(&attr.span()));
                 }
             }
         }

--- a/crates/stackable-versioned-macros/src/attrs/field.rs
+++ b/crates/stackable-versioned-macros/src/attrs/field.rs
@@ -31,10 +31,10 @@ pub(crate) struct FieldAttributes {
     // `Option<Ident>`, while for enum variants, the type is `Ident`.
     pub(crate) ident: Option<Ident>,
 
-    /// The original attributes for the field.
     // This must be named `attrs` for darling to populate it accordingly, and
     // cannot live in common because Vec<Attribute> is not implemented for
     // FromMeta.
+    /// The original attributes for the field.
     pub(crate) attrs: Vec<Attribute>,
 }
 

--- a/crates/stackable-versioned-macros/src/attrs/field.rs
+++ b/crates/stackable-versioned-macros/src/attrs/field.rs
@@ -1,5 +1,5 @@
 use darling::{Error, FromField};
-use syn::Ident;
+use syn::{Attribute, Ident};
 
 use crate::attrs::common::{ItemAttributes, ItemType};
 
@@ -19,7 +19,7 @@ use crate::attrs::common::{ItemAttributes, ItemType};
 #[derive(Debug, FromField)]
 #[darling(
     attributes(versioned),
-    forward_attrs(allow, doc, cfg, serde),
+    forward_attrs,
     and_then = FieldAttributes::validate
 )]
 pub(crate) struct FieldAttributes {
@@ -30,6 +30,12 @@ pub(crate) struct FieldAttributes {
     // shared item attributes because for struct fields, the type is
     // `Option<Ident>`, while for enum variants, the type is `Ident`.
     pub(crate) ident: Option<Ident>,
+
+    /// The original attributes for the field.
+    // This must be named `attrs` for darling to populate it accordingly, and
+    // cannot live in common because Vec<Attribute> is not implemented for
+    // FromMeta.
+    pub(crate) attrs: Vec<Attribute>,
 }
 
 impl FieldAttributes {
@@ -44,7 +50,7 @@ impl FieldAttributes {
             .ident
             .as_ref()
             .expect("internal error: field must have an ident");
-        self.common.validate(ident, &ItemType::Field)?;
+        self.common.validate(ident, &ItemType::Field, &self.attrs)?;
 
         Ok(self)
     }

--- a/crates/stackable-versioned-macros/src/attrs/variant.rs
+++ b/crates/stackable-versioned-macros/src/attrs/variant.rs
@@ -32,10 +32,10 @@ pub(crate) struct VariantAttributes {
     // `Option<Ident>`, while for enum variants, the type is `Ident`.
     pub(crate) ident: Ident,
 
-    /// The original attributes for the field.
     // This must be named `attrs` for darling to populate it accordingly, and
     // cannot live in common because Vec<Attribute> is not implemented for
     // FromMeta.
+    /// The original attributes for the field.
     pub(crate) attrs: Vec<Attribute>,
 }
 

--- a/crates/stackable-versioned-macros/src/attrs/variant.rs
+++ b/crates/stackable-versioned-macros/src/attrs/variant.rs
@@ -1,6 +1,6 @@
 use convert_case::{Case, Casing};
 use darling::{Error, FromVariant};
-use syn::Ident;
+use syn::{Attribute, Ident};
 
 use crate::attrs::common::{ItemAttributes, ItemType};
 
@@ -20,7 +20,7 @@ use crate::attrs::common::{ItemAttributes, ItemType};
 #[derive(Debug, FromVariant)]
 #[darling(
     attributes(versioned),
-    forward_attrs(allow, doc, cfg, serde),
+    forward_attrs,
     and_then = VariantAttributes::validate
 )]
 pub(crate) struct VariantAttributes {
@@ -31,6 +31,12 @@ pub(crate) struct VariantAttributes {
     // shared item attributes because for struct fields, the type is
     // `Option<Ident>`, while for enum variants, the type is `Ident`.
     pub(crate) ident: Ident,
+
+    /// The original attributes for the field.
+    // This must be named `attrs` for darling to populate it accordingly, and
+    // cannot live in common because Vec<Attribute> is not implemented for
+    // FromMeta.
+    pub(crate) attrs: Vec<Attribute>,
 }
 
 impl VariantAttributes {
@@ -43,7 +49,10 @@ impl VariantAttributes {
     fn validate(self) -> Result<Self, Error> {
         let mut errors = Error::accumulator();
 
-        errors.handle(self.common.validate(&self.ident, &ItemType::Variant));
+        errors.handle(
+            self.common
+                .validate(&self.ident, &ItemType::Variant, &self.attrs),
+        );
 
         // Validate names of renames
         if !self

--- a/crates/stackable-versioned-macros/src/codegen/common/container.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/container.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use proc_macro2::TokenStream;
-use syn::Ident;
+use syn::{Attribute, Ident};
 
 use crate::{attrs::common::ContainerAttributes, codegen::common::ContainerVersion};
 
@@ -21,7 +21,12 @@ where
     Self: Sized + Deref<Target = VersionedContainer<I>>,
 {
     /// Creates a new versioned container.
-    fn new(ident: Ident, data: D, attributes: ContainerAttributes) -> syn::Result<Self>;
+    fn new(
+        ident: Ident,
+        data: D,
+        attributes: ContainerAttributes,
+        original_attributes: Vec<Attribute>,
+    ) -> syn::Result<Self>;
 
     /// This generates the complete code for a single versioned container.
     ///
@@ -56,4 +61,7 @@ pub(crate) struct VersionedContainer<I> {
     /// Whether the [`From`] implementation generation should be skipped for all
     /// versions of this container.
     pub(crate) skip_from: bool,
+
+    /// The original attributes that were added to the container.
+    pub(crate) original_attributes: Vec<Attribute>,
 }

--- a/crates/stackable-versioned-macros/src/codegen/common/container.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/container.rs
@@ -32,12 +32,28 @@ where
     fn generate_tokens(&self) -> TokenStream;
 }
 
+/// Stores individual versions of a single container.
+///
+/// Each version tracks item actions, which describe if the item was added,
+/// renamed or deprecated in that particular version. Items which are not
+/// versioned are included in every version of the container.
 #[derive(Debug)]
 pub(crate) struct VersionedContainer<I> {
+    /// List of declared versions for this container. Each version generates a
+    /// definition with appropriate items.
     pub(crate) versions: Vec<ContainerVersion>,
+
+    /// List of items defined in the original container. How, and if, an item
+    /// should generate code, is decided by the currently generated version.
     pub(crate) items: Vec<I>,
+
+    /// The ident, or name, of the versioned container.
     pub(crate) ident: Ident,
 
+    /// The name of the container used in `From` implementations.
     pub(crate) from_ident: Ident,
+
+    /// Whether the [`From`] implementation generation should be skipped for all
+    /// versions of this container.
     pub(crate) skip_from: bool,
 }

--- a/crates/stackable-versioned-macros/src/codegen/common/item.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/item.rs
@@ -110,7 +110,7 @@ where
         let attrs = A::try_from(&item)?;
         attrs.validate_versions(container_attrs, &item)?;
 
-        // These are the attributes addde to the item outside of the macro.
+        // These are the attributes added to the item outside of the macro.
         let original_attributes = attrs.original_attributes().clone();
 
         // These are the versioned macro attrs that are common to all items.

--- a/crates/stackable-versioned-macros/src/codegen/common/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/mod.rs
@@ -32,6 +32,26 @@ pub(crate) struct ContainerVersion {
 
     /// The ident of the container.
     pub(crate) ident: Ident,
+
+    /// Store an additional doc-comment lines for this version.
+    pub(crate) version_specific_docs: Vec<String>,
+}
+
+/// Converts lines of doc-comments into a trimmed list.
+fn process_docs(input: &Option<String>) -> Vec<String> {
+    if let Some(input) = input {
+        input
+            // Trim the leading and trailing whitespace, deleting suprefluous
+            // empty lines.
+            .trim()
+            .lines()
+            // Trim the leading and trailing whitespace on each line that can be
+            // introduced when the developer indents multi-line comments.
+            .map(|line| line.trim().to_owned())
+            .collect()
+    } else {
+        Vec::new()
+    }
 }
 
 impl From<&ContainerAttributes> for Vec<ContainerVersion> {
@@ -44,6 +64,7 @@ impl From<&ContainerAttributes> for Vec<ContainerVersion> {
                 ident: Ident::new(&v.name.to_string(), Span::call_site()),
                 deprecated: v.deprecated.is_present(),
                 inner: v.name,
+                version_specific_docs: process_docs(&v.doc),
             })
             .collect()
     }

--- a/crates/stackable-versioned-macros/src/codegen/common/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/mod.rs
@@ -33,7 +33,7 @@ pub(crate) struct ContainerVersion {
     /// The ident of the container.
     pub(crate) ident: Ident,
 
-    /// Store an additional doc-comment lines for this version.
+    /// Store additional doc-comment lines for this version.
     pub(crate) version_specific_docs: Vec<String>,
 }
 

--- a/crates/stackable-versioned-macros/src/codegen/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/mod.rs
@@ -26,9 +26,11 @@ pub(crate) mod vstruct;
 pub(crate) fn expand(attributes: ContainerAttributes, input: DeriveInput) -> Result<TokenStream> {
     let expanded = match input.data {
         Data::Struct(data) => {
-            VersionedStruct::new(input.ident, data, attributes)?.generate_tokens()
+            VersionedStruct::new(input.ident, data, attributes, input.attrs)?.generate_tokens()
         }
-        Data::Enum(data) => VersionedEnum::new(input.ident, data, attributes)?.generate_tokens(),
+        Data::Enum(data) => {
+            VersionedEnum::new(input.ident, data, attributes, input.attrs)?.generate_tokens()
+        }
         _ => {
             return Err(Error::new(
                 input.span(),

--- a/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
@@ -122,12 +122,27 @@ impl VersionedEnum {
             .deprecated
             .then_some(quote! {#[deprecated = #deprecated_note]});
 
+        let mut version_specific_docs = TokenStream::new();
+        for (i, doc) in version.version_specific_docs.iter().enumerate() {
+            if i == 0 {
+                // Prepend an empty line to clearly separate the version
+                // specific docs.
+                version_specific_docs.extend(quote! {
+                    #[doc = ""]
+                })
+            }
+            version_specific_docs.extend(quote! {
+                #[doc = #doc]
+            })
+        }
+
         // Generate tokens for the module and the contained enum
         token_stream.extend(quote! {
             #[automatically_derived]
             #deprecated_attr
             pub mod #version_ident {
                 #(#original_attributes)*
+                #version_specific_docs
                 pub enum #enum_name {
                     #variants
                 }

--- a/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{DataEnum, Error, Ident};
+use syn::{Attribute, DataEnum, Error, Ident};
 
 use crate::{
     attrs::common::ContainerAttributes,
@@ -33,7 +33,12 @@ impl Deref for VersionedEnum {
 }
 
 impl Container<DataEnum, VersionedVariant> for VersionedEnum {
-    fn new(ident: Ident, data: DataEnum, attributes: ContainerAttributes) -> syn::Result<Self> {
+    fn new(
+        ident: Ident,
+        data: DataEnum,
+        attributes: ContainerAttributes,
+        original_attributes: Vec<Attribute>,
+    ) -> syn::Result<Self> {
         // Convert the raw version attributes into a container version.
         let versions: Vec<_> = (&attributes).into();
 
@@ -77,6 +82,7 @@ impl Container<DataEnum, VersionedVariant> for VersionedEnum {
             versions,
             items,
             ident,
+            original_attributes,
         }))
     }
 
@@ -100,6 +106,7 @@ impl VersionedEnum {
     ) -> TokenStream {
         let mut token_stream = TokenStream::new();
         let enum_name = &self.ident;
+        let original_attributes = &self.original_attributes;
 
         // Generate variants of the enum for `version`.
         let variants = self.generate_enum_variants(version);
@@ -120,6 +127,7 @@ impl VersionedEnum {
             #[automatically_derived]
             #deprecated_attr
             pub mod #version_ident {
+                #(#original_attributes)*
                 pub enum #enum_name {
                     #variants
                 }

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{DataStruct, Error, Ident};
+use syn::{Attribute, DataStruct, Error, Ident};
 
 use crate::{
     attrs::common::ContainerAttributes,
@@ -33,7 +33,12 @@ impl Deref for VersionedStruct {
 }
 
 impl Container<DataStruct, VersionedField> for VersionedStruct {
-    fn new(ident: Ident, data: DataStruct, attributes: ContainerAttributes) -> syn::Result<Self> {
+    fn new(
+        ident: Ident,
+        data: DataStruct,
+        attributes: ContainerAttributes,
+        original_attributes: Vec<Attribute>,
+    ) -> syn::Result<Self> {
         // Convert the raw version attributes into a container version.
         let versions: Vec<_> = (&attributes).into();
 
@@ -77,6 +82,7 @@ impl Container<DataStruct, VersionedField> for VersionedStruct {
             versions,
             items,
             ident,
+            original_attributes,
         }))
     }
 
@@ -100,6 +106,7 @@ impl VersionedStruct {
     ) -> TokenStream {
         let mut token_stream = TokenStream::new();
         let struct_name = &self.ident;
+        let original_attributes = &self.original_attributes;
 
         // Generate fields of the struct for `version`.
         let fields = self.generate_struct_fields(version);
@@ -120,6 +127,7 @@ impl VersionedStruct {
             #[automatically_derived]
             #deprecated_attr
             pub mod #version_ident {
+                #(#original_attributes)*
                 pub struct #struct_name {
                     #fields
                 }

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -122,12 +122,27 @@ impl VersionedStruct {
             .deprecated
             .then_some(quote! {#[deprecated = #deprecated_note]});
 
+        let mut version_specific_docs = TokenStream::new();
+        for (i, doc) in version.version_specific_docs.iter().enumerate() {
+            if i == 0 {
+                // Prepend an empty line to clearly separate the version
+                // specific docs.
+                version_specific_docs.extend(quote! {
+                    #[doc = ""]
+                })
+            }
+            version_specific_docs.extend(quote! {
+                #[doc = #doc]
+            })
+        }
+
         // Generate tokens for the module and the contained struct
         token_stream.extend(quote! {
             #[automatically_derived]
             #deprecated_attr
             pub mod #version_ident {
                 #(#original_attributes)*
+                #version_specific_docs
                 pub struct #struct_name {
                     #fields
                 }

--- a/crates/stackable-versioned-macros/tests/attributes.rs
+++ b/crates/stackable-versioned-macros/tests/attributes.rs
@@ -2,7 +2,7 @@ use stackable_versioned_macros::versioned;
 
 #[ignore]
 #[test]
-fn pass_container_attributes() {
+fn pass_struct_attributes() {
     /// General struct docs that cover all versions.
     #[versioned(
         version(name = "v1alpha1"),
@@ -59,4 +59,48 @@ fn pass_container_attributes() {
         baz: String::from("Hello"),
         quux: String::from("World"),
     };
+}
+
+#[ignore]
+#[allow(dead_code)]
+#[test]
+fn pass_enum_attributes() {
+    /// General enum docs that cover all versions.
+    #[versioned(
+        version(name = "v1alpha1"),
+        version(
+            name = "v1beta1",
+            doc = r#"
+                Additional docs for this version which are purposefully long to
+                show how manual line wrapping works. \
+                Multi-line docs are also supported, as per regular doc-comments.
+            "#
+        ),
+        version(name = "v1beta2"),
+        version(name = "v1"),
+        version(name = "v2"),
+        options(skip(from))
+    )]
+    #[derive(Default)]
+    enum Foo {
+        /// This variant is available in every version (so far).
+        #[default]
+        Foo,
+
+        /// Keep the main field docs the same, even after the field is
+        /// deprecated.
+        #[versioned(deprecated(since = "v1beta1", note = "gone"))]
+        DeprecatedBar,
+
+        /// This is for baz
+        #[versioned(added(since = "v1beta1"))]
+        // Just to check stackable-versioned deprecation warning appears.
+        // #[deprecated]
+        Baz,
+
+        /// This is will keep changing over time.
+        #[versioned(renamed(since = "v1beta1", from = "Qoox"))]
+        #[versioned(renamed(since = "v1", from = "Qaax"))]
+        Quux,
+    }
 }

--- a/crates/stackable-versioned-macros/tests/attributes.rs
+++ b/crates/stackable-versioned-macros/tests/attributes.rs
@@ -1,0 +1,50 @@
+use stackable_versioned_macros::versioned;
+
+#[ignore]
+#[test]
+fn pass_container_attributes() {
+    /// General struct docs that cover all versions.
+    #[versioned(
+        version(name = "v1alpha1"),
+        version(name = "v1beta1"),
+        version(name = "v1beta2"),
+        version(name = "v1"),
+        version(name = "v2"),
+        options(skip(from)),
+    )]
+    struct Foo {
+        foo: String,
+
+        #[versioned(deprecated(since = "v1beta1", note = "gone"))]
+        deprecated_bar: String,
+
+        #[versioned(added(since = "v1beta1"))]
+        baz: String,
+
+        #[versioned(renamed(since = "v1beta1", from = "qoox"))]
+        #[versioned(renamed(since = "v1", from = "qaax"))]
+        quux: String,
+    }
+
+    let _ = v1alpha1::Foo {
+        foo: String::from("foo"),
+        bar: String::from("Hello"),
+        qoox: String::from("world"),
+    };
+
+    #[allow(deprecated)]
+    let _ = v1beta1::Foo {
+        foo: String::from("foo"),
+        deprecated_bar: String::from("Hello"),
+        baz: String::from("Hello"),
+        qaax: String::from("World"),
+    };
+
+    #[allow(deprecated)]
+    let _ = v1::Foo {
+        foo: String::from("foo"),
+        deprecated_bar: String::from("Hello"),
+        baz: String::from("Hello"),
+        quux: String::from("World"),
+    };
+}

--- a/crates/stackable-versioned-macros/tests/attributes.rs
+++ b/crates/stackable-versioned-macros/tests/attributes.rs
@@ -13,14 +13,18 @@ fn pass_container_attributes() {
         options(skip(from)),
     )]
     struct Foo {
+        /// This field is available in every version (so far).
         foo: String,
 
+        /// Keep the main field docs the same, even after the field is deprecated.
         #[versioned(deprecated(since = "v1beta1", note = "gone"))]
         deprecated_bar: String,
 
+        /// This is for baz
         #[versioned(added(since = "v1beta1"))]
         baz: String,
 
+        /// This is will keep changing over time.
         #[versioned(renamed(since = "v1beta1", from = "qoox"))]
         #[versioned(renamed(since = "v1", from = "qaax"))]
         quux: String,

--- a/crates/stackable-versioned-macros/tests/attributes.rs
+++ b/crates/stackable-versioned-macros/tests/attributes.rs
@@ -6,12 +6,20 @@ fn pass_container_attributes() {
     /// General struct docs that cover all versions.
     #[versioned(
         version(name = "v1alpha1"),
-        version(name = "v1beta1"),
+        version(
+            name = "v1beta1",
+            doc = r#"
+                Additional docs for this version which are purposefully long to
+                show how manual line wrapping works. \
+                Multi-line docs are also supported, as per regular doc-comments.
+            "#
+        ),
         version(name = "v1beta2"),
         version(name = "v1"),
         version(name = "v2"),
-        options(skip(from)),
+        options(skip(from))
     )]
+    #[derive(Default)]
     struct Foo {
         /// This field is available in every version (so far).
         foo: String,

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Pass through container and item attributes (including doc-comments). Add
+  attribute for version specific docs. ([#847])
+
 ### Fixed
 
 - Report variant rename validation error at the correct span and trim underscores
   from variants not using PascalCase (#[842]).
 
 [#842]: https://github.com/stackabletech/operator-rs/pull/842
+[#847]: https://github.com/stackabletech/operator-rs/pull/847
 
 ## [0.1.1] - 2024-07-10
 


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/507, supersedes https://github.com/stackabletech/operator-rs/pull/816.

- Forward all container (struct/enum) and item (field/variant) attributes (this includes doc-comments).
- Allow docs to be added for a specific version (using the `doc` action attribute).
- Add a test case (purposefully ignored) with examples of what should be passed through.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
