### PR TITLE
ci: Publish crate docs on Github Pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,6 +5,10 @@ name: Publish Crate Docs
 # changed.
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/publish-docs.yml
+      - crates/**
   push:
     branches:
       - main

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,52 @@
+---
+name: Publish Crate Docs
+
+# Once the `preview` input is available, this can also run on PR when docs are
+# changed.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/publish-docs.yml
+      - crates/**
+
+env:
+  RUST_TOOLCHAIN_VERSION: "1.82.0"
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+
+      - name: Build Crate Docs
+        run: cargo doc --no-deps --all-features
+
+      - name: Add Redirect
+        run: echo '<meta http-equiv="refresh" content="0;url=stackable_operator/index.html">' > target/doc/index.html
+
+      - name: Upload Documentation Artifacts
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
+        with:
+          path: target/doc
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to Github Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,10 +5,6 @@ name: Publish Crate Docs
 # changed.
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/publish-docs.yml
-      - crates/**
   push:
     branches:
       - main


### PR DESCRIPTION
This PR adds a new workflow which will build the crate docs and publishes them on Github Pages. The workflow only runs when changes are pushed/merged to/into main.