### PR TITLE
Make kvp's Debug impls a lot more readable

### DIFF
--- a/crates/stackable-operator/src/kvp/key.rs
+++ b/crates/stackable-operator/src/kvp/key.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Display, ops::Deref, str::FromStr, sync::LazyLock};
+use std::{
+    fmt::{Debug, Display},
+    ops::Deref,
+    str::FromStr,
+    sync::LazyLock,
+};
 
 use regex::Regex;
 use snafu::{ensure, ResultExt, Snafu};
@@ -56,10 +61,19 @@ pub enum KeyError {
 /// values.
 ///
 /// [k8s-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Key {
     prefix: Option<KeyPrefix>,
     name: KeyName,
+}
+
+impl Debug for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(prefix) = &self.prefix {
+            write!(f, "{:?}/", prefix)?;
+        }
+        write!(f, "{:?}", self.name)
+    }
 }
 
 impl FromStr for Key {
@@ -203,8 +217,14 @@ pub enum KeyPrefixError {
 /// [`Deref`], which enables read-only access to the inner value (a [`String`]).
 /// It, however, does not implement [`DerefMut`](std::ops::DerefMut) which would
 /// enable unvalidated mutable access to inner values.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyPrefix(String);
+
+impl Debug for KeyPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
 
 impl FromStr for KeyPrefix {
     type Err = KeyPrefixError;
@@ -285,8 +305,14 @@ pub enum KeyNameError {
 /// which enables read-only access to the inner value (a [`String`]). It,
 /// however, does not implement [`DerefMut`](std::ops::DerefMut) which would
 /// enable unvalidated mutable access to inner values.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyName(String);
+
+impl Debug for KeyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
 
 impl FromStr for KeyName {
     type Err = KeyNameError;

--- a/crates/stackable-operator/src/kvp/label/value.rs
+++ b/crates/stackable-operator/src/kvp/label/value.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Display, ops::Deref, str::FromStr, sync::LazyLock};
+use std::{
+    fmt::{Debug, Display},
+    ops::Deref,
+    str::FromStr,
+    sync::LazyLock,
+};
 
 use regex::Regex;
 use snafu::{ensure, Snafu};
@@ -43,8 +48,14 @@ pub enum LabelValueError {
 /// unvalidated mutable access to inner values.
 ///
 /// [k8s-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LabelValue(String);
+
+impl Debug for LabelValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
 
 impl Value for LabelValue {
     type Error = LabelValueError;

--- a/crates/stackable-operator/src/kvp/mod.rs
+++ b/crates/stackable-operator/src/kvp/mod.rs
@@ -2,7 +2,7 @@
 //! key/value pairs, like labels and annotations.
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fmt::Display,
+    fmt::{Debug, Display},
     ops::Deref,
     str::FromStr,
 };
@@ -90,13 +90,22 @@ where
 ///
 /// - <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>
 /// - <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KeyValuePair<T>
 where
     T: Value,
 {
     key: Key,
     value: T,
+}
+
+impl<T> Debug for KeyValuePair<T>
+where
+    T: Value + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}: {:?}", self.key, self.value)
+    }
 }
 
 impl<K, V, T> TryFrom<(K, V)> for KeyValuePair<T>


### PR DESCRIPTION
-------

# Description

*Please add a description here. This will become the commit message of the merge request later.*

Changes the output from:

```rust
Labels(
    KeyValuePairs(
        {
            KeyValuePair {
                key: Key {
                    prefix: None,
                    name: KeyName(
                        "group",
                    ),
                },
                value: LabelValue(
                    "default",
                ),
            },
            KeyValuePair {
                key: Key {
                    prefix: None,
                    name: KeyName(
                        "role",
                    ),
                },
                value: LabelValue(
                    "namenode",
                ),
            },
            KeyValuePair {
                key: Key {
                    prefix: Some(
                        KeyPrefix(
                            "app.kubernetes.io",
                        ),
                    ),
                    name: KeyName(
                        "component",
                    ),
                },
                value: LabelValue(
                    "namenode",
                ),
            },
            KeyValuePair {
                key: Key {
                    prefix: Some(
                        KeyPrefix(
                            "app.kubernetes.io",
                        ),
                    ),
                    name: KeyName(
                        "instance",
                    ),
                },
                value: LabelValue(
                    "simple-hdfs",
                ),
            },
            KeyValuePair {
                key: Key {
                    prefix: Some(
                        KeyPrefix(
                            "app.kubernetes.io",
                        ),
                    ),
                    name: KeyName(
                        "name",
                    ),
                },
                value: LabelValue(
                    "hdfs",
                ),
            },
            KeyValuePair {
                key: Key {
                    prefix: Some(
                        KeyPrefix(
                            "app.kubernetes.io",
                        ),
                    ),
                    name: KeyName(
                        "role-group",
                    ),
                },
                value: LabelValue(
                    "default",
                ),
            },
        },
    ),
)
```

To:

``` rust
Labels(
    KeyValuePairs(
        {
            "group": "default",
            "role": "namenode",
            "app.kubernetes.io"/"component": "namenode",
            "app.kubernetes.io"/"instance": "simple-hdfs",
            "app.kubernetes.io"/"name": "hdfs",
            "app.kubernetes.io"/"role-group": "default",
        },
    ),
)
```

The useful information is still there, it's just.. a *lot* more readable if we cut away the fluff.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```