### PR TITLE
feat(stackable-versioned): Add action-specific docs

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/mod.rs
@@ -106,15 +106,13 @@ impl VersionedEnum {
         // enable the attribute macro to be applied to a module which
         // generates versioned versions of all contained containers.
 
+        let version_specific_docs = &version.docs;
         let version_ident = &version.ident;
 
         let deprecated_note = format!("Version {version} is deprecated", version = version_ident);
         let deprecated_attr = version
             .deprecated
             .then_some(quote! {#[deprecated = #deprecated_note]});
-
-        // Generate doc comments for the container (enum)
-        let version_specific_docs = self.generate_enum_docs(version);
 
         // Generate tokens for the module and the contained enum
         token_stream.extend(quote! {
@@ -123,8 +121,8 @@ impl VersionedEnum {
             #visibility mod #version_ident {
                 use super::*;
 
-                #version_specific_docs
                 #(#original_attributes)*
+                #version_specific_docs
                 pub enum #enum_name {
                     #variants
                 }
@@ -137,26 +135,6 @@ impl VersionedEnum {
         }
 
         token_stream
-    }
-
-    /// Generates version specific doc comments for the enum.
-    fn generate_enum_docs(&self, version: &ContainerVersion) -> TokenStream {
-        let mut tokens = TokenStream::new();
-
-        for (i, doc) in version.version_specific_docs.iter().enumerate() {
-            if i == 0 {
-                // Prepend an empty line to clearly separate the version
-                // specific docs.
-                tokens.extend(quote! {
-                    #[doc = ""]
-                })
-            }
-            tokens.extend(quote! {
-                #[doc = #doc]
-            })
-        }
-
-        tokens
     }
 
     fn generate_enum_variants(&self, version: &ContainerVersion) -> TokenStream {

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -126,15 +126,13 @@ impl VersionedStruct {
         // enable the attribute macro to be applied to a module which
         // generates versioned versions of all contained containers.
 
+        let version_specific_docs = &version.docs;
         let version_ident = &version.ident;
 
         let deprecated_note = format!("Version {version} is deprecated", version = version_ident);
         let deprecated_attr = version
             .deprecated
             .then_some(quote! {#[deprecated = #deprecated_note]});
-
-        // Generate doc comments for the container (struct)
-        let version_specific_docs = self.generate_struct_docs(version);
 
         // Generate K8s specific code
         let kubernetes_cr_derive = self.generate_kubernetes_cr_derive(version);
@@ -146,8 +144,8 @@ impl VersionedStruct {
             #visibility mod #version_ident {
                 use super::*;
 
-                #version_specific_docs
                 #(#original_attributes)*
+                #version_specific_docs
                 #kubernetes_cr_derive
                 pub struct #struct_name {
                     #fields
@@ -161,26 +159,6 @@ impl VersionedStruct {
         }
 
         token_stream
-    }
-
-    /// Generates version specific doc comments for the struct.
-    fn generate_struct_docs(&self, version: &ContainerVersion) -> TokenStream {
-        let mut tokens = TokenStream::new();
-
-        for (i, doc) in version.version_specific_docs.iter().enumerate() {
-            if i == 0 {
-                // Prepend an empty line to clearly separate the version
-                // specific docs.
-                tokens.extend(quote! {
-                    #[doc = ""]
-                })
-            }
-            tokens.extend(quote! {
-                #[doc = #doc]
-            })
-        }
-
-        tokens
     }
 
     /// Generates struct fields following the `name: type` format which includes

--- a/crates/stackable-versioned-macros/tests/default/fail/changed.rs
+++ b/crates/stackable-versioned-macros/tests/default/fail/changed.rs
@@ -9,7 +9,7 @@ fn main() {
     struct Foo {
         #[versioned(
             changed(since = "v1beta1", from_name = "deprecated_bar"),
-            changed(since = "v1", from_name = "deprecated_baz")
+            changed(since = "v1")
         )]
         bar: usize,
     }

--- a/crates/stackable-versioned-macros/tests/default/fail/changed.stderr
+++ b/crates/stackable-versioned-macros/tests/default/fail/changed.stderr
@@ -4,8 +4,8 @@ error: the previous field name must not start with the deprecation prefix
 11 |             changed(since = "v1beta1", from_name = "deprecated_bar"),
    |                                                    ^^^^^^^^^^^^^^^^
 
-error: the previous field name must not start with the deprecation prefix
-  --> tests/default/fail/changed.rs:12:47
+error: field was marked as `changed`, but both `from_name` and `from_type` are unset
+  --> tests/default/fail/changed.rs:14:9
    |
-12 |             changed(since = "v1", from_name = "deprecated_baz")
-   |                                               ^^^^^^^^^^^^^^^^
+14 |         bar: usize,
+   |         ^^^


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

This PR adds support to add action-specific docs to items (fields and variants).

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
