### PR TITLE
chore(stackable-versioned): Remove {write,print}_merged_crd function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,7 +3281,6 @@ version = "0.4.1"
 dependencies = [
  "kube",
  "snafu 0.8.5",
- "stackable-shared",
  "stackable-versioned-macros",
 ]
 
@@ -3306,7 +3305,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu 0.8.5",
- "stackable-shared",
  "stackable-versioned",
  "syn 2.0.89",
  "trybuild",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,7 +3280,6 @@ name = "stackable-versioned"
 version = "0.4.1"
 dependencies = [
  "kube",
- "snafu 0.8.5",
  "stackable-versioned-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,7 +3279,6 @@ dependencies = [
 name = "stackable-versioned"
 version = "0.4.1"
 dependencies = [
- "kube",
  "stackable-versioned-macros",
 ]
 

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -19,17 +19,16 @@ development = ["k8s-openapi", "schemars", "serde_yaml", "stackable-versioned"]
 
 # cargo-udeps throws an error stating that these dependencies are unused. They are all marked as
 # optional, which trips up cargo-udeps for whatever reason...
-normal = ["k8s-openapi", "kube", "stackable-shared"]
+normal = ["k8s-openapi", "kube"]
 
 [lib]
 proc-macro = true
 
 [features]
 full = ["k8s"]
-k8s = ["dep:kube", "dep:k8s-openapi", "dep:stackable-shared"]
+k8s = ["dep:kube", "dep:k8s-openapi"]
 
 [dependencies]
-stackable-shared = { path = "../stackable-shared", optional = true }
 k8s-version = { path = "../k8s-version", features = ["darling"] }
 
 convert_case.workspace = true

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
@@ -129,49 +129,4 @@ impl Foo {
             &stored_apiversion.to_string(),
         )
     }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to a file located at `path`.
