### PR TITLE
chore: Release workspace members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kube",
  "snafu 0.8.4",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.80.0] - 2024-10-23
+
 ### Changed
 
 - BREAKING: Don't parse `/etc/resolv.conf` to auto-detect the Kubernetes cluster domain in case it is not explicitly configured.

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.79.0"
+version = "0.80.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-10-23
+
 ### Added
 
 - Add basic handling for enum variants with data ([#892]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-rs/issues/898.

This PR releases `stackable-operator-0.80.0` and `stackable-versioned-0.4.1`:

## stackable-operator-0.80.0

### Changed

- BREAKING: Don't parse `/etc/resolv.conf` to auto-detect the Kubernetes cluster domain in case it is not explicitly configured. Instead the operator will default to `cluster.local`. We revert this now after some concerns where raised, we will create a follow-up decision instead addressing how we will continue with this ([#896]).
- Update Rust dependencies (Both `json-patch` and opentelemetry crates cannot be updated because of conflicts) ([#897]):
  - Bump `kube` to `0.96.0`,
  - `rstest` to `0.23.0` and
  - `tower-http` to `0.6.1`

### Fixed

- Fix Kubernetes cluster domain parsing from resolv.conf, e.g. on AWS EKS. We now only consider Kubernetes services domains instead of all domains (which could include non-Kubernetes domains) ([#895]).

[#895]: https://github.com/stackabletech/operator-rs/pull/895
[#896]: https://github.com/stackabletech/operator-rs/pull/896
[#897]: https://github.com/stackabletech/operator-rs/pull/897

## stackable-versioned-0.4.1

### Added

- Add basic handling for enum variants with data ([#892]).

### Fixed

- Accept a wider variety of formatting styles in the macro testing regex ([#892]).

[#892]: https://github.com/stackabletech/operator-rs/pull/892