### PR TITLE
Reorganize kvp so that KeyValuePairs is an alias for BTreeMap instead of newtyping it

### DIFF
--- a/crates/stackable-operator/src/builder/pdb.rs
+++ b/crates/stackable-operator/src/builder/pdb.rs
@@ -10,7 +10,7 @@ use snafu::{ResultExt, Snafu};
 
 use crate::{
     builder::meta::ObjectMetaBuilder,
-    kvp::{Label, Labels},
+    kvp::{label, KeyValuePairsExt},
 };
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -86,9 +86,9 @@ impl PodDisruptionBudgetBuilder<(), (), ()> {
         controller_name: &str,
     ) -> Result<PodDisruptionBudgetBuilder<ObjectMeta, LabelSelector, ()>> {
         let role_selector_labels =
-            Labels::role_selector(owner, app_name, role).context(RoleSelectorLabelsSnafu)?;
-        let managed_by_label =
-            Label::managed_by(operator_name, controller_name).context(ManagedByLabelSnafu)?;
+            label::sets::role_selector(owner, app_name, role).context(RoleSelectorLabelsSnafu)?;
+        let managed_by_label = label::well_known::managed_by(operator_name, controller_name)
+            .context(ManagedByLabelSnafu)?;
         let metadata = ObjectMetaBuilder::new()
             .namespace_opt(owner.namespace())
             .name(format!("{}-{}", owner.name_any(), role))
@@ -102,7 +102,7 @@ impl PodDisruptionBudgetBuilder<(), (), ()> {
             metadata,
             selector: LabelSelector {
                 match_expressions: None,
-                match_labels: Some(role_selector_labels.into()),
+                match_labels: Some(role_selector_labels.to_unvalidated()),
             },
             ..PodDisruptionBudgetBuilder::default()
         })

