### PR TITLE
refactor(stackable-versioned): Adjust variant rename validation error span

### DIFF
--- a/crates/stackable-versioned-macros/src/attrs/variant.rs
+++ b/crates/stackable-versioned-macros/src/attrs/variant.rs
@@ -46,14 +46,13 @@ impl VariantAttributes {
         errors.handle(self.common.validate(&self.ident, &ItemType::Variant));
 
         // Validate names of renames
-        if !self
-            .common
-            .renames
-            .iter()
-            .all(|r| r.from.is_case(Case::Pascal))
-        {
-            errors
-                .push(Error::custom("renamed variants must use PascalCase").with_span(&self.ident));
+        for rename in &self.common.renames {
+            if !rename.from.is_case(Case::Pascal) {
+                errors.push(
+                    Error::custom("renamed variant must use PascalCase")
+                        .with_span(&rename.from.span()),
+                )
+            }
         }
 
         errors.finish()?;


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

Variant rename validation errors are now reported on the `from` attribute instead of the variant ident.
