### PR TITLE
chore: Release stackable-operator 0.82.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.82.0] - 2024-11-23
+
 ### Fixed
 
 - Fixed URL handling related to OIDC and `rootPath` with and without trailing slashes. Also added a bunch of tests ([#910]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.81.0"
+version = "0.82.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

### Fixed

- Fixed URL handling related to OIDC and `rootPath` with and without trailing slashes. Also added a bunch of tests ([#910]).

### Changed

- BREAKING: Made `DEFAULT_OIDC_WELLKNOWN_PATH` private. Use `AuthenticationProvider::well_known_config_url` instead ([#910]).
- BREAKING: Changed visibility of `commons::rbac::service_account_name` and `commons::rbac::role_binding_name` to
  private, as these functions should not be called directly by the operators. This is likely to result in naming conflicts
  as the result is completely dependent on what is passed to this function. Operators should instead rely on the roleBinding
  and serviceAccount objects created by `commons::rbac::build_rbac_resources` and retrieve the name from the returned
  objects if they need it ([#909]).
- Changed the names of the objects that are returned from `commons::rbac::build_rbac_resources` to not rely solely on the product
  they refer to (e.g. "nifi-rolebinding") but instead include the name of the resource to be unique per cluster
  (e.g. simple-nifi-rolebinding) ([#909]).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