--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -331,16 +331,17 @@ impl PodBuilder {
     /// ```
     /// # use stackable_operator::builder::pod::PodBuilder;
     /// # use stackable_operator::builder::pod::container::ContainerBuilder;
+    /// # use stackable_operator::iter::TryFromIterator;
     /// # use stackable_operator::kvp::Labels;
     /// # use k8s_openapi::{
     /// #     apimachinery::pkg::apis::meta::v1::ObjectMeta,
     /// # };
     /// # use std::collections::BTreeMap;
     ///
-    /// let labels: Labels = Labels::try_from(
-    ///        BTreeMap::from([("app.kubernetes.io/component", "test-role"),
+    /// let labels: Labels = Labels::try_from_iter(
+    ///        [("app.kubernetes.io/component", "test-role"),
     ///             ("app.kubernetes.io/instance", "test"),
-    ///             ("app.kubernetes.io/name", "test")]))
+    ///             ("app.kubernetes.io/name", "test")])
     /// .unwrap();
     ///
     /// let pod = PodBuilder::new()
@@ -418,16 +419,17 @@ impl PodBuilder {
     /// ```
     /// # use stackable_operator::builder::pod::PodBuilder;
     /// # use stackable_operator::builder::pod::container::ContainerBuilder;
+    /// # use stackable_operator::iter::TryFromIterator;
     /// # use stackable_operator::kvp::Labels;
     /// # use k8s_openapi::{
     /// #    apimachinery::pkg::apis::meta::v1::ObjectMeta,
     /// # };
     /// # use std::collections::BTreeMap;
     ///
-    /// let labels: Labels = Labels::try_from(
-    ///        BTreeMap::from([("app.kubernetes.io/component", "test-role"),
+    /// let labels: Labels = Labels::try_from_iter(
+    ///        [("app.kubernetes.io/component", "test-role"),
     ///             ("app.kubernetes.io/instance", "test"),
-    ///             ("app.kubernetes.io/name", "test")]))
+    ///             ("app.kubernetes.io/name", "test")])
     /// .unwrap();
     ///
     /// let pod = PodBuilder::new()

--- a/crates/stackable-operator/src/cluster_resources.rs
+++ b/crates/stackable-operator/src/cluster_resources.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     kvp::{
         consts::{K8S_APP_INSTANCE_KEY, K8S_APP_MANAGED_BY_KEY, K8S_APP_NAME_KEY},
-        Label, LabelError, Labels,
+        label, LabelError, Labels,
     },
     utils::format_full_controller_name,
 };
@@ -464,12 +464,12 @@ impl ClusterResources {
     /// Return required labels for cluster resources to be uniquely identified for clean up.
     // TODO: This is a (quick-fix) helper method but should be replaced by better label handling
     pub fn get_required_labels(&self) -> Result<Labels, LabelError> {
-        let mut labels = Labels::common(&self.app_name, &self.app_instance)?;
+        let mut labels = label::sets::common(&self.app_name, &self.app_instance)?;
 
-        labels.insert(Label::managed_by(
+        labels.extend([label::well_known::managed_by(
             &self.operator_name,
             &self.controller_name,
-        )?);
+        )?]);
 
         Ok(labels)
     }

--- a/crates/stackable-operator/src/commons/product_image_selection.rs
+++ b/crates/stackable-operator/src/commons/product_image_selection.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use strum::AsRefStr;
 
 #[cfg(doc)]
-use crate::kvp::Labels;
+use crate::kvp::label;
 
 pub const STACKABLE_DOCKER_REPO: &str = "docker.stackable.tech/stackable";
 
@@ -67,7 +67,7 @@ pub struct ResolvedProductImage {
     /// Version of the product, e.g. `1.4.1`.
     pub product_version: String,
 
-    /// App version as formatted for [`Labels::recommended`]
+    /// App version as formatted for [`label::sets::recommended`]
     pub app_version_label: String,
 
     /// Image to be used for the product image e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`

--- a/crates/stackable-operator/src/kvp/annotation/mod.rs
+++ b/crates/stackable-operator/src/kvp/annotation/mod.rs
@@ -293,15 +293,14 @@ impl Annotations {
             pub fn contains_key(&self, key: impl TryInto<Key>) -> bool;
 
             /// Returns an [`Iterator`] over [`Annotations`] yielding a reference to every [`Annotation`] contained within.
-            pub fn iter(&self) -> impl Iterator<Item = &KeyValuePair<AnnotationValue>>;
-
+            pub fn iter(&self) -> impl Iterator<Item = KeyValuePair<AnnotationValue>> + '_;
         }
     }
 }
 
 impl IntoIterator for Annotations {
     type Item = KeyValuePair<AnnotationValue>;
-    type IntoIter = std::collections::btree_set::IntoIter<Self::Item>;
+    type IntoIter = <KeyValuePairs<AnnotationValue> as IntoIterator>::IntoIter;
 
     /// Returns a consuming [`Iterator`] over [`Annotations`] moving every [`Annotation`] out.
     /// The [`Annotations`] cannot be used again after calling this.

--- a/crates/stackable-operator/src/kvp/annotation/mod.rs
+++ b/crates/stackable-operator/src/kvp/annotation/mod.rs
@@ -9,25 +9,13 @@
 //!
 //! See <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>
 //! for more information on Kubernetes annotations.
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    convert::Infallible,
-    fmt::Display,
-};
+use std::convert::Infallible;
 
-use delegate::delegate;
-
-use crate::{
-    builder::pod::volume::SecretOperatorVolumeScope,
-    iter::TryFromIterator,
-    kvp::{Key, KeyValuePair, KeyValuePairError, KeyValuePairs, KeyValuePairsError},
-};
+use crate::kvp::{KeyValuePair, KeyValuePairError, KeyValuePairs};
 
 mod value;
 
 pub use value::*;
-
-pub type AnnotationsError = KeyValuePairsError;
 
 /// A type alias for errors returned when construction or manipulation of a set
 /// of annotations fails.
@@ -42,102 +30,7 @@ pub type AnnotationError = KeyValuePairError<Infallible>;
 ///
 /// See <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>
 /// for more information on Kubernetes annotations.
-#[derive(Debug)]
-pub struct Annotation(KeyValuePair<AnnotationValue>);
-
-impl<K, V> TryFrom<(K, V)> for Annotation
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    type Error = AnnotationError;
-
-    fn try_from(value: (K, V)) -> Result<Self, Self::Error> {
-        let kvp = KeyValuePair::try_from(value)?;
-        Ok(Self(kvp))
-    }
-}
-
-impl Display for Annotation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Annotation {
-    /// Returns an immutable reference to the annotation's [`Key`].
-    pub fn key(&self) -> &Key {
-        self.0.key()
-    }
-
-    /// Returns an immutable reference to the annotation's value.
-    pub fn value(&self) -> &AnnotationValue {
-        self.0.value()
-    }
-
-    /// Consumes self and returns the inner [`KeyValuePair<AnnotationValue>`].
-    pub fn into_inner(self) -> KeyValuePair<AnnotationValue> {
-        self.0
-    }
-
-    /// Constructs a `secrets.stackable.tech/class` annotation.
-    pub fn secret_class(secret_class: &str) -> Result<Self, AnnotationError> {
-        let kvp = KeyValuePair::try_from(("secrets.stackable.tech/class", secret_class))?;
-        Ok(Self(kvp))
-    }
-
-    /// Constructs a `secrets.stackable.tech/scope` annotation.
-    pub fn secret_scope(
-        scopes: impl AsRef<[SecretOperatorVolumeScope]>,
-    ) -> Result<Self, AnnotationError> {
-        let mut value = String::new();
-
-        for scope in scopes.as_ref() {
-            if !value.is_empty() {
-                value.push(',');
-            }
-
-            match scope {
-                SecretOperatorVolumeScope::Node => value.push_str("node"),
-                SecretOperatorVolumeScope::Pod => value.push_str("pod"),
-                SecretOperatorVolumeScope::Service { name } => {
-                    value.push_str("service=");
-                    value.push_str(name);
-                }
-                SecretOperatorVolumeScope::ListenerVolume { name } => {
-                    value.push_str("listener-volume=");
-                    value.push_str(name);
-                }
-            }
-        }
-
-        let kvp = KeyValuePair::try_from(("secrets.stackable.tech/scope", value))?;
-        Ok(Self(kvp))
-    }
-
-    /// Constructs a `secrets.stackable.tech/format` annotation.
-    pub fn secret_format(format: &str) -> Result<Self, AnnotationError> {
-        let kvp = KeyValuePair::try_from(("secrets.stackable.tech/format", format))?;
-        Ok(Self(kvp))
-    }
-
-    /// Constructs a `secrets.stackable.tech/kerberos.service.names` annotation.
-    pub fn kerberos_service_names(names: impl AsRef<[String]>) -> Result<Self, AnnotationError> {
-        let names = names.as_ref().join(",");
-        let kvp = KeyValuePair::try_from(("secrets.stackable.tech/kerberos.service.names", names))?;
-        Ok(Self(kvp))
-    }
-
-    /// Constructs a `secrets.stackable.tech/format.compatibility.tls-pkcs12.password`
-    /// annotation.
-    pub fn tls_pkcs12_password(password: &str) -> Result<Self, AnnotationError> {
-        let kvp = KeyValuePair::try_from((
-            "secrets.stackable.tech/format.compatibility.tls-pkcs12.password",
-            password,
-        ))?;
-        Ok(Self(kvp))
-    }
-}
+pub type Annotation = KeyValuePair<AnnotationValue>;
 
 /// A validated set/list of Kubernetes annotations.
 ///