-    pub fn write_merged_crd<P>(
-        path: P,
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error>
-    where
-        P: AsRef<::std::path::Path>,
-    {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::write_yaml_schema(
-                &merged_crd,
-                path,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to stdout.
-    pub fn print_merged_crd(
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error> {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::print_yaml_schema(
-                &merged_crd,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
@@ -132,49 +132,4 @@ impl Foo {
             &stored_apiversion.to_string(),
         )
     }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to a file located at `path`.
-    pub fn write_merged_crd<P>(
-        path: P,
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error>
-    where
-        P: AsRef<::std::path::Path>,
-    {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::write_yaml_schema(
-                &merged_crd,
-                path,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to stdout.
-    pub fn print_merged_crd(
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error> {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::print_yaml_schema(
-                &merged_crd,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
@@ -246,51 +246,6 @@ impl Foo {
             &stored_apiversion.to_string(),
         )
     }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to a file located at `path`.
-    pub fn write_merged_crd<P>(
-        path: P,
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error>
-    where
-        P: AsRef<::std::path::Path>,
-    {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::write_yaml_schema(
-                &merged_crd,
-                path,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to stdout.
-    pub fn print_merged_crd(
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error> {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::print_yaml_schema(
-                &merged_crd,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
 }
 #[automatically_derived]
 pub(crate) enum Bar {
@@ -328,50 +283,5 @@ impl Bar {
             ],
             &stored_apiversion.to_string(),
         )
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to a file located at `path`.
-    pub fn write_merged_crd<P>(
-        path: P,
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error>
-    where
-        P: AsRef<::std::path::Path>,
-    {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::write_yaml_schema(
-                &merged_crd,
-                path,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to stdout.
-    pub fn print_merged_crd(
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error> {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::print_yaml_schema(
-                &merged_crd,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
@@ -234,51 +234,6 @@ pub(crate) mod versioned {
                 &stored_apiversion.to_string(),
             )
         }
-        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-        /// macro to a file located at `path`.
-        pub fn write_merged_crd<P>(
-            path: P,
-            stored_apiversion: Self,
-            operator_version: &str,
-        ) -> Result<(), ::stackable_versioned::Error>
-        where
-            P: AsRef<::std::path::Path>,
-        {
-            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-            let merged_crd = Self::merged_crd(stored_apiversion)
-                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                    source: err,
-                })?;
-            YamlSchema::write_yaml_schema(
-                    &merged_crd,
-                    path,
-                    operator_version,
-                    SerializeOptions::default(),
-                )
-                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                    source: err,
-                })
-        }
-        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-        /// macro to stdout.
-        pub fn print_merged_crd(
-            stored_apiversion: Self,
-            operator_version: &str,
-        ) -> Result<(), ::stackable_versioned::Error> {
-            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-            let merged_crd = Self::merged_crd(stored_apiversion)
-                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                    source: err,
-                })?;
-            YamlSchema::print_yaml_schema(
-                    &merged_crd,
-                    operator_version,
-                    SerializeOptions::default(),
-                )
-                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                    source: err,
-                })
-        }
     }
     pub enum Bar {
         V1Alpha1,
@@ -313,51 +268,6 @@ pub(crate) mod versioned {
                 ],
                 &stored_apiversion.to_string(),
             )
-        }
-        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-        /// macro to a file located at `path`.
-        pub fn write_merged_crd<P>(
-            path: P,
-            stored_apiversion: Self,
-            operator_version: &str,
-        ) -> Result<(), ::stackable_versioned::Error>
-        where
-            P: AsRef<::std::path::Path>,
-        {
-            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-            let merged_crd = Self::merged_crd(stored_apiversion)
-                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                    source: err,
-                })?;
-            YamlSchema::write_yaml_schema(
-                    &merged_crd,
-                    path,
-                    operator_version,
-                    SerializeOptions::default(),
-                )
-                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                    source: err,
-                })
-        }
-        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-        /// macro to stdout.
-        pub fn print_merged_crd(
-            stored_apiversion: Self,
-            operator_version: &str,
-        ) -> Result<(), ::stackable_versioned::Error> {
-            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-            let merged_crd = Self::merged_crd(stored_apiversion)
-                .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                    source: err,
-                })?;
-            YamlSchema::print_yaml_schema(
-                    &merged_crd,
-                    operator_version,
-                    SerializeOptions::default(),
-                )
-                .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                    source: err,
-                })
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
@@ -129,49 +129,4 @@ impl FooBar {
             &stored_apiversion.to_string(),
         )
     }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to a file located at `path`.
-    pub fn write_merged_crd<P>(
-        path: P,
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error>
-    where
-        P: AsRef<::std::path::Path>,
-    {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::write_yaml_schema(
-                &merged_crd,
-                path,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
-    /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-    /// macro to stdout.
-    pub fn print_merged_crd(
-        stored_apiversion: Self,
-        operator_version: &str,
-    ) -> Result<(), ::stackable_versioned::Error> {
-        use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-        let merged_crd = Self::merged_crd(stored_apiversion)
-            .map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                source: err,
-            })?;
-        YamlSchema::print_yaml_schema(
-                &merged_crd,
-                operator_version,
-                SerializeOptions::default(),
-            )
-            .map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                source: err,
-            })
-    }
 }

