### PR TITLE
fix: Revert default cluster domain to 'cluster.local'

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Remove `Merge` trait bound from `erase` and make `product_specific_common_config` public ([#946]).
+- BREAKING: Revert the change of appending a dot to the default cluster domain to make it a FQDN, it is now `cluster.local` again. Users can instead explicitly opt-in to FQDNs via the ENV variable `KUBERNETES_CLUSTER_DOMAIN`. ([#947]).
 
 [#946]: https://github.com/stackabletech/operator-rs/pull/946
+[#947]: https://github.com/stackabletech/operator-rs/pull/947
 
 ## [0.84.0] - 2025-01-16
 

--- a/crates/stackable-operator/src/utils/cluster_info.rs
+++ b/crates/stackable-operator/src/utils/cluster_info.rs
@@ -2,18 +2,18 @@ use std::str::FromStr;
 
 use crate::commons::networking::DomainName;
 
-const KUBERNETES_CLUSTER_DOMAIN_DEFAULT: &str = "cluster.local.";
+const KUBERNETES_CLUSTER_DOMAIN_DEFAULT: &str = "cluster.local";
 
 /// Some information that we know about the Kubernetes cluster.
 #[derive(Debug, Clone)]
 pub struct KubernetesClusterInfo {
-    /// The Kubernetes cluster domain, typically `cluster.local.`.
+    /// The Kubernetes cluster domain, typically `cluster.local`.
     pub cluster_domain: DomainName,
 }
 
 #[derive(clap::Parser, Debug, Default, PartialEq, Eq)]
 pub struct KubernetesClusterInfoOpts {
-    /// Kubernetes cluster domain, usually this is `cluster.local.`.
+    /// Kubernetes cluster domain, usually this is `cluster.local`.
     ///
     /// Please note that we recommend adding a trailing dot (".") to reduce DNS requests, see
     /// <https://github.com/stackabletech/issues/issues/656> for details.


### PR DESCRIPTION
# Description

Revert the change of the default cluster domain introduced by https://github.com/stackabletech/operator-rs/pull/939.

Reasoning: We came across some issues with TLS certificates and Kerberos keytabs and decided to make this behavior (FQDN domains for services/pods) opt-in for now. We still wanted to keep experimental support for it, but only if a user opts in by explicitly setting `KUBERNETES_CLUSTER_DOMAIN` to a domain with a trailing dot.

I tested this change with Zookeeper, both with and without `KUBERNETES_CLUSTER_DOMAIN` set, works as expected.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
