### PR TITLE
chore: Release stackable-operator-0.83.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.82.0"
+version = "0.83.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.83.0] - 2024-12-03
+
 ### Added
 
 - Added cert lifetime setter to `SecretOperatorVolumeSourceBuilder` ([#915])

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.82.0"
+version = "0.83.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This release contains:

### Added

- Added cert lifetime setter to `SecretOperatorVolumeSourceBuilder` ([#915])

### Changed

- Replace unmaintained `derivative` crate with `educe` ([#907]).
- Bump dependencies, notably rustls 0.23.15 to 0.23.19 to fix [RUSTSEC-2024-0399] ([#917]).

[#907]: https://github.com/stackabletech/operator-rs/pull/907
[#915]: https://github.com/stackabletech/operator-rs/pull/915
[#917]: https://github.com/stackabletech/operator-rs/pull/917
[RUSTSEC-2024-0399]: https://rustsec.org/advisories/RUSTSEC-2024-0399