### PR TITLE
chore: Release stackable-operator 0.84.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.85.0"
+version = "0.84.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.85.0] - 2025-01-22
+## [0.84.1] - 2025-01-22
 
 ### Fixed
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.85.0] - 2025-01-22
+
 ### Fixed
 
 - Remove `Merge` trait bound from `erase` and make `product_specific_common_config` public ([#946]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.85.0"
+version = "0.84.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.84.0"
+version = "0.85.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases `stackbale-operator` 0.84.1 which includes:

### Fixed

- Remove `Merge` trait bound from `erase` and make `product_specific_common_config` public ([#946]).
- BREAKING: Revert the change of appending a dot to the default cluster domain to make it a FQDN, it is now `cluster.local` again. Users can instead explicitly opt-in to FQDNs via the ENV variable `KUBERNETES_CLUSTER_DOMAIN`. ([#947]).

[#946]: https://github.com/stackabletech/operator-rs/pull/946
[#947]: https://github.com/stackabletech/operator-rs/pull/947