### PR TITLE
fix(stackable-versioned): Emit Kubernetes code in modules

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/k8s/module.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/k8s/module.rs
@@ -1,0 +1,27 @@
+#[versioned(
+    version(name = "v1alpha1"),
+    version(name = "v1"),
+    version(name = "v2alpha1")
+)]
+// ---
+pub(crate) mod versioned {
+    #[versioned(k8s(group = "foo.example.org", plural = "foos", namespaced))]
+    pub struct FooSpec {
+        bar: usize,
+
+        #[versioned(added(since = "v1"))]
+        baz: bool,
+
+        #[versioned(deprecated(since = "v2alpha1"))]
+        deprecated_foo: String,
+    }
+
+    #[versioned(k8s(group = "bar.example.org", plural = "bars"))]
+    pub struct BarSpec {
+        baz: String,
+    }
+
+    pub struct Baz {
+        boom: Option<u16>,
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/inputs/k8s/module_preserve.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/k8s/module_preserve.rs
@@ -1,0 +1,28 @@
+#[versioned(
+    version(name = "v1alpha1"),
+    version(name = "v1"),
+    version(name = "v2alpha1"),
+    preserve_module
+)]
+// ---
+pub(crate) mod versioned {
+    #[versioned(k8s(group = "foo.example.org", plural = "foos", namespaced))]
+    pub struct FooSpec {
+        bar: usize,
+
+        #[versioned(added(since = "v1"))]
+        baz: bool,
+
+        #[versioned(deprecated(since = "v2alpha1"))]
+        deprecated_foo: String,
+    }
+
+    #[versioned(k8s(group = "bar.example.org", plural = "bars"))]
+    pub struct BarSpec {
+        baz: String,
+    }
+
+    pub struct Baz {
+        boom: Option<u16>,
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
@@ -1,0 +1,375 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/k8s/module.rs
+---
+#[automatically_derived]
+pub(crate) mod v1alpha1 {
+    use super::*;
+    #[derive(::kube::CustomResource)]
+    #[kube(
+        group = "foo.example.org",
+        version = "v1alpha1",
+        kind = "Foo",
+        plural = "foos",
+        namespaced
+    )]
+    pub struct FooSpec {
+        pub bar: usize,
+        pub foo: String,
+    }
+    #[derive(::kube::CustomResource)]
+    #[kube(
+        group = "bar.example.org",
+        version = "v1alpha1",
+        kind = "Bar",
+        plural = "bars"
+    )]
+    pub struct BarSpec {
+        pub baz: String,
+    }
+    pub struct Baz {
+        pub boom: Option<u16>,
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1alpha1::FooSpec> for v1::FooSpec {
+    fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
+        Self {
+            bar: __sv_foospec.bar,
+            baz: ::std::default::Default::default(),
+            foo: __sv_foospec.foo,
+        }
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1alpha1::BarSpec> for v1::BarSpec {
+    fn from(__sv_barspec: v1alpha1::BarSpec) -> Self {
+        Self { baz: __sv_barspec.baz }
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1alpha1::Baz> for v1::Baz {
+    fn from(__sv_baz: v1alpha1::Baz) -> Self {
+        Self { boom: __sv_baz.boom }
+    }
+}
+#[automatically_derived]
+pub(crate) mod v1 {
+    use super::*;
+    #[derive(::kube::CustomResource)]
+    #[kube(
+        group = "foo.example.org",
+        version = "v1",
+        kind = "Foo",
+        plural = "foos",
+        namespaced
+    )]
+    pub struct FooSpec {
+        pub bar: usize,
+        pub baz: bool,
+        pub foo: String,
+    }
+    #[derive(::kube::CustomResource)]
+    #[kube(group = "bar.example.org", version = "v1", kind = "Bar", plural = "bars")]
+    pub struct BarSpec {
+        pub baz: String,
+    }
+    pub struct Baz {
+        pub boom: Option<u16>,
+    }
+}
+#[automatically_derived]
+#[allow(deprecated)]
+impl ::std::convert::From<v1::FooSpec> for v2alpha1::FooSpec {
+    fn from(__sv_foospec: v1::FooSpec) -> Self {
+        Self {
+            bar: __sv_foospec.bar,
+            baz: __sv_foospec.baz,
+            deprecated_foo: __sv_foospec.foo,
+        }
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1::BarSpec> for v2alpha1::BarSpec {
+    fn from(__sv_barspec: v1::BarSpec) -> Self {
+        Self { baz: __sv_barspec.baz }
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1::Baz> for v2alpha1::Baz {
+    fn from(__sv_baz: v1::Baz) -> Self {
+        Self { boom: __sv_baz.boom }
+    }
+}
+#[automatically_derived]
+pub(crate) mod v2alpha1 {
+    use super::*;
+    #[derive(::kube::CustomResource)]
+    #[kube(
+        group = "foo.example.org",
+        version = "v2alpha1",
+        kind = "Foo",
+        plural = "foos",
+        namespaced
+    )]
+    pub struct FooSpec {
+        pub bar: usize,
+        pub baz: bool,
+        #[deprecated]
+        pub deprecated_foo: String,
+    }
+    #[derive(::kube::CustomResource)]
+    #[kube(
+        group = "bar.example.org",
+        version = "v2alpha1",
+        kind = "Bar",
+        plural = "bars"
+    )]
+    pub struct BarSpec {
+        pub baz: String,
+    }
+    pub struct Baz {
+        pub boom: Option<u16>,
+    }
+}
+#[automatically_derived]
+pub enum Foo {
+    V1Alpha1,
+    V1Alpha1,
+}
+#[automatically_derived]
+impl ::std::fmt::Display for Foo {
+    fn fmt(
+        &self,
+        f: &mut ::std::fmt::Formatter<'_>,
+    ) -> ::std::result::Result<(), ::std::fmt::Error> {
+        match self {
+            Self::V1Alpha1 => f.write_str("v1alpha1"),
+            Self::V1Alpha1 => f.write_str("v1alpha1"),
+        }
+    }
+}
+#[automatically_derived]
+impl Foo {
+    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    pub fn merged_crd(
+        stored_apiversion: Self,
+    ) -> ::std::result::Result<
+        ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+        ::kube::core::crd::MergeError,
+    > {
+        ::kube::core::crd::merge_crds(
+            vec![
+                < v1alpha1::Foo as ::kube::CustomResourceExt > ::crd(), < v1alpha1::Bar
+                as ::kube::CustomResourceExt > ::crd()
+            ],
+            &stored_apiversion.to_string(),
+        )
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to a file located at `path`.
+    pub fn write_merged_crd<P>(
+        path: P,
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error>
+    where
+        P: AsRef<::std::path::Path>,
+    {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::write_yaml_schema(
+                &merged_crd,
+                path,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to stdout.
+    pub fn print_merged_crd(
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error> {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::print_yaml_schema(
+                &merged_crd,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+}
+#[automatically_derived]
+pub enum Bar {
+    V1,
+    V1,
+}
+#[automatically_derived]
+impl ::std::fmt::Display for Bar {
+    fn fmt(
+        &self,
+        f: &mut ::std::fmt::Formatter<'_>,
+    ) -> ::std::result::Result<(), ::std::fmt::Error> {
+        match self {
+            Self::V1 => f.write_str("v1"),
+            Self::V1 => f.write_str("v1"),
+        }
+    }
+}
+#[automatically_derived]
+impl Bar {
+    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    pub fn merged_crd(
+        stored_apiversion: Self,
+    ) -> ::std::result::Result<
+        ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+        ::kube::core::crd::MergeError,
+    > {
+        ::kube::core::crd::merge_crds(
+            vec![
+                < v1::Foo as ::kube::CustomResourceExt > ::crd(), < v1::Bar as
+                ::kube::CustomResourceExt > ::crd()
+            ],
+            &stored_apiversion.to_string(),
+        )
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to a file located at `path`.
+    pub fn write_merged_crd<P>(
+        path: P,
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error>
+    where
+        P: AsRef<::std::path::Path>,
+    {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::write_yaml_schema(
+                &merged_crd,
+                path,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to stdout.
+    pub fn print_merged_crd(
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error> {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::print_yaml_schema(
+                &merged_crd,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+}
+#[automatically_derived]
+pub enum Baz {
+    V2Alpha1,
+    V2Alpha1,
+}
+#[automatically_derived]
+impl ::std::fmt::Display for Baz {
+    fn fmt(
+        &self,
+        f: &mut ::std::fmt::Formatter<'_>,
+    ) -> ::std::result::Result<(), ::std::fmt::Error> {
+        match self {
+            Self::V2Alpha1 => f.write_str("v2alpha1"),
+            Self::V2Alpha1 => f.write_str("v2alpha1"),
+        }
+    }
+}
+#[automatically_derived]
+impl Baz {
+    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    pub fn merged_crd(
+        stored_apiversion: Self,
+    ) -> ::std::result::Result<
+        ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+        ::kube::core::crd::MergeError,
+    > {
+        ::kube::core::crd::merge_crds(
+            vec![
+                < v2alpha1::Foo as ::kube::CustomResourceExt > ::crd(), < v2alpha1::Bar
+                as ::kube::CustomResourceExt > ::crd()
+            ],
+            &stored_apiversion.to_string(),
+        )
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to a file located at `path`.
+    pub fn write_merged_crd<P>(
+        path: P,
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error>
+    where
+        P: AsRef<::std::path::Path>,
+    {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::write_yaml_schema(
+                &merged_crd,
+                path,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+    /// macro to stdout.
+    pub fn print_merged_crd(
+        stored_apiversion: Self,
+        operator_version: &str,
+    ) -> Result<(), ::stackable_versioned::Error> {
+        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+        let merged_crd = Self::merged_crd(stored_apiversion)
+            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                source: err,
+            })?;
+        YamlSchema::print_yaml_schema(
+                &merged_crd,
+                operator_version,
+                SerializeOptions::default(),
+            )
+            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                source: err,
+            })
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
@@ -1,0 +1,360 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/k8s/module_preserve.rs
+---
+#[automatically_derived]
+pub(crate) mod versioned {
+    pub mod v1alpha1 {
+        use super::*;
+        #[derive(::kube::CustomResource)]
+        #[kube(
+            group = "foo.example.org",
+            version = "v1alpha1",
+            kind = "Foo",
+            plural = "foos",
+            namespaced
+        )]
+        pub struct FooSpec {
+            pub bar: usize,
+            pub foo: String,
+        }
+        #[derive(::kube::CustomResource)]
+        #[kube(
+            group = "bar.example.org",
+            version = "v1alpha1",
+            kind = "Bar",
+            plural = "bars"
+        )]
+        pub struct BarSpec {
+            pub baz: String,
+        }
+        pub struct Baz {
+            pub boom: Option<u16>,
+        }
+    }
+    impl ::std::convert::From<v1alpha1::FooSpec> for v1::FooSpec {
+        fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
+            Self {
+                bar: __sv_foospec.bar,
+                baz: ::std::default::Default::default(),
+                foo: __sv_foospec.foo,
+            }
+        }
+    }
+    impl ::std::convert::From<v1alpha1::BarSpec> for v1::BarSpec {
+        fn from(__sv_barspec: v1alpha1::BarSpec) -> Self {
+            Self { baz: __sv_barspec.baz }
+        }
+    }
+    impl ::std::convert::From<v1alpha1::Baz> for v1::Baz {
+        fn from(__sv_baz: v1alpha1::Baz) -> Self {
+            Self { boom: __sv_baz.boom }
+        }
+    }
+    pub mod v1 {
+        use super::*;
+        #[derive(::kube::CustomResource)]
+        #[kube(
+            group = "foo.example.org",
+            version = "v1",
+            kind = "Foo",
+            plural = "foos",
+            namespaced
+        )]
+        pub struct FooSpec {
+            pub bar: usize,
+            pub baz: bool,
+            pub foo: String,
+        }
+        #[derive(::kube::CustomResource)]
+        #[kube(group = "bar.example.org", version = "v1", kind = "Bar", plural = "bars")]
+        pub struct BarSpec {
+            pub baz: String,
+        }
+        pub struct Baz {
+            pub boom: Option<u16>,
+        }
+    }
+    #[allow(deprecated)]
+    impl ::std::convert::From<v1::FooSpec> for v2alpha1::FooSpec {
+        fn from(__sv_foospec: v1::FooSpec) -> Self {
+            Self {
+                bar: __sv_foospec.bar,
+                baz: __sv_foospec.baz,
+                deprecated_foo: __sv_foospec.foo,
+            }
+        }
+    }
+    impl ::std::convert::From<v1::BarSpec> for v2alpha1::BarSpec {
+        fn from(__sv_barspec: v1::BarSpec) -> Self {
+            Self { baz: __sv_barspec.baz }
+        }
+    }
+    impl ::std::convert::From<v1::Baz> for v2alpha1::Baz {
+        fn from(__sv_baz: v1::Baz) -> Self {
+            Self { boom: __sv_baz.boom }
+        }
+    }
+    pub mod v2alpha1 {
+        use super::*;
+        #[derive(::kube::CustomResource)]
+        #[kube(
+            group = "foo.example.org",
+            version = "v2alpha1",
+            kind = "Foo",
+            plural = "foos",
+            namespaced
+        )]
+        pub struct FooSpec {
+            pub bar: usize,
+            pub baz: bool,
+            #[deprecated]
+            pub deprecated_foo: String,
+        }
+        #[derive(::kube::CustomResource)]
+        #[kube(
+            group = "bar.example.org",
+            version = "v2alpha1",
+            kind = "Bar",
+            plural = "bars"
+        )]
+        pub struct BarSpec {
+            pub baz: String,
+        }
+        pub struct Baz {
+            pub boom: Option<u16>,
+        }
+    }
+    pub enum Foo {
+        V1Alpha1,
+        V1Alpha1,
+    }
+    impl ::std::fmt::Display for Foo {
+        fn fmt(
+            &self,
+            f: &mut ::std::fmt::Formatter<'_>,
+        ) -> ::std::result::Result<(), ::std::fmt::Error> {
+            match self {
+                Self::V1Alpha1 => f.write_str("v1alpha1"),
+                Self::V1Alpha1 => f.write_str("v1alpha1"),
+            }
+        }
+    }
+    impl Foo {
+        /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+        pub fn merged_crd(
+            stored_apiversion: Self,
+        ) -> ::std::result::Result<
+            ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+            ::kube::core::crd::MergeError,
+        > {
+            ::kube::core::crd::merge_crds(
+                vec![
+                    < v1alpha1::Foo as ::kube::CustomResourceExt > ::crd(), <
+                    v1alpha1::Bar as ::kube::CustomResourceExt > ::crd()
+                ],
+                &stored_apiversion.to_string(),
+            )
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to a file located at `path`.
+        pub fn write_merged_crd<P>(
+            path: P,
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error>
+        where
+            P: AsRef<::std::path::Path>,
+        {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::write_yaml_schema(
+                    &merged_crd,
+                    path,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to stdout.
+        pub fn print_merged_crd(
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error> {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::print_yaml_schema(
+                    &merged_crd,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+    }
+    pub enum Bar {
+        V1,
+        V1,
+    }
+    impl ::std::fmt::Display for Bar {
+        fn fmt(
+            &self,
+            f: &mut ::std::fmt::Formatter<'_>,
+        ) -> ::std::result::Result<(), ::std::fmt::Error> {
+            match self {
+                Self::V1 => f.write_str("v1"),
+                Self::V1 => f.write_str("v1"),
+            }
+        }
+    }
+    impl Bar {
+        /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+        pub fn merged_crd(
+            stored_apiversion: Self,
+        ) -> ::std::result::Result<
+            ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+            ::kube::core::crd::MergeError,
+        > {
+            ::kube::core::crd::merge_crds(
+                vec![
+                    < v1::Foo as ::kube::CustomResourceExt > ::crd(), < v1::Bar as
+                    ::kube::CustomResourceExt > ::crd()
+                ],
+                &stored_apiversion.to_string(),
+            )
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to a file located at `path`.
+        pub fn write_merged_crd<P>(
+            path: P,
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error>
+        where
+            P: AsRef<::std::path::Path>,
+        {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::write_yaml_schema(
+                    &merged_crd,
+                    path,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to stdout.
+        pub fn print_merged_crd(
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error> {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::print_yaml_schema(
+                    &merged_crd,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+    }
+    pub enum Baz {
+        V2Alpha1,
+        V2Alpha1,
+    }
+    impl ::std::fmt::Display for Baz {
+        fn fmt(
+            &self,
+            f: &mut ::std::fmt::Formatter<'_>,
+        ) -> ::std::result::Result<(), ::std::fmt::Error> {
+            match self {
+                Self::V2Alpha1 => f.write_str("v2alpha1"),
+                Self::V2Alpha1 => f.write_str("v2alpha1"),
+            }
+        }
+    }
+    impl Baz {
+        /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+        pub fn merged_crd(
+            stored_apiversion: Self,
+        ) -> ::std::result::Result<
+            ::k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition,
+            ::kube::core::crd::MergeError,
+        > {
+            ::kube::core::crd::merge_crds(
+                vec![
+                    < v2alpha1::Foo as ::kube::CustomResourceExt > ::crd(), <
+                    v2alpha1::Bar as ::kube::CustomResourceExt > ::crd()
+                ],
+                &stored_apiversion.to_string(),
+            )
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to a file located at `path`.
+        pub fn write_merged_crd<P>(
+            path: P,
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error>
+        where
+            P: AsRef<::std::path::Path>,
+        {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::write_yaml_schema(
+                    &merged_crd,
+                    path,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
+        /// macro to stdout.
+        pub fn print_merged_crd(
+            stored_apiversion: Self,
+            operator_version: &str,
+        ) -> Result<(), ::stackable_versioned::Error> {
+            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
+            let merged_crd = Self::merged_crd(stored_apiversion)
+                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
+                    source: err,
+                })?;
+            YamlSchema::print_yaml_schema(
+                    &merged_crd,
+                    operator_version,
+                    SerializeOptions::default(),
+                )
+                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
+                    source: err,
+                })
+        }
+    }
+}

--- a/crates/stackable-versioned-macros/src/codegen/container/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/mod.rs
@@ -85,9 +85,9 @@ impl Container {
     /// Kubernetes custom resources.
     pub(crate) fn generate_kubernetes_merge_crds(
         &self,
-        enum_variant_idents: Vec<IdentString>,
-        enum_variant_strings: Vec<String>,
-        fn_calls: Vec<TokenStream>,
+        enum_variant_idents: &[IdentString],
+        enum_variant_strings: &[String],
+        fn_calls: &[TokenStream],
         is_nested: bool,
     ) -> Option<TokenStream> {
         match self {
@@ -201,9 +201,9 @@ impl StandaloneContainer {
         }
 
         tokens.extend(self.container.generate_kubernetes_merge_crds(
-            kubernetes_enum_variant_idents,
-            kubernetes_enum_variant_strings,
-            kubernetes_merge_crds_fn_calls,
+            &kubernetes_enum_variant_idents,
+            &kubernetes_enum_variant_strings,
+            &kubernetes_merge_crds_fn_calls,
             false,
         ));
 

--- a/crates/stackable-versioned-macros/src/codegen/container/struct.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/struct.rs
@@ -312,9 +312,9 @@ impl Struct {
 
     pub(crate) fn generate_kubernetes_merge_crds(
         &self,
-        enum_variant_idents: Vec<IdentString>,
-        enum_variant_strings: Vec<String>,
-        fn_calls: Vec<TokenStream>,
+        enum_variant_idents: &[IdentString],
+        enum_variant_strings: &[String],
+        fn_calls: &[TokenStream],
         is_nested: bool,
     ) -> Option<TokenStream> {
         if enum_variant_idents.is_empty() {

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -13,7 +13,12 @@ All notable changes to this project will be documented in this file.
 
 - Bump Rust to 1.82.0 ([#891]).
 
+### Fixed
+
+- Correctly emit Kubernetes code when macro is used on modules ([#912]).
+
 [#891]: https://github.com/stackabletech/operator-rs/pull/891
+[#912]: https://github.com/stackabletech/operator-rs/pull/912
 
 ## [0.4.1] - 2024-10-23
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642

Previously, when the attribute macro was used on modules and contained structs used K8s specific features, the accompanying code was not generated. 
