### PR TITLE
chore: Release stackable-versioned 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,14 +2996,14 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "stackable-versioned-macros",
 ]
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-09-26
+
 ### Added
 
 - Add forwarding of `singular`, `plural`, and `namespaced` arguments in `k8s()`
@@ -14,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - BREAKING: The `merged_crd` function now accepts `Self` instead of a dedicated
-  `Version` enu ([#875]).
+  `Version` enum ([#875]).
 - The `merged_crd` associated function now takes `Version` instead of `&str` as
   input ([#872]).
 

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release includes:

### Added

- Add forwarding of `singular`, `plural`, and `namespaced` arguments in `k8s()` ([#873]).
- Generate a `Version` enum containing all declared versions as variants ([#872]).

### Changed

- BREAKING: The `merged_crd` function now accepts `Self` instead of a dedicated `Version` enum ([#875]).
- The `merged_crd` associated function now takes `Version` instead of `&str` as input ([#872]).

[#872]: https://github.com/stackabletech/operator-rs/pull/872
[#873]: https://github.com/stackabletech/operator-rs/pull/873
[#875]: https://github.com/stackabletech/operator-rs/pull/875