### PR TITLE
feat(stackable-versioned): Support visibility for CRD enum

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/k8s/basic.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/k8s/basic.rs
@@ -13,7 +13,7 @@
 #[derive(
     Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, kube::CustomResource,
 )]
-pub struct FooSpec {
+pub(crate) struct FooSpec {
     #[versioned(
         added(since = "v1beta1"),
         changed(since = "v1", from_name = "bah", from_type = "u16")

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
@@ -4,7 +4,7 @@ expression: formatted
 input_file: crates/stackable-versioned-macros/fixtures/inputs/k8s/basic.rs
 ---
 #[automatically_derived]
-pub mod v1alpha1 {
+pub(crate) mod v1alpha1 {
     use super::*;
     #[derive(
         Clone,
@@ -36,7 +36,7 @@ impl ::std::convert::From<v1alpha1::FooSpec> for v1beta1::FooSpec {
     }
 }
 #[automatically_derived]
-pub mod v1beta1 {
+pub(crate) mod v1beta1 {
     use super::*;
     #[derive(
         Clone,
@@ -69,7 +69,7 @@ impl ::std::convert::From<v1beta1::FooSpec> for v1::FooSpec {
     }
 }
 #[automatically_derived]
-pub mod v1 {
+pub(crate) mod v1 {
     use super::*;
     #[derive(
         Clone,
@@ -93,7 +93,7 @@ pub mod v1 {
     }
 }
 #[automatically_derived]
-pub enum Foo {
+pub(crate) enum Foo {
     V1Alpha1,
     V1Beta1,
     V1,
@@ -113,7 +113,7 @@ impl ::std::fmt::Display for Foo {
 }
 #[automatically_derived]
 impl Foo {
-    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
     pub fn merged_crd(
         stored_apiversion: Self,
     ) -> ::std::result::Result<

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
@@ -116,7 +116,7 @@ impl ::std::fmt::Display for Foo {
 }
 #[automatically_derived]
 impl Foo {
-    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
     pub fn merged_crd(
         stored_apiversion: Self,
     ) -> ::std::result::Result<

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
@@ -206,7 +206,7 @@ pub(crate) mod v2alpha1 {
     }
 }
 #[automatically_derived]
-pub enum Foo {
+pub(crate) enum Foo {
     V1Alpha1,
     V1,
     V2Alpha1,
@@ -226,7 +226,7 @@ impl ::std::fmt::Display for Foo {
 }
 #[automatically_derived]
 impl Foo {
-    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
     pub fn merged_crd(
         stored_apiversion: Self,
     ) -> ::std::result::Result<
@@ -289,7 +289,7 @@ impl Foo {
     }
 }
 #[automatically_derived]
-pub enum Bar {
+pub(crate) enum Bar {
     V1Alpha1,
     V1,
     V2Alpha1,
@@ -309,7 +309,7 @@ impl ::std::fmt::Display for Bar {
 }
 #[automatically_derived]
 impl Bar {
-    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
     pub fn merged_crd(
         stored_apiversion: Self,
     ) -> ::std::result::Result<

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
@@ -214,7 +214,7 @@ pub(crate) mod versioned {
         }
     }
     impl Foo {
-        /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+        /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
         pub fn merged_crd(
             stored_apiversion: Self,
         ) -> ::std::result::Result<
@@ -294,7 +294,7 @@ pub(crate) mod versioned {
         }
     }
     impl Bar {
-        /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+        /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
         pub fn merged_crd(
             stored_apiversion: Self,
         ) -> ::std::result::Result<

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
@@ -113,7 +113,7 @@ impl ::std::fmt::Display for FooBar {
 }
 #[automatically_derived]
 impl FooBar {
-    /// Generates a merged CRD which contains all versions defined using the `#[versioned()]` macro.
+    /// Generates a merged CRD containing all versions and marking `stored_apiversion` as stored.
     pub fn merged_crd(
         stored_apiversion: Self,
     ) -> ::std::result::Result<

--- a/crates/stackable-versioned-macros/src/codegen/container/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/mod.rs
@@ -93,6 +93,7 @@ impl Container {
         enum_variant_idents: &[IdentString],
         enum_variant_strings: &[String],
         fn_calls: &[TokenStream],
+        vis: &Visibility,
         is_nested: bool,
     ) -> Option<TokenStream> {
         match self {
@@ -100,6 +101,7 @@ impl Container {
                 enum_variant_idents,
                 enum_variant_strings,
                 fn_calls,
+                vis,
                 is_nested,
             ),
             Container::Enum(_) => None,
@@ -216,6 +218,7 @@ impl StandaloneContainer {
             &kubernetes_enum_variant_idents,
             &kubernetes_enum_variant_strings,
             &kubernetes_merge_crds_fn_calls,
+            vis,
             false,
         ));
 

--- a/crates/stackable-versioned-macros/src/codegen/module.rs
+++ b/crates/stackable-versioned-macros/src/codegen/module.rs
@@ -137,6 +137,7 @@ impl Module {
                     kubernetes_enum_variant_idents,
                     kubernetes_enum_variant_strings,
                     kubernetes_merge_crds_fn_calls,
+                    version_module_vis,
                     self.preserve_module,
                 ));
             }

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Use visibility of container definition or module for generated CRD enum ([#923]).
 - Add support to apply the `#[versioned()]` macro to modules to version all contained items at
   once ([#891]).
 - Add support for passing a `status`, `crates`, and `shortname` arguments through to the `#[kube]`
@@ -35,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#919]: https://github.com/stackabletech/operator-rs/pull/919
 [#920]: https://github.com/stackabletech/operator-rs/pull/920
 [#922]: https://github.com/stackabletech/operator-rs/pull/922
+[#923]: https://github.com/stackabletech/operator-rs/pull/923
 
 ## [0.4.1] - 2024-10-23
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642

The generated CRD enum now uses the same visibility as the container definition (standalone mode) or the module (nested mode).

### Before

```rust
#[versioned]
pub(crate) struct FooSpec {}

// Expanded to ...

pub enum Foo {}
```

### After

```rust
#[versioned]
pub(crate) struct FooSpec {}

// Expands to ...

pub(crate) enum Foo {}
```