### PR TITLE
chore: Release stackable-versioned 0.2.0, k8s-version 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "k8s-version"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2982,14 +2982,14 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "stackable-versioned-macros",
 ]
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.2] - 2024-09-19
+
 ### Changed
 
 - Replace `lazy_static` with `std::cell::LazyCell` ([#827], [#835], [#840]).

--- a/crates/k8s-version/Cargo.toml
+++ b/crates/k8s-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-version"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.1.1"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-09-19
+
 ### Added
 
 - Add `from_name` parameter validation ([#865]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.1.1"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

## stackable-versioned 0.2.0

### Added

- Add `from_name` parameter validation ([#865]).
- Add new `from_type` parameter to `changed()` action ([#844]).
- Pass through container and item attributes (including doc-comments). Add attribute for version specific docs ([#847]).
- Forward container visibility to generated modules ([#850]).
- Add support for Kubernetes-specific features ([#857]).
- Add `use super::*` to version modules to be able to use imported types ([#859]).

### Changed

- BREAKING: Rename `renamed()` action to `changed()` and renamed `from` parameter to `from_name` ([#844]).
- Bump syn to 2.0.77 ([#857]).

### Fixed

- Report variant rename validation error at the correct span and trim underscores from variants not using PascalCase ([#842]).
- Emit correct struct field types for fields with no changes (NoChange) ([#860]).

[#842]: https://github.com/stackabletech/operator-rs/pull/842
[#844]: https://github.com/stackabletech/operator-rs/pull/844
[#847]: https://github.com/stackabletech/operator-rs/pull/847
[#850]: https://github.com/stackabletech/operator-rs/pull/850
[#857]: https://github.com/stackabletech/operator-rs/pull/857
[#859]: https://github.com/stackabletech/operator-rs/pull/859
[#860]: https://github.com/stackabletech/operator-rs/pull/860
[#865]: https://github.com/stackabletech/operator-rs/pull/865

## k8s-version 0.1.2

### Changed

- Replace `lazy_static` with `std::cell::LazyCell` ([#827], [#835], [#840]).

[#827]: https://github.com/stackabletech/operator-rs/pull/827
[#835]: https://github.com/stackabletech/operator-rs/pull/835
[#840]: https://github.com/stackabletech/operator-rs/pull/840