### PR TITLE
feat(stackable-telemetry): Add tuple to settings conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,6 +3271,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "pin-project",
+ "rstest",
  "snafu 0.8.5",
  "stackable-webhook",
  "tokio",

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [dev-dependencies]
 tokio.workspace = true
 tracing-opentelemetry.workspace = true
+rstest.workspace = true
 stackable-webhook = { path = "../stackable-webhook" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -44,7 +44,7 @@ pub enum Error {
 ///
 /// # Usage:
 /// ```
-/// use stackable_telemetry::tracing::{Tracing, Error, settings::{Build as _, Settings}};
+/// use stackable_telemetry::tracing::{Tracing, Error, settings::Settings};
 /// use tracing_subscriber::filter::LevelFilter;
 ///
 /// #[tokio::main]

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -68,7 +68,8 @@ pub enum Error {
 ///         .build()                            // |
 ///         .init()?;                           // |
 ///                                             // |
-///     tracing::info!("log a message");        // < Scope ends here, guard is dropped
+///     tracing::info!("log a message");        // |
+///     Ok(())                                  // < Scope ends here, guard is dropped
 /// }
 /// ```
 ///

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -18,7 +18,7 @@ use snafu::{ResultExt as _, Snafu};
 use tracing::subscriber::SetGlobalDefaultError;
 use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Layer, Registry};
 
-use settings::{ConsoleLogSettings, OtlpLogSettings, OtlpTraceSettings};
+use settings::*;
 
 pub mod settings;
 
@@ -45,9 +45,8 @@ pub enum Error {
 /// # Usage
 ///
 /// There are two different styles to configure individual subscribers: Using the sophisticated
-/// [`SettingsBuilder`][settings::SettingsBuilder] or the simplified tuple style for basic
-/// configuration. Currently, three different subscribers are supported: console output, OTLP log
-/// export, and OTLP trace export.
+/// [`SettingsBuilder`] or the simplified tuple style for basic configuration. Currently, three
+/// different subscribers are supported: console output, OTLP log export, and OTLP trace export.
 ///
 /// The subscribers are active as long as the tracing guard returned by [`Tracing::init`] is in
 /// scope and not dropped. Dropping it results in subscribers being shut down, which can lead to
@@ -104,6 +103,14 @@ pub enum Error {
 /// ```
 ///
 /// ## Advanced configuration
+///
+/// More advanced configurations can be done via the [`Settings::builder`] function. Each
+/// subscriber provides specific settings based on a common set of options. These options can be
+/// customized via the following methods:
+///
+/// - [`SettingsBuilder::console_log_settings_builder`]
+/// - [`SettingsBuilder::otlp_log_settings_builder`]
+/// - [`SettingsBuilder::otlp_trace_settings_builder`]
 ///
 /// ```
 /// # use stackable_telemetry::tracing::{Tracing, Error, settings::Settings};
@@ -220,8 +227,10 @@ impl Tracing {
     /// Initialise the configured tracing subscribers, returning a guard that
     /// will shutdown the subscribers when dropped.
     ///
-    /// IMPORTANT: Name the guard variable appropriately, do not just use
-    /// `let _ =`, as that will drop immediately.
+    /// <div class="warning">
+    /// Name the guard variable appropriately, do not just use <code>let _ =</code>, as that will drop
+    /// immediately.
+    /// </div>
     pub fn init(mut self) -> Result<Tracing> {
         let mut layers: Vec<Box<dyn Layer<Registry> + Sync + Send>> = Vec::new();
 

--- a/crates/stackable-telemetry/src/tracing/settings/console_log.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/console_log.rs
@@ -2,7 +2,9 @@
 
 use std::ops::Deref;
 
-use super::{Build, Settings, SettingsBuilder};
+use tracing::level_filters::LevelFilter;
+
+use super::{Settings, SettingsBuilder};
 
 /// Configure specific settings for the Console Log subscriber.
 #[derive(Debug, Default, PartialEq)]
@@ -74,12 +76,36 @@ impl From<SettingsBuilder> for ConsoleLogSettingsBuilder {
     }
 }
 
-/// This implementation is used to build console log settings from common settings without
-/// specifying console log specific settings.
-impl Build<ConsoleLogSettings> for SettingsBuilder {
-    fn build(self) -> ConsoleLogSettings {
+impl From<Settings> for ConsoleLogSettings {
+    fn from(common_settings: Settings) -> Self {
         ConsoleLogSettings {
-            common_settings: self.build(),
+            common_settings,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<(&'static str, LevelFilter)> for ConsoleLogSettings {
+    fn from(value: (&'static str, LevelFilter)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: true,
+            },
+            ..Default::default()
+        }
+    }
+}
+
+impl From<(&'static str, LevelFilter, bool)> for ConsoleLogSettings {
+    fn from(value: (&'static str, LevelFilter, bool)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: value.2,
+            },
             ..Default::default()
         }
     }

--- a/crates/stackable-telemetry/src/tracing/settings/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/mod.rs
@@ -51,22 +51,6 @@ pub struct SettingsBuilder {
     default_level: LevelFilter,
 }
 
-/// Finalizer to be implemented on builders.
-pub trait Build<T> {
-    /// Finalize settings.
-    fn build(self) -> T;
-}
-
-impl Build<Settings> for SettingsBuilder {
-    fn build(self) -> Settings {
-        Settings {
-            environment_variable: self.environment_variable,
-            default_level: self.default_level,
-            enabled: self.enabled,
-        }
-    }
-}
-
 impl SettingsBuilder {
     /// Set the environment variable used for overriding the [`Settings::default_level`].
     ///
@@ -113,6 +97,15 @@ impl SettingsBuilder {
     /// Set specific [`OtlpTraceSettings`].
     pub fn otlp_trace_settings_builder(self) -> OtlpTraceSettingsBuilder {
         self.into()
+    }
+
+    /// Consumes self and constructs valid [`Settings`].
+    pub fn build(self) -> Settings {
+        Settings {
+            environment_variable: self.environment_variable,
+            default_level: self.default_level,
+            enabled: self.enabled,
+        }
     }
 }
 

--- a/crates/stackable-telemetry/src/tracing/settings/otlp_log.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/otlp_log.rs
@@ -2,7 +2,9 @@
 
 use std::ops::Deref;
 
-use super::{Build, Settings, SettingsBuilder};
+use tracing::level_filters::LevelFilter;
+
+use super::{Settings, SettingsBuilder};
 
 #[derive(Debug, Default, PartialEq)]
 pub struct OtlpLogSettings {
@@ -39,13 +41,32 @@ impl From<SettingsBuilder> for OtlpLogSettingsBuilder {
     }
 }
 
-/// This implementation is used to build OTLP log settings from common settings without
-/// specifying OTLP log specific settings.
-impl Build<OtlpLogSettings> for SettingsBuilder {
-    fn build(self) -> OtlpLogSettings {
-        OtlpLogSettings {
-            common_settings: self.build(),
-            // ..Default::default()
+impl From<Settings> for OtlpLogSettings {
+    fn from(common_settings: Settings) -> Self {
+        Self { common_settings }
+    }
+}
+
+impl From<(&'static str, LevelFilter)> for OtlpLogSettings {
+    fn from(value: (&'static str, LevelFilter)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: true,
+            },
+        }
+    }
+}
+
+impl From<(&'static str, LevelFilter, bool)> for OtlpLogSettings {
+    fn from(value: (&'static str, LevelFilter, bool)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: value.2,
+            },
         }
     }
 }

--- a/crates/stackable-telemetry/src/tracing/settings/otlp_trace.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/otlp_trace.rs
@@ -2,7 +2,9 @@
 
 use std::ops::Deref;
 
-use super::{Build, Settings, SettingsBuilder};
+use tracing::level_filters::LevelFilter;
+
+use super::{Settings, SettingsBuilder};
 
 #[derive(Debug, Default, PartialEq)]
 pub struct OtlpTraceSettings {
@@ -39,13 +41,32 @@ impl From<SettingsBuilder> for OtlpTraceSettingsBuilder {
     }
 }
 
-/// This implementation is used to build OTLP trace settings from common settings without
-/// specifying OTLP trace specific settings.
-impl Build<OtlpTraceSettings> for SettingsBuilder {
-    fn build(self) -> OtlpTraceSettings {
-        OtlpTraceSettings {
-            common_settings: self.build(),
-            // ..Default::default()
+impl From<Settings> for OtlpTraceSettings {
+    fn from(common_settings: Settings) -> Self {
+        Self { common_settings }
+    }
+}
+
+impl From<(&'static str, LevelFilter)> for OtlpTraceSettings {
+    fn from(value: (&'static str, LevelFilter)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: true,
+            },
+        }
+    }
+}
+
+impl From<(&'static str, LevelFilter, bool)> for OtlpTraceSettings {
+    fn from(value: (&'static str, LevelFilter, bool)) -> Self {
+        Self {
+            common_settings: Settings {
+                environment_variable: value.0,
+                default_level: value.1,
+                enabled: value.2,
+            },
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/639

This adds conversions to turn `(&'static str, LevelFilter)` and `(&'static str, LevelFilter, bool)` into subscriber settings.