--- a/crates/stackable-versioned-macros/src/codegen/container/struct.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/struct.rs
@@ -348,9 +348,6 @@ impl Struct {
                 let kube_core_path = &*kubernetes_options.crates.kube_core;
 
                 // TODO (@Techassi): Use proper visibility instead of hard-coding 'pub'
-                // TODO (@Techassi): Move the YAML printing code into 'stackable-versioned' so that we don't
-                // have any cross-dependencies and the macro can be used on it's own (K8s features of course
-                // still need kube and friends).
                 Some(quote! {
                     #automatically_derived
                     pub enum #enum_ident {
@@ -373,45 +370,6 @@ impl Struct {
                             stored_apiversion: Self
                         ) -> ::std::result::Result<#k8s_openapi_path::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition, #kube_core_path::crd::MergeError> {
                             #kube_core_path::crd::merge_crds(vec![#(#fn_calls),*], &stored_apiversion.to_string())
-                        }
-
-                        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-                        /// macro to a file located at `path`.
-                        pub fn write_merged_crd<P>(path: P, stored_apiversion: Self, operator_version: &str) -> Result<(), ::stackable_versioned::Error>
-                            where P: AsRef<::std::path::Path>
-                        {
-                            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-
-                            let merged_crd = Self::merged_crd(stored_apiversion).map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                                source: err,
-                            })?;
-
-                            YamlSchema::write_yaml_schema(
-                                &merged_crd,
-                                path,
-                                operator_version,
-                                SerializeOptions::default()
-                            ).map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                                source: err,
-                            })
-                        }
-
-                        /// Generates and writes a merged CRD which contains all versions defined using the `#[versioned()]`
-                        /// macro to stdout.
-                        pub fn print_merged_crd(stored_apiversion: Self, operator_version: &str) -> Result<(), ::stackable_versioned::Error> {
-                            use ::stackable_shared::yaml::{YamlSchema, SerializeOptions};
-
-                            let merged_crd = Self::merged_crd(stored_apiversion).map_err(|err| ::stackable_versioned::Error::MergeCrd {
-                                source: err,
-                            })?;
-
-                            YamlSchema::print_yaml_schema(
-                                &merged_crd,
-                                operator_version,
-                                SerializeOptions::default()
-                            ).map_err(|err| ::stackable_versioned::Error::SerializeYaml {
-                                source: err,
-                            })
                         }
                     }
                 })

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- BREAKING: Remove {write,print}_merged_crd functions ([#924]).
 - BREAKING: Remove the `CustomResource` derive ([#914]).
 
 ### Changed
@@ -35,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#919]: https://github.com/stackabletech/operator-rs/pull/919
 [#920]: https://github.com/stackabletech/operator-rs/pull/920
 [#922]: https://github.com/stackabletech/operator-rs/pull/922
+[#924]: https://github.com/stackabletech/operator-rs/pull/924
 
 ## [0.4.1] - 2024-10-23
 

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -14,14 +14,12 @@ all-features = true
 full = ["k8s"]
 k8s = [
   "stackable-versioned-macros/k8s", # Forward the k8s feature to the underlying macro crate
-  "dep:stackable-shared",
   "dep:snafu",
   "dep:kube",
 ]
 
 [dependencies]
 stackable-versioned-macros = { path = "../stackable-versioned-macros" }
-stackable-shared = { path = "../stackable-shared", optional = true }
 
 kube = { workspace = true, optional = true }
 snafu = { workspace = true, optional = true }

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -14,10 +14,7 @@ all-features = true
 full = ["k8s"]
 k8s = [
   "stackable-versioned-macros/k8s", # Forward the k8s feature to the underlying macro crate
-  "dep:kube",
 ]
 
 [dependencies]
 stackable-versioned-macros = { path = "../stackable-versioned-macros" }
-
-kube = { workspace = true, optional = true }

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -14,7 +14,6 @@ all-features = true
 full = ["k8s"]
 k8s = [
   "stackable-versioned-macros/k8s", # Forward the k8s feature to the underlying macro crate
-  "dep:snafu",
   "dep:kube",
 ]
 
@@ -22,4 +21,3 @@ k8s = [
 stackable-versioned-macros = { path = "../stackable-versioned-macros" }
 
 kube = { workspace = true, optional = true }
-snafu = { workspace = true, optional = true }

--- a/crates/stackable-versioned/src/lib.rs
+++ b/crates/stackable-versioned/src/lib.rs
@@ -15,18 +15,6 @@
 // Re-export macro
 pub use stackable_versioned_macros::*;
 
-#[cfg(feature = "k8s")]
-#[derive(Debug, snafu::Snafu)]
-pub enum Error {
-    #[snafu(display("failed to merge CRDs"))]
-    MergeCrd { source: kube::core::crd::MergeError },
-
-    #[snafu(display("failed to serialize YAML"))]
-    SerializeYaml {
-        source: stackable_shared::yaml::Error,
-    },
-}
-
 // Unused for now, might get picked up again in the future.
 #[doc(hidden)]
 pub trait AsVersionStr {


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642

The dependency on stackable-shared can cause some conflicts in projects which use stackable-versioned. This also de-couples Stackable specific code from the versioning macro, which we want to be usable outside of Stackable as well.

Consumers can still generate the merged CRD and then use functions from the `stackable_shared::CustomResourceExt` trait to print or write the YAML.