### PR TITLE
feat(stackable-versioned): Add from_name parameter validation

### DIFF
--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -454,8 +454,11 @@ pub struct FooSpec {
     bar: usize,
     baz: bool,
 }
+
+# fn main() {
 let merged_crd = Foo::merged_crd("v1").unwrap();
 println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
+# }
 ```
 "#
 )]

--- a/crates/stackable-versioned-macros/tests/default/fail/changed.rs
+++ b/crates/stackable-versioned-macros/tests/default/fail/changed.rs
@@ -1,0 +1,16 @@
+use stackable_versioned_macros::versioned;
+
+fn main() {
+    #[versioned(
+        version(name = "v1alpha1"),
+        version(name = "v1beta1"),
+        version(name = "v1")
+    )]
+    struct Foo {
+        #[versioned(
+            changed(since = "v1beta1", from_name = "deprecated_bar"),
+            changed(since = "v1", from_name = "deprecated_baz")
+        )]
+        bar: usize,
+    }
+}

--- a/crates/stackable-versioned-macros/tests/default/fail/changed.stderr
+++ b/crates/stackable-versioned-macros/tests/default/fail/changed.stderr
@@ -1,0 +1,11 @@
+error: the previous field name must not start with the deprecation prefix
+  --> tests/default/fail/changed.rs:11:52
+   |
+11 |             changed(since = "v1beta1", from_name = "deprecated_bar"),
+   |                                                    ^^^^^^^^^^^^^^^^
+
+error: the previous field name must not start with the deprecation prefix
+  --> tests/default/fail/changed.rs:12:47
+   |
+12 |             changed(since = "v1", from_name = "deprecated_baz")
+   |                                               ^^^^^^^^^^^^^^^^

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add `from_name` parameter validation ([#865]).
 - Add new `from_type` parameter to `changed()` action ([#844]).
 - Pass through container and item attributes (including doc-comments). Add
   attribute for version specific docs ([#847]).
@@ -33,6 +34,7 @@ All notable changes to this project will be documented in this file.
 [#857]: https://github.com/stackabletech/operator-rs/pull/857
 [#859]: https://github.com/stackabletech/operator-rs/pull/859
 [#860]: https://github.com/stackabletech/operator-rs/pull/860
+[#865]: https://github.com/stackabletech/operator-rs/pull/865
 
 ## [0.1.1] - 2024-07-10
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

This PR adds validation to the `from_name` parameter of the `changed()` action. It is now prohibited to use field / variant names which include the deprecation prefix.

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
