### PR TITLE
feat(stackable-versioned): Forward selected kube args

### DIFF
--- a/crates/stackable-versioned-macros/src/attrs/common/container.rs
+++ b/crates/stackable-versioned-macros/src/attrs/common/container.rs
@@ -141,7 +141,10 @@ pub(crate) struct OptionAttributes {
 #[derive(Clone, Debug, FromMeta)]
 pub(crate) struct KubernetesAttributes {
     pub(crate) skip: Option<KubernetesSkipAttributes>,
+    pub(crate) singular: Option<String>,
+    pub(crate) plural: Option<String>,
     pub(crate) kind: Option<String>,
+    pub(crate) namespaced: Flag,
     pub(crate) group: String,
 }
 

--- a/crates/stackable-versioned-macros/src/codegen/common/container.rs
+++ b/crates/stackable-versioned-macros/src/codegen/common/container.rs
@@ -118,6 +118,9 @@ impl<I> VersionedContainer<I> {
 
         let kubernetes_options = attributes.kubernetes_attrs.map(|a| KubernetesOptions {
             skip_merged_crd: a.skip.map_or(false, |s| s.merged_crd.is_present()),
+            namespaced: a.namespaced.is_present(),
+            singular: a.singular,
+            plural: a.plural,
             group: a.group,
             kind: a.kind,
         });
@@ -166,7 +169,10 @@ pub(crate) struct VersionedContainerOptions {
 
 #[derive(Debug)]
 pub(crate) struct KubernetesOptions {
+    pub(crate) singular: Option<String>,
+    pub(crate) plural: Option<String>,
     pub(crate) skip_merged_crd: bool,
     pub(crate) kind: Option<String>,
+    pub(crate) namespaced: bool,
     pub(crate) group: String,
 }

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -253,6 +253,7 @@ impl VersionedStruct {
     /// attributes.
     fn generate_kubernetes_cr_derive(&self, version: &ContainerVersion) -> Option<TokenStream> {
         if let Some(kubernetes_options) = &self.options.kubernetes_options {
+            // Required arguments
             let group = &kubernetes_options.group;
             let version = version.inner.to_string();
             let kind = kubernetes_options
@@ -260,9 +261,22 @@ impl VersionedStruct {
                 .as_ref()
                 .map_or(self.idents.kubernetes.to_string(), |kind| kind.clone());
 
+            // Optional arguments
+            let namespaced = kubernetes_options
+                .namespaced
+                .then_some(quote! { , namespaced });
+            let singular = kubernetes_options
+                .singular
+                .as_ref()
+                .map(|s| quote! { , singular = #s });
+            let plural = kubernetes_options
+                .plural
+                .as_ref()
+                .map(|p| quote! { , plural = #p });
+
             return Some(quote! {
                 #[derive(::kube::CustomResource)]
-                #[kube(group = #group, version = #version, kind = #kind)]
+                #[kube(group = #group, version = #version, kind = #kind #singular #plural #namespaced)]
             });
         }
 

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -470,7 +470,7 @@ println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
 /// - `singular`: Sets the singular name.
 /// - `plural`: Sets the plural name.
 /// - `namespaced`: Specify that this is a namespaced resource rather than
-///   cluster level.
+///   a cluster scoped.
 #[proc_macro_attribute]
 pub fn versioned(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let attrs = match NestedMeta::parse_meta_list(attrs.into()) {

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -469,7 +469,7 @@ println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
 ///   to the struct name (without the 'Spec' suffix).
 /// - `singular`: Sets the singular name.
 /// - `plural`: Sets the plural name.
-/// - `namespaced`: Specify that this is a namespaced resource rather than
+/// - `namespaced`: Specifies that this is a namespaced resource rather than
 ///   a cluster scoped.
 #[proc_macro_attribute]
 pub fn versioned(attrs: TokenStream, input: TokenStream) -> TokenStream {

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -462,6 +462,15 @@ println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
 ```
 "#
 )]
+/// Currently, the following arguments are supported:
+///
+/// - `group`: Sets the CRD group, usually the domain of the company.
+/// - `kind`:  Allows overwriting the kind field of the CRD. This defaults
+///   to the struct name (without the 'Spec' suffix).
+/// - `singular`: Sets the singular name.
+/// - `plural`: Sets the plural name.
+/// - `namespaced`: Specify that this is a namespaced resource rather than
+///   cluster level.
 #[proc_macro_attribute]
 pub fn versioned(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let attrs = match NestedMeta::parse_meta_list(attrs.into()) {

--- a/crates/stackable-versioned-macros/tests/k8s/pass/crd.rs
+++ b/crates/stackable-versioned-macros/tests/k8s/pass/crd.rs
@@ -9,7 +9,12 @@ fn main() {
         version(name = "v1alpha1"),
         version(name = "v1beta1"),
         version(name = "v1"),
-        k8s(group = "stackable.tech")
+        k8s(
+            group = "stackable.tech",
+            singular = "foo",
+            plural = "foos",
+            namespaced,
+        )
     )]
     #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
     pub struct FooSpec {

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add forwarding of `singular`, `plural`, and `namespaced` arguments in `k8s()`
+  ([#873]).
+
+[#873]: https://github.com/stackabletech/operator-rs/pull/873
+
 ## [0.2.0] - 2024-09-19
 
 ### Added


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

Forwards selected `kube` arguments.

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
