### PR TITLE
Add preferred address type field to ListenerClass

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Re-export the `YamlSchema` trait and the `stackable-shared` crate as the `shared` module ([#883]).
+- BREAKING: Added `preferredAddressType` field to ListenerClass CRD ([#885]).
 
 ### Changed
 
@@ -17,9 +18,10 @@ All notable changes to this project will be documented in this file.
 
 - BREAKING: The `CustomResourceExt` trait doesn't provide a `generate_yaml_schema` function any
   more. Instead, use the high-level functions to write the schema to a file, write it to stdout or
-  use it as a `String`.
+  use it as a `String` ([#883]).
 
 [#883]: https://github.com/stackabletech/operator-rs/pull/883
+[#885]: https://github.com/stackabletech/operator-rs/pull/885
 
 ## [0.78.0] - 2024-09-30
 

--- a/crates/stackable-operator/src/commons/listener.rs
+++ b/crates/stackable-operator/src/commons/listener.rs
@@ -67,6 +67,7 @@ pub struct ListenerClassSpec {
     /// Whether addresses should prefer using the IP address (`IP`) or the hostname (`Hostname`).
     ///
     /// The other type will be used if the preferred type is not available.
+    /// By default `Hostname` is used.
     #[serde(default = "ListenerClassSpec::default_preferred_address_type")]
     pub preferred_address_type: AddressType,
 }

--- a/crates/stackable-operator/src/commons/listener.rs
+++ b/crates/stackable-operator/src/commons/listener.rs
@@ -63,11 +63,21 @@ pub struct ListenerClassSpec {
     /// break Local mode (IONOS so far).
     #[serde(default = "ListenerClassSpec::default_service_external_traffic_policy")]
     pub service_external_traffic_policy: KubernetesTrafficPolicy,
+
+    /// Whether addresses should prefer using the IP address (`IP`) or the hostname (`Hostname`).
+    ///
+    /// The other type will be used if the preferred type is not available.
+    #[serde(default = "ListenerClassSpec::default_preferred_address_type")]
+    pub preferred_address_type: AddressType,
 }
 
 impl ListenerClassSpec {
     const fn default_service_external_traffic_policy() -> KubernetesTrafficPolicy {
         KubernetesTrafficPolicy::Local
+    }
+
+    const fn default_preferred_address_type() -> AddressType {
+        AddressType::Hostname
     }
 }
 


### PR DESCRIPTION

# Description

See https://github.com/stackabletech/listener-operator/issues/139. In short, it allows users to specify whether they want to prefer exposing IP addresses or hostnames.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
