### PR TITLE
feat(stackable-versioned): Add conditional allow attr generation

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/chain.rs
+++ b/crates/stackable-versioned-macros/src/codegen/chain.rs
@@ -5,6 +5,9 @@ where
     K: Ord + Eq,
 {
     fn get_neighbors(&self, key: &K) -> (Option<&V>, Option<&V>);
+    fn value_is<F>(&self, key: &K, f: F) -> bool
+    where
+        F: Fn(&V) -> bool;
 
     fn lo_bound(&self, bound: Bound<&K>) -> Option<(&K, &V)>;
     fn up_bound(&self, bound: Bound<&K>) -> Option<(&K, &V)>;
@@ -49,6 +52,13 @@ where
             (Some((_, lo)), Some((_, up))) => (Some(lo), Some(up)),
             (None, None) => unreachable!(),
         }
+    }
+
+    fn value_is<F>(&self, key: &K, f: F) -> bool
+    where
+        F: Fn(&V) -> bool,
+    {
+        self.get(key).map_or(false, f)
     }
 
     fn lo_bound(&self, bound: Bound<&K>) -> Option<(&K, &V)> {

--- a/crates/stackable-versioned-macros/src/codegen/chain.rs
+++ b/crates/stackable-versioned-macros/src/codegen/chain.rs
@@ -4,7 +4,19 @@ pub(crate) trait Neighbors<K, V>
 where
     K: Ord + Eq,
 {
+    /// Returns the values of keys which are neighbors of `key`.
+    ///
+    /// Given a map which contains the following keys: 1, 3, 5. Calling this
+    /// function with these keys, results in the following return values:
+    ///
+    /// - Key **0**: `(None, Some(1))`
+    /// - Key **2**: `(Some(1), Some(3))`
+    /// - Key **4**: `(Some(3), Some(5))`
+    /// - Key **6**: `(Some(5), None)`
     fn get_neighbors(&self, key: &K) -> (Option<&V>, Option<&V>);
+
+    /// Returns whether the function `f` returns true if applied to the value
+    /// identified by `key`.
     fn value_is<F>(&self, key: &K, f: F) -> bool
     where
         F: Fn(&V) -> bool;
@@ -17,15 +29,6 @@ impl<K, V> Neighbors<K, V> for BTreeMap<K, V>
 where
     K: Ord + Eq,
 {
-    /// Returns the values of keys which are neighbors of `key`.
-    ///
-    /// Given a map which contains the following keys: 1, 3, 5. Calling this
-    /// function with these keys, results in the following return values:
-    ///
-    /// - Key **0**: `(None, Some(1))`
-    /// - Key **2**: `(Some(1), Some(3))`
-    /// - Key **4**: `(Some(3), Some(5))`
-    /// - Key **6**: `(Some(5), None)`
     fn get_neighbors(&self, key: &K) -> (Option<&V>, Option<&V>) {
         // NOTE (@Techassi): These functions might get added to the standard
         // library at some point. If that's the case, we can use the ones

--- a/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
+++ b/crates/stackable-versioned-macros/src/codegen/venum/variant.rs
@@ -142,10 +142,21 @@ impl VersionedVariant {
                         #ident,
                     })
                 }
-                ItemStatus::NoChange { ident, .. } => Some(quote! {
-                    #(#original_attributes)*
-                    #ident,
-                }),
+                ItemStatus::NoChange {
+                    previously_deprecated,
+                    ident,
+                    ..
+                } => {
+                    // TODO (@Techassi): Also carry along the deprecation
+                    // note.
+                    let deprecated_attr = previously_deprecated.then(|| quote! {#[deprecated]});
+
+                    Some(quote! {
+                        #(#original_attributes)*
+                        #deprecated_attr
+                        #ident,
+                    })
+                }
                 ItemStatus::NotPresent => None,
             },
             None => {

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/field.rs
@@ -157,10 +157,22 @@ impl VersionedField {
                         })
                     }
                     ItemStatus::NotPresent => None,
-                    ItemStatus::NoChange { ident, ty } => Some(quote! {
-                        #(#original_attributes)*
-                        pub #ident: #ty,
-                    }),
+                    ItemStatus::NoChange {
+                        previously_deprecated,
+                        ident,
+                        ty,
+                        ..
+                    } => {
+                        // TODO (@Techassi): Also carry along the deprecation
+                        // note.
+                        let deprecated_attr = previously_deprecated.then(|| quote! {#[deprecated]});
+
+                        Some(quote! {
+                            #(#original_attributes)*
+                            #deprecated_attr
+                            pub #ident: #ty,
+                        })
+                    }
                 }
             }
             None => {

--- a/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/vstruct/mod.rs
@@ -8,8 +8,10 @@ use syn::{parse_quote, DataStruct, Error, Ident};
 use crate::{
     attrs::common::ContainerAttributes,
     codegen::{
+        chain::Neighbors,
         common::{
-            Container, ContainerInput, ContainerVersion, Item, VersionExt, VersionedContainer,
+            Container, ContainerInput, ContainerVersion, Item, ItemStatus, VersionExt,
+            VersionedContainer,
         },
         vstruct::field::VersionedField,
     },
@@ -241,11 +243,20 @@ impl VersionedStruct {
 
             let fields = self.generate_from_fields(version, next_version, from_ident);
 
+            // Include allow(deprecated) only when this or the next version is
+            // deprecated. Also include it, when a field in this or the next
+            // version is deprecated.
+            let allow_attribute = (version.deprecated
+                || next_version.deprecated
+                || self.any_field_deprecated(version)
+                || self.any_field_deprecated(next_version))
+            .then_some(quote! { #[allow(deprecated)] });
+
             // TODO (@Techassi): Be a little bit more clever about when to include
             // the #[allow(deprecated)] attribute.
             return Some(quote! {
                 #[automatically_derived]
-                #[allow(deprecated)]
+                #allow_attribute
                 impl From<#module_name::#struct_ident> for #next_module_name::#struct_ident {
                     fn from(#from_ident: #module_name::#struct_ident) -> Self {
                         Self {
@@ -274,6 +285,25 @@ impl VersionedStruct {
         }
 
         token_stream
+    }
+
+    /// Returns whether any field is deprecated in the provided
+    /// [`ContainerVersion`].
+    fn any_field_deprecated(&self, version: &ContainerVersion) -> bool {
+        // First, iterate over all fields. Any will return true if any of the
+        // function invocations return true. If a field doesn't have a chain,
+        // we can safely default to false (unversioned fields cannot be
+        // deprecated). Then we retrieve the status of the field and ensure it
+        // is deprecated.
+        // TODO (@Techassi): This currently does not include fields which were
+        // already deprecated and thus now have the NoChange status.
+        self.items.iter().any(|f| {
+            f.chain.as_ref().map_or(false, |c| {
+                c.value_is(&version.inner, |a| {
+                    matches!(a, ItemStatus::Deprecation { .. })
+                })
+            })
+        })
     }
 }
 

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -456,7 +456,7 @@ pub struct FooSpec {
 }
 
 # fn main() {
-let merged_crd = Foo::merged_crd("v1").unwrap();
+let merged_crd = Foo::merged_crd(Foo::V1).unwrap();
 println!("{}", serde_yaml::to_string(&merged_crd).unwrap());
 # }
 ```

--- a/crates/stackable-versioned-macros/tests/default/pass/deprecate.rs
+++ b/crates/stackable-versioned-macros/tests/default/pass/deprecate.rs
@@ -7,7 +7,7 @@ fn main() {
         version(name = "v1")
     )]
     struct Foo {
-        #[versioned(deprecated(since = "v1beta1", note = "gone"))]
+        #[versioned(deprecated(since = "v1", note = "gone"))]
         deprecated_bar: usize,
         baz: bool,
     }

--- a/crates/stackable-versioned-macros/tests/default/pass/deprecate_enum.rs
+++ b/crates/stackable-versioned-macros/tests/default/pass/deprecate_enum.rs
@@ -1,0 +1,16 @@
+use stackable_versioned_macros::versioned;
+
+fn main() {
+    #[versioned(
+        version(name = "v1alpha1"),
+        version(name = "v1beta1"),
+        version(name = "v1"),
+        version(name = "v2"),
+        version(name = "v3")
+    )]
+    enum Foo {
+        #[versioned(deprecated(since = "v1"))]
+        DeprecatedBar,
+        Baz,
+    }
+}

--- a/crates/stackable-versioned-macros/tests/default/pass/deprecate_struct.rs
+++ b/crates/stackable-versioned-macros/tests/default/pass/deprecate_struct.rs
@@ -4,7 +4,9 @@ fn main() {
     #[versioned(
         version(name = "v1alpha1"),
         version(name = "v1beta1"),
-        version(name = "v1")
+        version(name = "v1"),
+        version(name = "v2"),
+        version(name = "v3")
     )]
     struct Foo {
         #[versioned(deprecated(since = "v1", note = "gone"))]

--- a/crates/stackable-versioned-macros/tests/trybuild.rs
+++ b/crates/stackable-versioned-macros/tests/trybuild.rs
@@ -17,13 +17,14 @@
 #[allow(dead_code)]
 mod default {
     // mod pass {
-    //     mod attributes_enum;
-    //     mod attributes_struct;
-    //     mod basic;
+    //     // mod attributes_enum;
+    //     // mod attributes_struct;
+    //     // mod basic;
 
-    //     mod deprecate;
-    //     mod rename;
-    //     mod skip_from_version;
+    //     // mod deprecate_enum;
+    //     // mod deprecate_struct;
+    //     // mod rename;
+    //     // mod skip_from_version;
     // }
 
     // mod fail {


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/507

With this PR `#[allow(deprecated)]` is only added when needed. Also, `#[deprecated]` is now carried along for fields and variants after they have been marked as deprecated. This currently does not include the note, but the note will be added in the future. To more efficiently store this data, the chain of actions needs to be improved in a follow-up PR.

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
