### PR TITLE
chore: Release stackable-operator 0.79.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.79.0] - 2024-10-18
+
 ### Added
 
 - Re-export the `YamlSchema` trait and the `stackable-shared` crate as the `shared` module ([#883]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.78.0"
+version = "0.79.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION

### Added

- Re-export the `YamlSchema` trait and the `stackable-shared` crate as the `shared` module ([#883]).
- BREAKING: Added `preferredAddressType` field to ListenerClass CRD ([#885]).
- BREAKING: The cluster domain (default: `cluster.local`) can now be configured in the individual
  operators via the ENV variable `KUBERNETES_CLUSTER_DOMAIN` or resolved automatically by parsing
  the `/etc/resolve.conf` file. This requires using `initialize_operator` instead of `create_client`
  in the `main.rs` of the individual operators ([#893]).

### Changed

- BREAKING: The `CustomResourceExt` trait is now re-exported from the `stackable-shared` crate. The
  trait functions use the same parameters but return a different error type ([#883]).
- BREAKING: `KeyValuePairs` (as well as `Labels`/`Annotations` via it) is now backed by a `BTreeMap`
  rather than a `BTreeSet` ([#888]).
  - The `Deref` impl now returns a `BTreeMap` instead.
  - `iter()` now clones the values.

### Fixed

- BREAKING: `KeyValuePairs::insert` (as well as `Labels::`/`Annotations::` via it) now overwrites
  the old value if the key already exists. Previously, `iter()` would return *both* values in
  lexicographical order (causing further conversions like `Into<BTreeMap>` to prefer the maximum
  value) ([#888]).

### Removed

- BREAKING: The `CustomResourceExt` trait doesn't provide a `generate_yaml_schema` function any
  more. Instead, use the high-level functions to write the schema to a file, write it to stdout or
  use it as a `String` ([#883]).

[#883]: https://github.com/stackabletech/operator-rs/pull/883
[#885]: https://github.com/stackabletech/operator-rs/pull/885
[#888]: https://github.com/stackabletech/operator-rs/pull/888
[#893]: https://github.com/stackabletech/operator-rs/pull/893
