### PR TITLE
chore: Release stackable-operator 0.85.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.84.1"
+version = "0.85.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.85.0] - 2025-01-28
+
 ### Changed
 
 - Change constant used for product image selection so that it defaults to OCI ([#945]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.84.1"
+version = "0.85.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackbale-operator 0.85.0 which includes:

### Changed

- Change constant used for product image selection so that it defaults to OCI ([#945](https://github.com/stackabletech/operator-rs/pull/945))