### PR TITLE
fix(stackable-versioned): Remove type comparison and use into() on all field conversions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,6 @@ jobs:
   run_tests:
     name: Run Cargo Tests
     needs:
-      - run_cargodeny
       - run_clippy
       - run_rustfmt
       - run_rustdoc

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@basic_struct.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@basic_struct.rs.snap
@@ -19,7 +19,7 @@ impl ::std::convert::From<v1alpha1::Foo> for v1beta1::Foo {
     fn from(__sv_foo: v1alpha1::Foo) -> Self {
         Self {
             bar: __sv_foo.jjj.into(),
-            baz: __sv_foo.baz,
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -37,7 +37,7 @@ impl ::std::convert::From<v1beta1::Foo> for v1::Foo {
     fn from(__sv_foo: v1beta1::Foo) -> Self {
         Self {
             bar: __sv_foo.bar.into(),
-            baz: __sv_foo.baz,
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -55,8 +55,8 @@ pub(crate) mod v1 {
 impl ::std::convert::From<v1::Foo> for v2::Foo {
     fn from(__sv_foo: v1::Foo) -> Self {
         Self {
-            deprecated_bar: __sv_foo.bar,
-            baz: __sv_foo.baz,
+            deprecated_bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -75,8 +75,8 @@ pub(crate) mod v2 {
 impl ::std::convert::From<v2::Foo> for v3::Foo {
     fn from(__sv_foo: v2::Foo) -> Self {
         Self {
-            deprecated_bar: __sv_foo.deprecated_bar,
-            baz: __sv_foo.baz,
+            deprecated_bar: __sv_foo.deprecated_bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@deprecate_struct.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@deprecate_struct.rs.snap
@@ -15,8 +15,8 @@ mod v1alpha1 {
 impl ::std::convert::From<v1alpha1::Foo> for v1beta1::Foo {
     fn from(__sv_foo: v1alpha1::Foo) -> Self {
         Self {
-            bar: __sv_foo.bar,
-            baz: __sv_foo.baz,
+            bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -33,8 +33,8 @@ mod v1beta1 {
 impl ::std::convert::From<v1beta1::Foo> for v1::Foo {
     fn from(__sv_foo: v1beta1::Foo) -> Self {
         Self {
-            deprecated_bar: __sv_foo.bar,
-            baz: __sv_foo.baz,
+            deprecated_bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -52,8 +52,8 @@ mod v1 {
 impl ::std::convert::From<v1::Foo> for v2::Foo {
     fn from(__sv_foo: v1::Foo) -> Self {
         Self {
-            deprecated_bar: __sv_foo.deprecated_bar,
-            baz: __sv_foo.baz,
+            deprecated_bar: __sv_foo.deprecated_bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -71,8 +71,8 @@ mod v2 {
 impl ::std::convert::From<v2::Foo> for v3::Foo {
     fn from(__sv_foo: v2::Foo) -> Self {
         Self {
-            deprecated_bar: __sv_foo.deprecated_bar,
-            baz: __sv_foo.baz,
+            deprecated_bar: __sv_foo.deprecated_bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@module.rs.snap
@@ -18,16 +18,16 @@ pub(crate) mod v1alpha1 {
 impl ::std::convert::From<v1alpha1::Foo> for v1::Foo {
     fn from(__sv_foo: v1alpha1::Foo) -> Self {
         Self {
-            bar: __sv_foo.bar,
+            bar: __sv_foo.bar.into(),
             baz: ::std::default::Default::default(),
-            foo: __sv_foo.foo,
+            foo: __sv_foo.foo.into(),
         }
     }
 }
 #[automatically_derived]
 impl ::std::convert::From<v1alpha1::Bar> for v1::Bar {
     fn from(__sv_bar: v1alpha1::Bar) -> Self {
-        Self { baz: __sv_bar.baz }
+        Self { baz: __sv_bar.baz.into() }
     }
 }
 #[automatically_derived]
@@ -47,16 +47,16 @@ pub(crate) mod v1 {
 impl ::std::convert::From<v1::Foo> for v2alpha1::Foo {
     fn from(__sv_foo: v1::Foo) -> Self {
         Self {
-            bar: __sv_foo.bar,
-            baz: __sv_foo.baz,
-            deprecated_foo: __sv_foo.foo,
+            bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
+            deprecated_foo: __sv_foo.foo.into(),
         }
     }
 }
 #[automatically_derived]
 impl ::std::convert::From<v1::Bar> for v2alpha1::Bar {
     fn from(__sv_bar: v1::Bar) -> Self {
-        Self { baz: __sv_bar.baz }
+        Self { baz: __sv_bar.baz.into() }
     }
 }
 #[automatically_derived]

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@module_preserve.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@module_preserve.rs.snap
@@ -18,15 +18,15 @@ pub(crate) mod versioned {
     impl ::std::convert::From<v1alpha1::Foo> for v1::Foo {
         fn from(__sv_foo: v1alpha1::Foo) -> Self {
             Self {
-                bar: __sv_foo.bar,
+                bar: __sv_foo.bar.into(),
                 baz: ::std::default::Default::default(),
-                foo: __sv_foo.foo,
+                foo: __sv_foo.foo.into(),
             }
         }
     }
     impl ::std::convert::From<v1alpha1::Bar> for v1::Bar {
         fn from(__sv_bar: v1alpha1::Bar) -> Self {
-            Self { baz: __sv_bar.baz }
+            Self { baz: __sv_bar.baz.into() }
         }
     }
     pub mod v1 {
@@ -44,15 +44,15 @@ pub(crate) mod versioned {
     impl ::std::convert::From<v1::Foo> for v2alpha1::Foo {
         fn from(__sv_foo: v1::Foo) -> Self {
             Self {
-                bar: __sv_foo.bar,
-                baz: __sv_foo.baz,
-                deprecated_foo: __sv_foo.foo,
+                bar: __sv_foo.bar.into(),
+                baz: __sv_foo.baz.into(),
+                deprecated_foo: __sv_foo.foo.into(),
             }
         }
     }
     impl ::std::convert::From<v1::Bar> for v2alpha1::Bar {
         fn from(__sv_bar: v1::Bar) -> Self {
-            Self { baz: __sv_bar.baz }
+            Self { baz: __sv_bar.baz.into() }
         }
     }
     pub mod v2alpha1 {

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@rename.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@rename.rs.snap
@@ -15,8 +15,8 @@ mod v1alpha1 {
 impl ::std::convert::From<v1alpha1::Foo> for v1beta1::Foo {
     fn from(__sv_foo: v1alpha1::Foo) -> Self {
         Self {
-            bar: __sv_foo.bat,
-            baz: __sv_foo.baz,
+            bar: __sv_foo.bat.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }
@@ -32,8 +32,8 @@ mod v1beta1 {
 impl ::std::convert::From<v1beta1::Foo> for v1::Foo {
     fn from(__sv_foo: v1beta1::Foo) -> Self {
         Self {
-            bar: __sv_foo.bar,
-            baz: __sv_foo.baz,
+            bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@skip_from_field.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@skip_from_field.rs.snap
@@ -15,7 +15,7 @@ impl ::std::convert::From<v1alpha1::Foo> for v1beta1::Foo {
     fn from(__sv_foo: v1alpha1::Foo) -> Self {
         Self {
             bar: ::std::default::Default::default(),
-            baz: __sv_foo.baz,
+            baz: __sv_foo.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@basic.rs.snap
@@ -31,7 +31,7 @@ impl ::std::convert::From<v1alpha1::FooSpec> for v1beta1::FooSpec {
     fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
         Self {
             bah: ::std::default::Default::default(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }
@@ -64,7 +64,7 @@ impl ::std::convert::From<v1beta1::FooSpec> for v1::FooSpec {
     fn from(__sv_foospec: v1beta1::FooSpec) -> Self {
         Self {
             bar: __sv_foospec.bah.into(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@crate_overrides.rs.snap
@@ -32,7 +32,7 @@ impl ::std::convert::From<v1alpha1::FooSpec> for v1beta1::FooSpec {
     fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
         Self {
             bah: ::std::default::Default::default(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }
@@ -66,7 +66,7 @@ impl ::std::convert::From<v1beta1::FooSpec> for v1::FooSpec {
     fn from(__sv_foospec: v1beta1::FooSpec) -> Self {
         Self {
             bar: __sv_foospec.bah.into(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module.rs.snap
@@ -53,23 +53,25 @@ pub(crate) mod v1alpha1 {
 #[automatically_derived]
 impl ::std::convert::From<v1alpha1::Baz> for v1::Baz {
     fn from(__sv_baz: v1alpha1::Baz) -> Self {
-        Self { boom: __sv_baz.boom }
+        Self { boom: __sv_baz.boom.into() }
     }
 }
 #[automatically_derived]
 impl ::std::convert::From<v1alpha1::FooSpec> for v1::FooSpec {
     fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
         Self {
-            bar: __sv_foospec.bar,
+            bar: __sv_foospec.bar.into(),
             baz: ::std::default::Default::default(),
-            foo: __sv_foospec.foo,
+            foo: __sv_foospec.foo.into(),
         }
     }
 }
 #[automatically_derived]
 impl ::std::convert::From<v1alpha1::BarSpec> for v1::BarSpec {
     fn from(__sv_barspec: v1alpha1::BarSpec) -> Self {
-        Self { baz: __sv_barspec.baz }
+        Self {
+            baz: __sv_barspec.baz.into(),
+        }
     }
 }
 #[automatically_derived]
@@ -127,7 +129,7 @@ pub(crate) mod v1 {
 #[automatically_derived]
 impl ::std::convert::From<v1::Baz> for v2alpha1::Baz {
     fn from(__sv_baz: v1::Baz) -> Self {
-        Self { boom: __sv_baz.boom }
+        Self { boom: __sv_baz.boom.into() }
     }
 }
 #[automatically_derived]
@@ -135,16 +137,18 @@ impl ::std::convert::From<v1::Baz> for v2alpha1::Baz {
 impl ::std::convert::From<v1::FooSpec> for v2alpha1::FooSpec {
     fn from(__sv_foospec: v1::FooSpec) -> Self {
         Self {
-            bar: __sv_foospec.bar,
-            baz: __sv_foospec.baz,
-            deprecated_foo: __sv_foospec.foo,
+            bar: __sv_foospec.bar.into(),
+            baz: __sv_foospec.baz.into(),
+            deprecated_foo: __sv_foospec.foo.into(),
         }
     }
 }
 #[automatically_derived]
 impl ::std::convert::From<v1::BarSpec> for v2alpha1::BarSpec {
     fn from(__sv_barspec: v1::BarSpec) -> Self {
-        Self { baz: __sv_barspec.baz }
+        Self {
+            baz: __sv_barspec.baz.into(),
+        }
     }
 }
 #[automatically_derived]

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@module_preserve.rs.snap
@@ -53,21 +53,23 @@ pub(crate) mod versioned {
     }
     impl ::std::convert::From<v1alpha1::Baz> for v1::Baz {
         fn from(__sv_baz: v1alpha1::Baz) -> Self {
-            Self { boom: __sv_baz.boom }
+            Self { boom: __sv_baz.boom.into() }
         }
     }
     impl ::std::convert::From<v1alpha1::FooSpec> for v1::FooSpec {
         fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
             Self {
-                bar: __sv_foospec.bar,
+                bar: __sv_foospec.bar.into(),
                 baz: ::std::default::Default::default(),
-                foo: __sv_foospec.foo,
+                foo: __sv_foospec.foo.into(),
             }
         }
     }
     impl ::std::convert::From<v1alpha1::BarSpec> for v1::BarSpec {
         fn from(__sv_barspec: v1alpha1::BarSpec) -> Self {
-            Self { baz: __sv_barspec.baz }
+            Self {
+                baz: __sv_barspec.baz.into(),
+            }
         }
     }
     impl ::std::convert::From<v1alpha1::Boom> for v1::Boom {
@@ -122,22 +124,24 @@ pub(crate) mod versioned {
     }
     impl ::std::convert::From<v1::Baz> for v2alpha1::Baz {
         fn from(__sv_baz: v1::Baz) -> Self {
-            Self { boom: __sv_baz.boom }
+            Self { boom: __sv_baz.boom.into() }
         }
     }
     #[allow(deprecated)]
     impl ::std::convert::From<v1::FooSpec> for v2alpha1::FooSpec {
         fn from(__sv_foospec: v1::FooSpec) -> Self {
             Self {
-                bar: __sv_foospec.bar,
-                baz: __sv_foospec.baz,
-                deprecated_foo: __sv_foospec.foo,
+                bar: __sv_foospec.bar.into(),
+                baz: __sv_foospec.baz.into(),
+                deprecated_foo: __sv_foospec.foo.into(),
             }
         }
     }
     impl ::std::convert::From<v1::BarSpec> for v2alpha1::BarSpec {
         fn from(__sv_barspec: v1::BarSpec) -> Self {
-            Self { baz: __sv_barspec.baz }
+            Self {
+                baz: __sv_barspec.baz.into(),
+            }
         }
     }
     impl ::std::convert::From<v1::Boom> for v2alpha1::Boom {

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@renamed_kind.rs.snap
@@ -31,7 +31,7 @@ impl ::std::convert::From<v1alpha1::FooSpec> for v1beta1::FooSpec {
     fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
         Self {
             bah: ::std::default::Default::default(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }
@@ -64,7 +64,7 @@ impl ::std::convert::From<v1beta1::FooSpec> for v1::FooSpec {
     fn from(__sv_foospec: v1beta1::FooSpec) -> Self {
         Self {
             bar: __sv_foospec.bah.into(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@skip.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__k8s_snapshots@skip.rs.snap
@@ -31,7 +31,7 @@ impl ::std::convert::From<v1alpha1::FooSpec> for v1beta1::FooSpec {
     fn from(__sv_foospec: v1alpha1::FooSpec) -> Self {
         Self {
             bah: ::std::default::Default::default(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }
@@ -64,7 +64,7 @@ impl ::std::convert::From<v1beta1::FooSpec> for v1::FooSpec {
     fn from(__sv_foospec: v1beta1::FooSpec) -> Self {
         Self {
             bar: __sv_foospec.bah.into(),
-            baz: __sv_foospec.baz,
+            baz: __sv_foospec.baz.into(),
         }
     }
 }

--- a/crates/stackable-versioned-macros/src/codegen/item/field.rs
+++ b/crates/stackable-versioned-macros/src/codegen/item/field.rs
@@ -168,18 +168,11 @@ impl VersionedField {
                         ItemStatus::Change {
                             from_ident: old_field_ident,
                             to_ident,
-                            from_type,
-                            to_type,
+                            ..
                         },
                     ) => {
-                        if from_type == to_type {
-                            quote! {
-                                #to_ident: #from_struct_ident.#old_field_ident,
-                            }
-                        } else {
-                            quote! {
-                                #to_ident: #from_struct_ident.#old_field_ident.into(),
-                            }
+                        quote! {
+                            #to_ident: #from_struct_ident.#old_field_ident.into(),
                         }
                     }
                     (old, next) => {
@@ -187,7 +180,7 @@ impl VersionedField {
                         let old_field_ident = old.get_ident();
 
                         quote! {
-                            #next_field_ident: #from_struct_ident.#old_field_ident,
+                            #next_field_ident: #from_struct_ident.#old_field_ident.into(),
                         }
                     }
                 }
@@ -196,7 +189,7 @@ impl VersionedField {
                 let field_ident = &*self.ident;
 
                 quote! {
-                    #field_ident: #from_struct_ident.#field_ident,
+                    #field_ident: #from_struct_ident.#field_ident.into(),
                 }
             }
         }

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 - Emit correct enum ident based on kube/k8s kind argument ([#920]).
 - Generate Kubernetes code independent of container order ([#913]).
 - Correctly emit Kubernetes code when macro is used on modules ([#912]).
+- Remove type comparison and use into() on all field conversions ([#925]).
+  Type semantics are not known, so the comparison was invalid.
 
 [#891]: https://github.com/stackabletech/operator-rs/pull/891
 [#912]: https://github.com/stackabletech/operator-rs/pull/912
@@ -37,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#920]: https://github.com/stackabletech/operator-rs/pull/920
 [#922]: https://github.com/stackabletech/operator-rs/pull/922
 [#923]: https://github.com/stackabletech/operator-rs/pull/923
+[#925]: https://github.com/stackabletech/operator-rs/pull/925
 
 ## [0.4.1] - 2024-10-23
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -28,8 +28,8 @@ All notable changes to this project will be documented in this file.
 - Emit correct enum ident based on kube/k8s kind argument ([#920]).
 - Generate Kubernetes code independent of container order ([#913]).
 - Correctly emit Kubernetes code when macro is used on modules ([#912]).
-- Remove type comparison and use into() on all field conversions ([#925]).
-  Type semantics are not known, so the comparison was invalid.
+- Use `.into()` on all field conversions ([#925]).
+- Remove invalid type comparison on field conversion because the semantics are unknown ([#925]).
 
 [#891]: https://github.com/stackabletech/operator-rs/pull/891
 [#912]: https://github.com/stackabletech/operator-rs/pull/912


### PR DESCRIPTION
Remove type comparison and use `.into()` on all field conversions

> [!NOTE]
> The from/to type comparison was semantically invalid as we have no information of the actual type which might still be an equivalent string (eg: `::foo::TypeA` in two versions of a crate are possibly not equivalent).

---

> [!IMPORTANT]
> **CI**: The run_tests dependency on the run_cargodeny job has been removed.