### PR TITLE
chore: Release stackable-operator 0.75.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.74.0"
+version = "0.75.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.75.0] - 2024-09-19
+
 ### Added
 
 - Add `Hostname` and `KerberosRealmName` types extracted from secret-operator ([#851]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.74.0"
+version = "0.75.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

### Added

- Add `Hostname` and `KerberosRealmName` types extracted from secret-operator ([#851]).
- Add support for listener volume scopes to `SecretOperatorVolumeSourceBuilder` ([#858]).

### Changed

- BREAKING: `validation` module now uses typed errors ([#851]).
- Set `checkIncrement` to 5 seconds in Logback config ([#853]).
- Bump Rust dependencies and enable Kubernetes 1.31 (via `kube` 0.95.0) ([#867]).

### Fixed

- Fix the CRD description of `ClientAuthenticationDetails` to not contain internal Rust doc, but a public CRD description ([#846]).
- `StackableAffinity` fields are no longer erroneously marked as required ([#855]).
- BREAKING: `ClusterResources` will now only consider deleting objects that are marked as directly owned (via `.metadata.ownerReferences`) ([#862]).

[#846]: https://github.com/stackabletech/operator-rs/pull/846
[#851]: https://github.com/stackabletech/operator-rs/pull/851
[#853]: https://github.com/stackabletech/operator-rs/pull/853
[#855]: https://github.com/stackabletech/operator-rs/pull/855
[#858]: https://github.com/stackabletech/operator-rs/pull/858
[#862]: https://github.com/stackabletech/operator-rs/pull/862
[#867]: https://github.com/stackabletech/operator-rs/pull/867