@@ -150,181 +43,91 @@ impl Annotation {
 ///
 /// ```
 /// # use std::collections::BTreeMap;
+/// # use stackable_operator::iter::TryFromIterator;
 /// # use stackable_operator::kvp::Annotations;
 /// let map = BTreeMap::from([
 ///     ("stackable.tech/managed-by", "stackablectl"),
 ///     ("stackable.tech/vendor", "Stäckable"),
 /// ]);
 ///
-/// let labels = Annotations::try_from(map).unwrap();
+/// let labels = Annotations::try_from_iter(map).unwrap();
 /// ```
 ///
 /// ### Creating a list of labels from an array
 ///
 /// ```
+/// # use stackable_operator::iter::TryFromIterator;
 /// # use stackable_operator::kvp::Annotations;
-/// let labels = Annotations::try_from([
+/// let labels = Annotations::try_from_iter([
 ///     ("stackable.tech/managed-by", "stackablectl"),
 ///     ("stackable.tech/vendor", "Stäckable"),
 /// ]).unwrap();
 /// ```
-#[derive(Clone, Debug, Default)]
-pub struct Annotations(KeyValuePairs<AnnotationValue>);
+pub type Annotations = KeyValuePairs<AnnotationValue>;
 
-impl<K, V> TryFrom<BTreeMap<K, V>> for Annotations
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    type Error = AnnotationError;
+/// Well-known annotations used by other tools or standard conventions.
+pub mod well_known {
+    /// Annotations applicable to Stackable Secret Operator volumes
+    pub mod secret_volume {
+        use crate::{
+            builder::pod::volume::SecretOperatorVolumeScope,
+            kvp::{Annotation, AnnotationError},
+        };
 
-    fn try_from(map: BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        Self::try_from_iter(map)
-    }
-}
-
-impl<K, V> TryFrom<&BTreeMap<K, V>> for Annotations
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    type Error = AnnotationError;
-
-    fn try_from(map: &BTreeMap<K, V>) -> Result<Self, Self::Error> {
-        Self::try_from_iter(map)
-    }
-}
-
-impl<const N: usize, K, V> TryFrom<[(K, V); N]> for Annotations
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    type Error = AnnotationError;
-
-    fn try_from(array: [(K, V); N]) -> Result<Self, Self::Error> {
-        Self::try_from_iter(array)
-    }
-}
-
-impl FromIterator<KeyValuePair<AnnotationValue>> for Annotations {
-    fn from_iter<T: IntoIterator<Item = KeyValuePair<AnnotationValue>>>(iter: T) -> Self {
-        let kvps = KeyValuePairs::from_iter(iter);
-        Self(kvps)
-    }
-}
-
-impl<K, V> TryFromIterator<(K, V)> for Annotations
-where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    type Error = AnnotationError;
-
-    fn try_from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Result<Self, Self::Error> {
-        let kvps = KeyValuePairs::try_from_iter(iter)?;
-        Ok(Self(kvps))
-    }
-}
-
-impl From<Annotations> for BTreeMap<String, String> {
-    fn from(value: Annotations) -> Self {
-        value.0.into()
-    }
-}
-
-impl Annotations {
-    /// Creates a new empty list of [`Annotations`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates a new list of [`Annotations`] from `pairs`.
-    pub fn new_with(pairs: BTreeSet<KeyValuePair<AnnotationValue>>) -> Self {
-        Self(KeyValuePairs::new_with(pairs))
-    }
-
-    /// Tries to insert a new annotation by first parsing `annotation` as an
-    /// [`Annotation`] and then inserting it into the list. This function will
-    /// overwrite any existing annotation already present.
-    pub fn parse_insert(
-        &mut self,
-        annotation: impl TryInto<Annotation, Error = AnnotationError>,
-    ) -> Result<(), AnnotationError> {
-        self.0.insert(annotation.try_into()?.0);
-        Ok(())
-    }
-
-    /// Inserts a new [`Annotation`]. This function will overwrite any existing
-    /// annotation already present.
-    pub fn insert(&mut self, annotation: Annotation) -> &mut Self {
-        self.0.insert(annotation.0);
-        self
-    }
-
-    // This forwards / delegates associated functions to the inner field. In
-    // this case self.0 which is of type KeyValuePairs<T>. So calling
-    // Annotations::len() will be delegated to KeyValuePair<T>::len() without
-    // the need to write boilerplate code.
-    delegate! {
-        to self.0 {
-            /// Tries to insert a new [`Annotation`]. It ensures there are no duplicate
-            /// entries. Trying to insert duplicated data returns an error. If no such
-            /// check is required, use [`Annotations::insert`] instead.
-            pub fn try_insert(&mut self, #[newtype] annotation: Annotation) -> Result<(), AnnotationsError>;
-
-            /// Extends `self` with `other`.
-            pub fn extend(&mut self, #[newtype] other: Self);
-
-            /// Returns the number of labels.
-            pub fn len(&self) -> usize;
-
-            /// Returns if the set of labels is empty.
-            pub fn is_empty(&self) -> bool;
-
-            /// Returns if the set of annotations contains the provided
-            /// `annotation`. Failure to parse/validate the [`KeyValuePair`]
-            /// will return `false`.
-            pub fn contains(&self, annotation: impl TryInto<KeyValuePair<AnnotationValue>>) -> bool;
-
-            /// Returns if the set of annotations contains a label with the
-            /// provided `key`. Failure to parse/validate the [`Key`] will
-            /// return `false`.
-            pub fn contains_key(&self, key: impl TryInto<Key>) -> bool;
-
-            /// Returns an [`Iterator`] over [`Annotations`] yielding a reference to every [`Annotation`] contained within.
-            pub fn iter(&self) -> impl Iterator<Item = KeyValuePair<AnnotationValue>> + '_;
+        /// Constructs a `secrets.stackable.tech/class` annotation.
+        pub fn secret_class(secret_class: &str) -> Result<Annotation, AnnotationError> {
+            Annotation::try_from(("secrets.stackable.tech/class", secret_class))
         }
-    }
-}
 
-impl IntoIterator for Annotations {
-    type Item = KeyValuePair<AnnotationValue>;
-    type IntoIter = <KeyValuePairs<AnnotationValue> as IntoIterator>::IntoIter;
+        /// Constructs a `secrets.stackable.tech/scope` annotation.
+        pub fn secret_scope(
+            scopes: &[SecretOperatorVolumeScope],
+        ) -> Result<Annotation, AnnotationError> {
+            let mut value = String::new();
 
-    /// Returns a consuming [`Iterator`] over [`Annotations`] moving every [`Annotation`] out.
-    /// The [`Annotations`] cannot be used again after calling this.
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
+            for scope in scopes {
+                if !value.is_empty() {
+                    value.push(',');
+                }
 
-#[cfg(test)]
-mod test {
-    use super::*;
+                match scope {
+                    SecretOperatorVolumeScope::Node => value.push_str("node"),
+                    SecretOperatorVolumeScope::Pod => value.push_str("pod"),
+                    SecretOperatorVolumeScope::Service { name } => {
+                        value.push_str("service=");
+                        value.push_str(name);
+                    }
+                    SecretOperatorVolumeScope::ListenerVolume { name } => {
+                        value.push_str("listener-volume=");
+                        value.push_str(name);
+                    }
+                }
+            }
 
-    #[test]
-    fn parse_insert() {
-        let mut annotations = Annotations::new();
+            Annotation::try_from(("secrets.stackable.tech/scope", value.as_str()))
+        }
 
-        annotations
-            .parse_insert(("stackable.tech/managed-by", "stackablectl"))
-            .unwrap();
+        /// Constructs a `secrets.stackable.tech/format` annotation.
+        pub fn secret_format(format: &str) -> Result<Annotation, AnnotationError> {
+            Annotation::try_from(("secrets.stackable.tech/format", format))
+        }
 
-        annotations
-            .parse_insert(("stackable.tech/vendor", "Stäckable"))
-            .unwrap();
+        /// Constructs a `secrets.stackable.tech/kerberos.service.names` annotation.
+        pub fn kerberos_service_names(names: &[String]) -> Result<Annotation, AnnotationError> {
+            let names = names.join(",");
+            Annotation::try_from((
+                "secrets.stackable.tech/kerberos.service.names",
+                names.as_str(),
+            ))
+        }
 
-        assert_eq!(annotations.len(), 2);
+        /// Constructs a `secrets.stackable.tech/format.compatibility.tls-pkcs12.password`
+        /// annotation.
+        pub fn tls_pkcs12_password(password: &str) -> Result<Annotation, AnnotationError> {
+            Annotation::try_from((
+                "secrets.stackable.tech/format.compatibility.tls-pkcs12.password",
+                password,
+            ))
+        }
     }
 }

--- a/crates/stackable-operator/src/kvp/key.rs
+++ b/crates/stackable-operator/src/kvp/key.rs
@@ -109,6 +109,12 @@ impl Display for Key {
     }
 }
 
+impl From<&Key> for String {
+    fn from(value: &Key) -> Self {
+        value.to_string()
+    }
+}
+
 impl Key {
     /// Retrieves the key's prefix.
     ///
@@ -413,7 +419,7 @@ mod test {
         let label = Label::try_from((key, "zookeeper")).unwrap();
 
         let is_valid = label
-            .key()
+            .key
             .prefix()
             .is_some_and(|prefix| *prefix == "app.kubernetes.io");
 
@@ -427,7 +433,7 @@ mod test {
     #[case("foo", false)]
     fn key_name_deref(#[case] key: &str, #[case] expected: bool) {
         let label = Label::try_from((key, "zookeeper")).unwrap();
-        let is_valid = *label.key().name() == "name";
+        let is_valid = *label.key.name() == "name";
 
         assert_eq!(is_valid, expected);
     }

--- a/crates/stackable-operator/src/kvp/label/mod.rs
+++ b/crates/stackable-operator/src/kvp/label/mod.rs
@@ -385,7 +385,7 @@ impl Labels {
             pub fn contains_key(&self, key: impl TryInto<Key>) -> bool;
 
             /// Returns an [`Iterator`] over [`Labels`] yielding a reference to every [`Label`] contained within.
-            pub fn iter(&self) -> impl Iterator<Item = &KeyValuePair<LabelValue>>;
+            pub fn iter(&self) -> impl Iterator<Item = KeyValuePair<LabelValue>> + '_;
 
         }
     }
@@ -393,7 +393,7 @@ impl Labels {
 
 impl IntoIterator for Labels {
     type Item = KeyValuePair<LabelValue>;
-    type IntoIter = std::collections::btree_set::IntoIter<Self::Item>;
+    type IntoIter = <KeyValuePairs<LabelValue> as IntoIterator>::IntoIter;
 
     /// Returns a consuming [`Iterator`] over [`Labels`] moving every [`Label`] out.
     /// The [`Labels`] cannot be used again after calling this.

--- a/crates/stackable-operator/src/kvp/mod.rs
+++ b/crates/stackable-operator/src/kvp/mod.rs
@@ -152,8 +152,8 @@ where
 
 #[derive(Debug, PartialEq, Snafu)]
 pub enum KeyValuePairsError {
-    #[snafu(display("key/value pair already exists"))]
-    PairAlreadyExists,
+    #[snafu(display("key already exists"))]
+    KeyAlreadyExists,
 }
 
 /// A validated set/list of Kubernetes key/value pairs.
@@ -304,7 +304,7 @@ where
     /// If the list already had this key present, nothing is updated, and an
     /// error is returned.
     pub fn try_insert(&mut self, kvp: KeyValuePair<T>) -> Result<(), KeyValuePairsError> {
-        ensure!(!self.0.contains_key(&kvp.key), PairAlreadyExistsSnafu);
+        ensure!(!self.0.contains_key(&kvp.key), KeyAlreadyExistsSnafu);
         self.insert(kvp);
         Ok(())
     }

--- a/crates/stackable-operator/src/kvp/mod.rs
+++ b/crates/stackable-operator/src/kvp/mod.rs
@@ -178,7 +178,7 @@ pub enum KeyValuePairsError {
 /// which ultimately prevent unncessary reconciliations due to changes
 /// in item order.
 #[derive(Clone, Debug, Default)]
-pub struct KeyValuePairs<T: Value>(BTreeSet<KeyValuePair<T>>);
+pub struct KeyValuePairs<T: Value>(BTreeMap<Key, T>);
 
 impl<K, V, T> TryFrom<BTreeMap<K, V>> for KeyValuePairs<T>
 where
@@ -224,7 +224,7 @@ where
     T: Value,
 {
     fn from_iter<I: IntoIterator<Item = KeyValuePair<T>>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self(iter.into_iter().map(|kvp| (kvp.key, kvp.value)).collect())
     }
 }
 
@@ -242,7 +242,7 @@ where
             .map(KeyValuePair::try_from)
             .collect::<Result<BTreeSet<_>, KeyValuePairError<T::Error>>>()?;
 
-        Ok(Self(pairs))
+        Ok(Self::from_iter(pairs))
     }
 }
 
@@ -253,7 +253,7 @@ where
     fn from(value: KeyValuePairs<T>) -> Self {
         value
             .iter()
-            .map(|pair| (pair.key().to_string(), pair.value().to_string()))
+            .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
     }
 }
@@ -262,7 +262,7 @@ impl<T> Deref for KeyValuePairs<T>
 where
     T: Value,
 {
-    type Target = BTreeSet<KeyValuePair<T>>;
+    type Target = BTreeMap<Key, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -280,7 +280,7 @@ where
 
     /// Creates a new list of [`KeyValuePair`]s from `pairs`.
     pub fn new_with(pairs: BTreeSet<KeyValuePair<T>>) -> Self {
-        Self(pairs)
+        Self::from_iter(pairs)
     }
 
     /// Extends `self` with `other`.
@@ -295,16 +295,16 @@ where
     /// [`KeyValuePairs::contains_key`] before inserting or try to insert
     /// fallible via [`KeyValuePairs::try_insert`].
     pub fn insert(&mut self, kvp: KeyValuePair<T>) -> &mut Self {
-        self.0.insert(kvp);
+        self.0.insert(kvp.key, kvp.value);
         self
     }
 
     /// Tries to insert a new [`KeyValuePair`] into the list of pairs.
     ///
-    /// If the list already had this pair present, nothing is updated, and an
+    /// If the list already had this key present, nothing is updated, and an
     /// error is returned.
     pub fn try_insert(&mut self, kvp: KeyValuePair<T>) -> Result<(), KeyValuePairsError> {
-        ensure!(!self.0.contains(&kvp), PairAlreadyExistsSnafu);
+        ensure!(!self.0.contains_key(&kvp.key), PairAlreadyExistsSnafu);
         self.insert(kvp);
         Ok(())
     }
@@ -314,7 +314,10 @@ where
         let Ok(kvp) = kvp.try_into() else {
             return false;
         };
-        self.0.contains(&kvp)
+        let Some(value) = self.get(&kvp.key) else {
+            return false;
+        };
+        value == &kvp.value
     }
 
     /// Returns if the list contains a key/value pair with a specific [`Key`].
@@ -323,18 +326,15 @@ where
             return false;
         };
 
-        for kvp in &self.0 {
-            if kvp.key == key {
-                return true;
-            }
-        }
-
-        false
+        self.0.contains_key(&key)
     }
 
     /// Returns an [`Iterator`] over [`KeyValuePairs`] yielding a reference to every [`KeyValuePair`] contained within.
-    pub fn iter(&self) -> impl Iterator<Item = &KeyValuePair<T>> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = KeyValuePair<T>> + '_ {
+        self.0.iter().map(|(k, v)| KeyValuePair {
+            key: k.clone(),
+            value: v.clone(),
+        })
     }
 }
 
