### PR TITLE
fix: Fix Kubernetes cluster domain parsing from resolv.conf

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix Kubernetes cluster domain parsing from resolv.conf, e.g. on AWS EKS.
-  We now only consider Kubernetes services domains instead of all domains (which could include non-Kubernetes domains) ([#XXX]).
+  We now only consider Kubernetes services domains instead of all domains (which could include non-Kubernetes domains) ([#895]).
+
+[#895]: https://github.com/stackabletech/operator-rs/pull/895
 
 ## [0.79.0] - 2024-10-18
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.79.1] - 2024-10-21
-
 ### Fixed
 
 - Fix Kubernetes cluster domain parsing from resolv.conf, e.g. on AWS EKS.

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.79.1] - 2024-10-21
+
+### Fixed
+
+- Fix Kubernetes cluster domain parsing from resolv.conf, e.g. on AWS EKS.
+  We now only consider Kubernetes services domains instead of all domains (which could include non-Kubernetes domains) ([#XXX]).
+
 ## [0.79.0] - 2024-10-18
 
 ### Added

--- a/crates/stackable-operator/fixtures/cluster_domain/fail/no-service-domain.conf
+++ b/crates/stackable-operator/fixtures/cluster_domain/fail/no-service-domain.conf
@@ -1,0 +1,3 @@
+search cluster.local
+nameserver 10.243.21.53
+options ndots:5

--- a/crates/stackable-operator/fixtures/cluster_domain/pass/aws-eks.resolv.conf
+++ b/crates/stackable-operator/fixtures/cluster_domain/pass/aws-eks.resolv.conf
@@ -1,0 +1,3 @@
+search default.svc.cluster.local svc.cluster.local cluster.local ec2.internal
+nameserver 172.20.0.10
+options ndots:5

--- a/crates/stackable-operator/src/utils/cluster_domain.rs
+++ b/crates/stackable-operator/src/utils/cluster_domain.rs
@@ -125,9 +125,9 @@ fn retrieve_cluster_domain_from_resolv_conf(
     let last_search_entry = content
         .lines()
         .rev()
-        .map(|l| l.trim())
-        .find(|&l| l.starts_with("search"))
-        .map(|l| l.trim_start_matches("search").trim())
+        .map(|entry| entry.trim())
+        .find(|&entry| entry.starts_with("search"))
+        .map(|entry| entry.trim_start_matches("search").trim())
         .context(NoSearchEntrySnafu)?;
 
     // We only care about entries starting with "svc." to limit the entries to the ones used by


### PR DESCRIPTION
# Description

This fixes a bug on AWS EKS:

Given the resolv.conf

```
search default.svc.cluster.local svc.cluster.local cluster.local ec2.internal
nameserver 172.20.0.10
options ndots:5
```

the operators logged

`retrieve_cluster_domain: stackable_operator::utils::cluster_domain: Using Kubernetes cluster domain from "/etc/resolv.conf" file cluster_domain=ec2.internal`.

However, they should have used `cluster.local`. This PR fixes that.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
