### PR TITLE
feat(stackable-versioned): Add 'use super::*' to generated version module

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
@@ -150,6 +150,8 @@ impl VersionedEnum {
             #[automatically_derived]
             #deprecated_attr
             #visibility mod #version_ident {
+                use super::*;
+
                 #(#original_attributes)*
                 #version_specific_docs
                 pub enum #enum_name {

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -150,6 +150,8 @@ impl VersionedStruct {
             #[automatically_derived]
             #deprecated_attr
             #visibility mod #version_ident {
+                use super::*;
+
                 #(#original_attributes)*
                 #version_specific_docs
                 pub struct #struct_name {

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
   attribute for version specific docs ([#847]).
 - Forward container visibility to generated modules ([#850]).
 - Add `use super::*` to version modules to be able to use imported types
-  ([#xxx]).
+  ([#859]).
 
 ### Changed
 
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 [#844]: https://github.com/stackabletech/operator-rs/pull/844
 [#847]: https://github.com/stackabletech/operator-rs/pull/847
 [#850]: https://github.com/stackabletech/operator-rs/pull/850
-[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#859]: https://github.com/stackabletech/operator-rs/pull/859
 
 ## [0.1.1] - 2024-07-10
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Pass through container and item attributes (including doc-comments). Add
   attribute for version specific docs ([#847]).
 - Forward container visibility to generated modules ([#850]).
+- Add `use super::*` to version modules to be able to use imported types
+  ([#xxx]).
 
 ### Changed
 
@@ -19,12 +21,13 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Report variant rename validation error at the correct span and trim underscores
-  from variants not using PascalCase (#[842]).
+  from variants not using PascalCase ([#842]).
 
 [#842]: https://github.com/stackabletech/operator-rs/pull/842
 [#844]: https://github.com/stackabletech/operator-rs/pull/844
 [#847]: https://github.com/stackabletech/operator-rs/pull/847
 [#850]: https://github.com/stackabletech/operator-rs/pull/850
+[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
 
 ## [0.1.1] - 2024-07-10
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

This PR enables the user to use imported items in container definitions. Previously, the version modules limited the visibility of such items inside said module. Now, using `use super::*` the items can be accessed.

This issue was reported by @sbernauer after a first quick testing round.