@@ -343,12 +343,15 @@ where
     T: Value,
 {
     type Item = KeyValuePair<T>;
-    type IntoIter = std::collections::btree_set::IntoIter<Self::Item>;
+    type IntoIter =
+        std::iter::Map<std::collections::btree_map::IntoIter<Key, T>, fn((Key, T)) -> Self::Item>;
 
     /// Returns a consuming [`Iterator`] over [`KeyValuePairs`] moving every [`KeyValuePair`] out.
     /// The [`KeyValuePairs`] cannot be used again after calling this.
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.0
+            .into_iter()
+            .map(|(key, value)| KeyValuePair { key, value })
     }
 }
 
@@ -487,5 +490,18 @@ mod test {
         let err = Label::try_from(("stackable.tech/vendor", "Stäckable")).unwrap_err();
         let report = Report::from_error(err);
         println!("{report}")
+    }
+
+    #[test]
+    fn merge() {
+        let mut merged_labels =
+            Labels::try_from_iter([("a", "b"), ("b", "a"), ("c", "c")]).unwrap();
+        merged_labels.extend(Labels::try_from_iter([("a", "a"), ("b", "b"), ("d", "d")]).unwrap());
+        assert_eq!(
+            BTreeMap::from(merged_labels),
+            BTreeMap::from(
+                Labels::try_from_iter([("a", "a"), ("b", "b"), ("c", "c"), ("d", "d")]).unwrap()
+            )
+        )
     }
 }


### PR DESCRIPTION
# Description

This is effectively an extended version of #888 (and supersedes it).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
