### PR TITLE
refactor(stackable-versioned): Rework version enum for merged_crd

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -322,12 +322,12 @@ impl VersionedStruct {
         let enum_ident = &self.idents.kubernetes;
         let enum_vis = &self.visibility;
 
-        let mut enum_variant_matches = TokenStream::new();
+        let mut enum_display_impl_matches = TokenStream::new();
         let mut enum_variant_idents = TokenStream::new();
 
         for (enum_variant_ident, enum_variant_display) in enum_variants {
             enum_variant_idents.extend(quote! {#enum_variant_ident,});
-            enum_variant_matches.extend(quote! {
+            enum_display_impl_matches.extend(quote! {
                 #enum_ident::#enum_variant_ident => f.write_str(#enum_variant_display),
             });
         }
@@ -342,7 +342,7 @@ impl VersionedStruct {
             impl ::std::fmt::Display for #enum_ident {
                 fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::result::Result<(), ::std::fmt::Error> {
                     match self {
-                        #enum_variant_matches
+                        #enum_display_impl_matches
                     }
                 }
             }

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -319,22 +319,40 @@ impl VersionedStruct {
         crd_fn_calls: Vec<TokenStream>,
         enum_variants: Vec<(Ident, String)>,
     ) -> TokenStream {
-        let ident = &self.idents.kubernetes;
+        let enum_ident = &self.idents.kubernetes;
+        let enum_vis = &self.visibility;
 
-        let version_enum_definition = self.generate_kubernetes_version_enum(enum_variants);
+        let mut enum_variant_matches = TokenStream::new();
+        let mut enum_variant_idents = TokenStream::new();
+
+        for (enum_variant_ident, enum_variant_display) in enum_variants {
+            enum_variant_idents.extend(quote! {#enum_variant_ident,});
+            enum_variant_matches.extend(quote! {
+                #enum_ident::#enum_variant_ident => f.write_str(#enum_variant_display),
+            });
+        }
 
         quote! {
             #[automatically_derived]
-            pub struct #ident;
-
-            #version_enum_definition
+            #enum_vis enum #enum_ident {
+                #enum_variant_idents
+            }
 
             #[automatically_derived]
-            impl #ident {
+            impl ::std::fmt::Display for #enum_ident {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::result::Result<(), ::std::fmt::Error> {
+                    match self {
+                        #enum_variant_matches
+                    }
+                }
+            }
+
+            #[automatically_derived]
+            impl #enum_ident {
                 /// Generates a merged CRD which contains all versions defined using the
                 /// `#[versioned()]` macro.
                 pub fn merged_crd(
-                    stored_apiversion: Version
+                    stored_apiversion: Self
                 ) -> ::std::result::Result<::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition, ::kube::core::crd::MergeError> {
                     ::kube::core::crd::merge_crds(vec![#(#crd_fn_calls),*], &stored_apiversion.to_string())
                 }
@@ -351,34 +369,6 @@ impl VersionedStruct {
 
         quote! {
             <#path as ::kube::CustomResourceExt>::crd()
-        }
-    }
-
-    fn generate_kubernetes_version_enum(&self, enum_variants: Vec<(Ident, String)>) -> TokenStream {
-        let mut enum_variant_matches = TokenStream::new();
-        let mut enum_variant_idents = TokenStream::new();
-
-        for (enum_variant_ident, enum_variant_display) in enum_variants {
-            enum_variant_idents.extend(quote! {#enum_variant_ident,});
-            enum_variant_matches.extend(quote! {
-                Version::#enum_variant_ident => f.write_str(#enum_variant_display),
-            });
-        }
-
-        quote! {
-            #[automatically_derived]
-            pub enum Version {
-                #enum_variant_idents
-            }
-
-            #[automatically_derived]
-            impl ::std::fmt::Display for Version {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::result::Result<(), ::std::fmt::Error> {
-                    match self {
-                        #enum_variant_matches
-                    }
-                }
-            }
         }
     }
 }

--- a/crates/stackable-versioned-macros/tests/k8s/pass/crd.rs
+++ b/crates/stackable-versioned-macros/tests/k8s/pass/crd.rs
@@ -26,6 +26,6 @@ fn main() {
         baz: bool,
     }
 
-    let merged_crd = Foo::merged_crd(Version::V1).unwrap();
+    let merged_crd = Foo::merged_crd(Foo::V1).unwrap();
     println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
 }

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -13,11 +13,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- BREAKING: The `merged_crd` function now accepts `Self` instead of a dedicated
+  `Version` enu ([#875]).
 - The `merged_crd` associated function now takes `Version` instead of `&str` as
   input ([#872]).
 
 [#872]: https://github.com/stackabletech/operator-rs/pull/872
 [#873]: https://github.com/stackabletech/operator-rs/pull/873
+[#875]: https://github.com/stackabletech/operator-rs/pull/875
 
 ## [0.2.0] - 2024-09-19
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507, follow-up of https://github.com/stackabletech/operator-rs/pull/872#discussion_r1770889930

This PR adjusts the version enum generation used in the `merged_crd` function.

```rust
let merged_crd = Foo::merged_crd(Foo::V1).unwrap();
println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
```