### PR TITLE
chore: Release stackable-versioned 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "kube",
  "snafu 0.8.4",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-10-14
+
 ### Added
 
 - Add YAML serialization for merged CRD schema. The schema can now be printed to stdout or written

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## [0.4.0] - 2024-10-14

### Added

- Add YAML serialization for merged CRD schema. The schema can now be printed to stdout or written to file ([#884]).
- Add snapshot tests to verify generated code matches expected output ([#881]).

[#881]: https://github.com/stackabletech/operator-rs/pull/881
[#884]: https://github.com/stackabletech/operator-rs/pull/884
[0.4.0]: https://github.com/stackabletech/operator-rs/releases/tag/stackable-versioned-0.4.0