### PR TITLE
feat(stackable-versioned): Add basic handling for enum variants with data

### DIFF
--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 # are, however, used in K8s specific test cases. This is a false-positive and an
 # apparent limitation of cargo-udeps. These entries can be removed once
 # cargo-udeps supports detecting usage of such dependencies.
-development = ["schemars", "serde_yaml", "stackable-versioned"]
+development = ["k8s-openapi", "schemars", "serde_yaml", "stackable-versioned"]
 
 # cargo-udeps throws an error stating that these dependencies are unused. They are all marked as
 # optional, which trips up cargo-udeps for whatever reason...

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -45,6 +45,7 @@ quote.workspace = true
 [dev-dependencies]
 # Only needed for doc tests / examples
 stackable-versioned = { path = "../stackable-versioned", features = ["k8s"] }
+k8s-openapi = { workspace = true }
 
 insta.workspace = true
 prettyplease.workspace = true

--- a/crates/stackable-versioned-macros/fixtures/inputs/default/enum_data_simple.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/enum_data_simple.rs
@@ -1,0 +1,12 @@
+#[versioned(version(name = "v1alpha1"), version(name = "v1alpha2"))]
+// ---
+enum Foo {
+    Foo,
+    Bar(u32, String),
+
+    #[versioned(added(since = "v1alpha2"))]
+    Baz {
+        id: u32,
+        name: String,
+    },
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@enum_data_simple.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@enum_data_simple.rs.snap
@@ -1,0 +1,31 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/enum_data_simple.rs
+---
+#[automatically_derived]
+mod v1alpha1 {
+    use super::*;
+    pub enum Foo {
+        Foo,
+        Bar(u32, String),
+    }
+}
+#[automatically_derived]
+impl From<v1alpha1::Foo> for v1alpha2::Foo {
+    fn from(__sv_foo: v1alpha1::Foo) -> Self {
+        match __sv_foo {
+            v1alpha1::Foo::Foo => v1alpha2::Foo::Foo,
+            v1alpha1::Foo::Bar(__sv_0, __sv_1) => v1alpha2::Foo::Bar(__sv_0, __sv_1),
+        }
+    }
+}
+#[automatically_derived]
+mod v1alpha2 {
+    use super::*;
+    pub enum Foo {
+        Foo,
+        Bar(u32, String),
+        Baz { id: u32, name: String },
+    }
+}

--- a/crates/stackable-versioned-macros/src/test_utils.rs
+++ b/crates/stackable-versioned-macros/src/test_utils.rs
@@ -15,7 +15,7 @@ use crate::versioned_impl;
 const DELIMITER: &str = "// ---\n";
 
 static REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"#\[versioned\(\n(?P<args>[[:ascii:]]+)\n\)\]")
+    Regex::new(r"#\[versioned\(\s*(?P<args>[[:ascii:]]+)\s*\)\]")
         .expect("failed to compile versioned regex")
 });
 
@@ -55,7 +55,7 @@ fn prepare_from_string(input: String) -> Result<(TokenStream, DeriveInput), Erro
 
     let attrs = REGEX
         .captures(attrs)
-        .unwrap()
+        .expect("the regex did not match")
         .name("args")
         .context(MissingRegexMatchGroupSnafu)?
         .as_str();

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add basic handling for enum variants with data ([#892]).
+
+### Fixed
+
+- Accept a wider variety of formatting styles in the macro testing regex ([#892]).
+
+[#892]: https://github.com/stackabletech/operator-rs/pull/892
+
 ## [0.4.0] - 2024-10-14
 
 ### Added


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/642.

- stackable-versioned: Add basic handling for enum variants with data, with a snapshot test.
  _TODO: Handle versioning of named/unnamed enum fields_.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```
