### PR TITLE
chore: Release stackable-operator 0.78.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.77.1"
+version = "0.78.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.78.0] - 2024-09-30
+
 ### Added
 
 - Add Kerberos AuthenticationProvider ([#880]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.77.1"
+version = "0.78.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

### Added/Changed
- Add Kerberos AuthenticationProvider ([#880]).

This is a breaking change as `match` statements that check for values of `pub enum AuthenticationClassProvider` will need to consider the new case.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Integration tests passed (for non trivial changes). Tested with Kafka/Kerberos.
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
