### PR TITLE
fix(stackable-versioned): Emit right type for unchanged fields

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
@@ -142,7 +142,7 @@ impl VersionedVariant {
                         #ident,
                     })
                 }
-                ItemStatus::NoChange(ident) => Some(quote! {
+                ItemStatus::NoChange { ident, .. } => Some(quote! {
                     #(#original_attributes)*
                     #ident,
                 }),

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
@@ -157,9 +157,9 @@ impl VersionedField {
                         })
                     }
                     ItemStatus::NotPresent => None,
-                    ItemStatus::NoChange(field_ident) => Some(quote! {
+                    ItemStatus::NoChange { ident, ty } => Some(quote! {
                         #(#original_attributes)*
-                        pub #field_ident: #field_type,
+                        pub #ident: #ty,
                     }),
                 }
             }

--- a/crates/stackable-versioned-macros/tests/good/basic.rs
+++ b/crates/stackable-versioned-macros/tests/good/basic.rs
@@ -13,7 +13,7 @@ use stackable_versioned_macros::versioned;
 )]
 pub(crate) struct Foo {
     #[versioned(
-        added(since = "v1alpha1"),
+        // added(since = "v1alpha1"),
         changed(since = "v1beta1", from_name = "jjj", from_type = "u8"),
         changed(since = "v1", from_type = "u16"),
         deprecated(since = "v2", note = "not empty")

--- a/crates/stackable-versioned-macros/tests/good/basic.rs
+++ b/crates/stackable-versioned-macros/tests/good/basic.rs
@@ -13,7 +13,6 @@ use stackable_versioned_macros::versioned;
 )]
 pub(crate) struct Foo {
     #[versioned(
-        // added(since = "v1alpha1"),
         changed(since = "v1beta1", from_name = "jjj", from_type = "u8"),
         changed(since = "v1", from_type = "u16"),
         deprecated(since = "v2", note = "not empty")

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -22,12 +22,14 @@ All notable changes to this project will be documented in this file.
 
 - Report variant rename validation error at the correct span and trim underscores
   from variants not using PascalCase ([#842]).
+- Emit correct struct field types for fields with no changes (NoChange) ([#860]).
 
 [#842]: https://github.com/stackabletech/operator-rs/pull/842
 [#844]: https://github.com/stackabletech/operator-rs/pull/844
 [#847]: https://github.com/stackabletech/operator-rs/pull/847
 [#850]: https://github.com/stackabletech/operator-rs/pull/850
 [#859]: https://github.com/stackabletech/operator-rs/pull/859
+[#860]: https://github.com/stackabletech/operator-rs/pull/860
 
 ## [0.1.1] - 2024-07-10
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

Previously, the type used in fields marked as NoChange in a particular version was incorrect. It used the type of the definition container. The NoChange action now also tracks the field type and can thus generate the correct type.

Discovered by @sbernauer.
