### PR TITLE
chore: Add rustfmt config

### DIFF
--- a/.github/workflows/pr_pre-commit.yaml
+++ b/.github/workflows/pr_pre-commit.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN_VERSION: "1.82.0"
+  RUST_TOOLCHAIN_VERSION: "nightly-2025-01-15"
   HADOLINT_VERSION: "v1.17.6"
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
       - id: rustfmt
         name: rustfmt
         language: system
+        # Pinning to a specific rustc version, so that we get consistent formatting
         entry: cargo +nightly-2025-01-15 fmt --all -- --check
         stages: [pre-commit]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
     hooks:
-      - id: fmt
-        args: ["--all", "--", "--check"]
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]
   - repo: https://github.com/adrienverge/yamllint
@@ -52,4 +50,11 @@ repos:
         language: system
         entry: .scripts/verify_crate_versions.sh
         stages: [pre-commit, pre-merge-commit, manual]
+        pass_filenames: false
+
+      - id: rustfmt
+        name: rustfmt
+        language: system
+        entry: cargo +nightly-2025-01-15 fmt --all -- --check
+        stages: [pre-commit]
         pass_filenames: false

--- a/crates/k8s-version/src/api_version.rs
+++ b/crates/k8s-version/src/api_version.rs
@@ -1,9 +1,8 @@
 use std::{cmp::Ordering, fmt::Display, str::FromStr};
 
-use snafu::{ResultExt, Snafu};
-
 #[cfg(feature = "darling")]
 use darling::FromMeta;
+use snafu::{ResultExt, Snafu};
 
 use crate::{Group, ParseGroupError, ParseVersionError, Version};
 
@@ -102,13 +101,12 @@ impl ApiVersion {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::Level;
-
-    use rstest::rstest;
-
     #[cfg(feature = "darling")]
     use quote::quote;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::Level;
 
     #[cfg(feature = "darling")]
     fn parse_meta(tokens: proc_macro2::TokenStream) -> ::std::result::Result<syn::Meta, String> {

--- a/crates/k8s-version/src/level.rs
+++ b/crates/k8s-version/src/level.rs
@@ -7,11 +7,10 @@ use std::{
     sync::LazyLock,
 };
 
-use regex::Regex;
-use snafu::{OptionExt, ResultExt, Snafu};
-
 #[cfg(feature = "darling")]
 use darling::FromMeta;
+use regex::Regex;
+use snafu::{OptionExt, ResultExt, Snafu};
 
 static LEVEL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?P<identifier>[a-z]+)(?P<version>\d+)$").expect("failed to compile level regex")
@@ -158,13 +157,12 @@ impl FromMeta for Level {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "darling")]
+    use quote::quote;
     use rstest::rstest;
     use rstest_reuse::*;
 
     use super::*;
-
-    #[cfg(feature = "darling")]
-    use quote::quote;
 
     #[cfg(feature = "darling")]
     fn parse_meta(tokens: proc_macro2::TokenStream) -> ::std::result::Result<syn::Meta, String> {

--- a/crates/k8s-version/src/version.rs
+++ b/crates/k8s-version/src/version.rs
@@ -1,10 +1,9 @@
 use std::{cmp::Ordering, fmt::Display, num::ParseIntError, str::FromStr, sync::LazyLock};
 
-use regex::Regex;
-use snafu::{OptionExt, ResultExt, Snafu};
-
 #[cfg(feature = "darling")]
 use darling::FromMeta;
+use regex::Regex;
+use snafu::{OptionExt, ResultExt, Snafu};
 
 use crate::{Level, ParseLevelError};
 
@@ -117,13 +116,12 @@ impl Version {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "darling")]
+    use quote::quote;
     use rstest::rstest;
     use rstest_reuse::{apply, template};
 
     use super::*;
-
-    #[cfg(feature = "darling")]
-    use quote::quote;
 
     #[cfg(feature = "darling")]
     fn parse_meta(tokens: proc_macro2::TokenStream) -> ::std::result::Result<syn::Meta, String> {

--- a/crates/stackable-certs/src/keys/ecdsa.rs
+++ b/crates/stackable-certs/src/keys/ecdsa.rs
@@ -40,11 +40,10 @@ impl SigningKey {
 }
 
 impl CertificateKeypair for SigningKey {
-    type SigningKey = p256::ecdsa::SigningKey;
-    type Signature = ecdsa::der::Signature<NistP256>;
-    type VerifyingKey = p256::ecdsa::VerifyingKey;
-
     type Error = Error;
+    type Signature = ecdsa::der::Signature<NistP256>;
+    type SigningKey = p256::ecdsa::SigningKey;
+    type VerifyingKey = p256::ecdsa::VerifyingKey;
 
     fn signing_key(&self) -> &Self::SigningKey {
         &self.0

--- a/crates/stackable-certs/src/keys/rsa.rs
+++ b/crates/stackable-certs/src/keys/rsa.rs
@@ -60,10 +60,10 @@ impl SigningKey {
 }
 
 impl CertificateKeypair for SigningKey {
-    type SigningKey = rsa::pkcs1v15::SigningKey<sha2::Sha256>;
-    type Signature = rsa::pkcs1v15::Signature;
-    type VerifyingKey = rsa::pkcs1v15::VerifyingKey<sha2::Sha256>;
     type Error = Error;
+    type Signature = rsa::pkcs1v15::Signature;
+    type SigningKey = rsa::pkcs1v15::SigningKey<sha2::Sha256>;
+    type VerifyingKey = rsa::pkcs1v15::VerifyingKey<sha2::Sha256>;
 
     fn signing_key(&self) -> &Self::SigningKey {
         &self.0

--- a/crates/stackable-certs/src/lib.rs
+++ b/crates/stackable-certs/src/lib.rs
@@ -21,6 +21,8 @@
 #[cfg(feature = "rustls")]
 use std::ops::Deref;
 
+use snafu::Snafu;
+use x509_cert::{spki::EncodePublicKey, Certificate};
 #[cfg(feature = "rustls")]
 use {
     p256::pkcs8::EncodePrivateKey,
@@ -28,9 +30,6 @@ use {
     tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     x509_cert::der::Encode,
 };
-
-use snafu::Snafu;
-use x509_cert::{spki::EncodePublicKey, Certificate};
 
 use crate::keys::CertificateKeypair;
 

--- a/crates/stackable-operator/src/builder/configmap.rs
+++ b/crates/stackable-operator/src/builder/configmap.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeMap;
+
 use k8s_openapi::{api::core::v1::ConfigMap, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use snafu::{OptionExt, Snafu};
-use std::collections::BTreeMap;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -64,9 +65,9 @@ impl ConfigMapBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::{configmap::ConfigMapBuilder, meta::ObjectMetaBuilder};
-
     use std::collections::BTreeMap;
+
+    use crate::builder::{configmap::ConfigMapBuilder, meta::ObjectMetaBuilder};
 
     #[test]
     fn configmap_builder() {

--- a/crates/stackable-operator/src/builder/meta.rs
+++ b/crates/stackable-operator/src/builder/meta.rs
@@ -311,9 +311,10 @@ impl OwnerReferenceBuilder {
 
 #[cfg(test)]
 mod tests {
+    use k8s_openapi::api::core::v1::Pod;
+
     use super::*;
     use crate::builder::meta::ObjectMetaBuilder;
-    use k8s_openapi::api::core::v1::Pod;
 
     #[test]
     fn objectmeta_builder() {

--- a/crates/stackable-operator/src/builder/pdb.rs
+++ b/crates/stackable-operator/src/builder/pdb.rs
@@ -209,9 +209,8 @@ mod tests {
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
+    use super::*;
     use crate::builder::meta::{ObjectMetaBuilder, OwnerReferenceBuilder};
-
-    use super::PodDisruptionBudgetBuilder;
 
     #[test]
     pub fn normal_build() {

--- a/crates/stackable-operator/src/builder/pod/container.rs
+++ b/crates/stackable-operator/src/builder/pod/container.rs
@@ -1,8 +1,5 @@
 use std::fmt;
 
-#[cfg(doc)]
-use {k8s_openapi::api::core::v1::PodSpec, std::collections::BTreeMap};
-
 use indexmap::IndexMap;
 use k8s_openapi::api::core::v1::{
     ConfigMapKeySelector, Container, ContainerPort, EnvVar, EnvVarSource, Lifecycle,
@@ -11,6 +8,8 @@ use k8s_openapi::api::core::v1::{
 };
 use snafu::{ResultExt as _, Snafu};
 use tracing::instrument;
+#[cfg(doc)]
+use {k8s_openapi::api::core::v1::PodSpec, std::collections::BTreeMap};
 
 use crate::{
     commons::product_image_selection::ResolvedProductImage,

--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -12,9 +12,11 @@ use k8s_openapi::{
 use snafu::{OptionExt, ResultExt, Snafu};
 use tracing::{instrument, warn};
 
-use crate::kvp::Labels;
 use crate::{
-    builder::meta::ObjectMetaBuilder,
+    builder::{
+        meta::ObjectMetaBuilder,
+        pod::volume::{ListenerOperatorVolumeSourceBuilder, ListenerReference, VolumeBuilder},
+    },
     commons::{
         affinity::StackableAffinity,
         product_image_selection::ResolvedProductImage,
@@ -23,10 +25,9 @@ use crate::{
             LIMIT_REQUEST_RATIO_CPU, LIMIT_REQUEST_RATIO_MEMORY,
         },
     },
+    kvp::Labels,
     time::Duration,
 };
-
-use self::volume::{ListenerOperatorVolumeSourceBuilder, ListenerReference, VolumeBuilder};
 
 pub mod container;
 pub mod resources;
@@ -633,6 +634,7 @@ mod tests {
     };
     use rstest::*;
 
+    use super::*;
     use crate::builder::{
         meta::ObjectMetaBuilder,
         pod::{
@@ -640,8 +642,6 @@ mod tests {
             volume::VolumeBuilder,
         },
     };
-
-    use super::*;
 
     // A simple [`Container`] with a name and image.
     #[fixture]

--- a/crates/stackable-operator/src/builder/pod/security.rs
+++ b/crates/stackable-operator/src/builder/pod/security.rs
@@ -70,6 +70,7 @@ impl SecurityContextBuilder {
         sc.level = Some(level.into());
         self
     }
+
     pub fn se_linux_role(&mut self, role: impl Into<String>) -> &mut Self {
         let sc = self
             .security_context
@@ -201,6 +202,7 @@ impl PodSecurityContextBuilder {
             ));
         self
     }
+
     pub fn se_linux_role(&mut self, role: &str) -> &mut Self {
         self.pod_security_context.se_linux_options =
             Some(self.pod_security_context.se_linux_options.clone().map_or(
@@ -215,6 +217,7 @@ impl PodSecurityContextBuilder {
             ));
         self
     }
+
     pub fn se_linux_type(&mut self, type_: &str) -> &mut Self {
         self.pod_security_context.se_linux_options =
             Some(self.pod_security_context.se_linux_options.clone().map_or(
@@ -229,6 +232,7 @@ impl PodSecurityContextBuilder {
             ));
         self
     }
+
     pub fn se_linux_user(&mut self, user: &str) -> &mut Self {
         self.pod_security_context.se_linux_options =
             Some(self.pod_security_context.se_linux_options.clone().map_or(
@@ -335,8 +339,9 @@ impl PodSecurityContextBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use k8s_openapi::api::core::v1::{PodSecurityContext, SELinuxOptions, SeccompProfile, Sysctl};
+
+    use super::*;
 
     #[test]
     fn security_context_builder() {

--- a/crates/stackable-operator/src/builder/pod/volume.rs
+++ b/crates/stackable-operator/src/builder/pod/volume.rs
@@ -8,7 +8,6 @@ use k8s_openapi::{
     },
     apimachinery::pkg::api::resource::Quantity,
 };
-
 use snafu::{ResultExt, Snafu};
 use tracing::warn;
 
@@ -568,9 +567,11 @@ impl ListenerOperatorVolumeSourceBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
     use std::collections::BTreeMap;
+
+    use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+
+    use super::*;
 
     #[test]
     fn builder() {

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -284,12 +284,13 @@ fn resolve_path<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{env, fs::File};
+
     use clap::Parser;
     use rstest::*;
-    use std::env;
-    use std::fs::File;
     use tempfile::tempdir;
+
+    use super::*;
 
     const USER_PROVIDED_PATH: &str = "user_provided_path_properties.yaml";
     const DEPLOY_FILE_PATH: &str = "deploy_config_spec_properties.yaml";

--- a/crates/stackable-operator/src/client.rs
+++ b/crates/stackable-operator/src/client.rs
@@ -579,12 +579,14 @@ where
     (K, K::Scope): GetApiImpl<Resource = K>,
 {
     type Namespace = <(K, K::Scope) as GetApiImpl>::Namespace;
+
     fn get_api(client: kube::Client, ns: &Self::Namespace) -> kube::Api<Self>
     where
         Self::DynamicType: Default,
     {
         <(K, K::Scope) as GetApiImpl>::get_api(client, ns)
     }
+
     fn get_namespace(&self) -> &Self::Namespace {
         <(K, K::Scope) as GetApiImpl>::get_namespace(self)
     }
@@ -605,14 +607,16 @@ impl<K> GetApiImpl for (K, NamespaceResourceScope)
 where
     K: Resource<Scope = NamespaceResourceScope>,
 {
-    type Resource = K;
     type Namespace = str;
+    type Resource = K;
+
     fn get_api(client: kube::Client, ns: &Self::Namespace) -> kube::Api<K>
     where
         <Self::Resource as Resource>::DynamicType: Default,
     {
         Api::namespaced(client, ns)
     }
+
     fn get_namespace(res: &Self::Resource) -> &Self::Namespace {
         res.meta().namespace.as_deref().unwrap_or_default()
     }
@@ -622,14 +626,16 @@ impl<K> GetApiImpl for (K, ClusterResourceScope)
 where
     K: Resource<Scope = ClusterResourceScope>,
 {
-    type Resource = K;
     type Namespace = ();
+    type Resource = K;
+
     fn get_api(client: kube::Client, (): &Self::Namespace) -> kube::Api<K>
     where
         <Self::Resource as Resource>::DynamicType: Default,
     {
         Api::all(client)
     }
+
     fn get_namespace(_res: &Self::Resource) -> &Self::Namespace {
         &()
     }

--- a/crates/stackable-operator/src/cluster_resources.rs
+++ b/crates/stackable-operator/src/cluster_resources.rs
@@ -1,20 +1,8 @@
 //! A structure containing the cluster resources.
 
-use crate::{
-    client::{Client, GetApi},
-    commons::{
-        cluster_operation::ClusterOperation,
-        listener::Listener,
-        resources::{
-            ComputeResource, ResourceRequirementsExt, ResourceRequirementsType,
-            LIMIT_REQUEST_RATIO_CPU, LIMIT_REQUEST_RATIO_MEMORY,
-        },
-    },
-    kvp::{
-        consts::{K8S_APP_INSTANCE_KEY, K8S_APP_MANAGED_BY_KEY, K8S_APP_NAME_KEY},
-        Label, LabelError, Labels,
-    },
-    utils::format_full_controller_name,
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Debug,
 };
 
 use k8s_openapi::{
@@ -33,10 +21,6 @@ use k8s_openapi::{
 use kube::{core::ErrorResponse, Resource, ResourceExt};
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
-use std::{
-    collections::{BTreeMap, HashSet},
-    fmt::Debug,
-};
 use strum::Display;
 use tracing::{debug, info, warn};
 
@@ -44,6 +28,22 @@ use tracing::{debug, info, warn};
 use crate::k8s_openapi::api::{
     apps::v1::Deployment,
     core::v1::{NodeSelector, Pod},
+};
+use crate::{
+    client::{Client, GetApi},
+    commons::{
+        cluster_operation::ClusterOperation,
+        listener::Listener,
+        resources::{
+            ComputeResource, ResourceRequirementsExt, ResourceRequirementsType,
+            LIMIT_REQUEST_RATIO_CPU, LIMIT_REQUEST_RATIO_MEMORY,
+        },
+    },
+    kvp::{
+        consts::{K8S_APP_INSTANCE_KEY, K8S_APP_MANAGED_BY_KEY, K8S_APP_NAME_KEY},
+        Label, LabelError, Labels,
+    },
+    utils::format_full_controller_name,
 };
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/stackable-operator/src/commons/affinity.rs
+++ b/crates/stackable-operator/src/commons/affinity.rs
@@ -138,9 +138,8 @@ mod tests {
         apimachinery::pkg::apis::meta::v1::LabelSelectorRequirement,
     };
 
-    use crate::config::fragment;
-
     use super::*;
+    use crate::config::fragment;
 
     #[test]
     fn merge_new_attributes() {

--- a/crates/stackable-operator/src/commons/listener.rs
+++ b/crates/stackable-operator/src/commons/listener.rs
@@ -27,14 +27,13 @@
 
 use std::collections::BTreeMap;
 
-use kube::CustomResource;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 #[cfg(doc)]
 use k8s_openapi::api::core::v1::{
     Node, PersistentVolume, PersistentVolumeClaim, Pod, Service, Volume,
 };
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
 use crate::builder::pod::volume::ListenerOperatorVolumeSourceBuilder;

--- a/crates/stackable-operator/src/commons/networking.rs
+++ b/crates/stackable-operator/src/commons/networking.rs
@@ -177,9 +177,9 @@ impl Deref for KerberosRealmName {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("foo")]

--- a/crates/stackable-operator/src/commons/opa.rs
+++ b/crates/stackable-operator/src/commons/opa.rs
@@ -45,13 +45,14 @@
 //! ```
 use std::sync::LazyLock;
 
-use crate::client::{Client, GetApi};
 use k8s_openapi::{api::core::v1::ConfigMap, NamespaceResourceScope};
 use kube::{Resource, ResourceExt};
 use regex::Regex;
 use schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::client::{Client, GetApi};
 
 static DOT_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new("\\.").expect("failed to compile OPA dot regex"));

--- a/crates/stackable-operator/src/commons/product_image_selection.rs
+++ b/crates/stackable-operator/src/commons/product_image_selection.rs
@@ -178,9 +178,9 @@ impl ProductImage {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case::stackable_version_without_stackable_version_stable_version(

--- a/crates/stackable-operator/src/commons/resources.rs
+++ b/crates/stackable-operator/src/commons/resources.rs
@@ -68,6 +68,24 @@
 //! }
 //! ```
 
+use std::{collections::BTreeMap, fmt::Debug};
+
+use educe::Educe;
+use k8s_openapi::{
+    api::core::v1::{
+        Container, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec, ResourceRequirements,
+        VolumeResourceRequirements,
+    },
+    apimachinery::pkg::{
+        api::resource::Quantity,
+        apis::meta::v1::{LabelSelector, ObjectMeta},
+    },
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use strum::Display;
+
 use crate::{
     config::{
         fragment::{Fragment, FromFragment},
@@ -76,18 +94,6 @@ use crate::{
     cpu::CpuQuantity,
     memory::MemoryQuantity,
 };
-use educe::Educe;
-use k8s_openapi::api::core::v1::{
-    Container, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec, ResourceRequirements,
-    VolumeResourceRequirements,
-};
-use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use snafu::{ResultExt, Snafu};
-use std::{collections::BTreeMap, fmt::Debug};
-use strum::Display;
 
 pub const LIMIT_REQUEST_RATIO_CPU: f32 = 5.0;
 pub const LIMIT_REQUEST_RATIO_MEMORY: f32 = 1.0;
@@ -522,17 +528,19 @@ impl ResourceRequirementsExt for PodSpec {
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::pod::resources::ResourceRequirementsBuilder;
-    use crate::commons::resources::{PvcConfig, PvcConfigFragment, Resources, ResourcesFragment};
-    use crate::config::{
-        fragment::{self, Fragment},
-        merge::Merge,
-    };
     use k8s_openapi::api::core::v1::{Container, PersistentVolumeClaim, ResourceRequirements};
     use rstest::rstest;
     use serde::{Deserialize, Serialize};
 
     use super::*;
+    use crate::{
+        builder::pod::resources::ResourceRequirementsBuilder,
+        commons::resources::{PvcConfig, PvcConfigFragment, Resources, ResourcesFragment},
+        config::{
+            fragment::{self, Fragment},
+            merge::Merge,
+        },
+    };
 
     #[derive(Clone, Debug, Default, Fragment)]
     #[fragment(path_overrides(fragment = "crate::config::fragment"))]

--- a/crates/stackable-operator/src/commons/s3/crd.rs
+++ b/crates/stackable-operator/src/commons/s3/crd.rs
@@ -3,10 +3,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::commons::{
-    networking::HostName, secret_class::SecretClassVolume, tls_verification::TlsClientDetails,
+    networking::HostName, s3::S3ConnectionInlineOrReference, secret_class::SecretClassVolume,
+    tls_verification::TlsClientDetails,
 };
-
-use super::S3ConnectionInlineOrReference;
 
 /// S3 bucket specification containing the bucket name and an inlined or referenced connection specification.
 /// Learn more on the [S3 concept documentation](DOCS_BASE_URL_PLACEHOLDER/concepts/s3).

--- a/crates/stackable-operator/src/commons/s3/helpers.rs
+++ b/crates/stackable-operator/src/commons/s3/helpers.rs
@@ -7,13 +7,14 @@ use url::Url;
 use crate::{
     builder::pod::{container::ContainerBuilder, volume::VolumeMountBuilder, PodBuilder},
     client::Client,
-    commons::authentication::SECRET_BASE_PATH,
-};
-
-use super::{
-    AddS3CredentialVolumesSnafu, AddS3TlsClientDetailsVolumesSnafu, AddVolumeMountsSnafu,
-    AddVolumesSnafu, ParseS3EndpointSnafu, RetrieveS3ConnectionSnafu, S3Bucket, S3BucketSpec,
-    S3Connection, S3ConnectionSpec, S3Error, SetS3EndpointSchemeSnafu,
+    commons::{
+        authentication::SECRET_BASE_PATH,
+        s3::{
+            AddS3CredentialVolumesSnafu, AddS3TlsClientDetailsVolumesSnafu, AddVolumeMountsSnafu,
+            AddVolumesSnafu, ParseS3EndpointSnafu, RetrieveS3ConnectionSnafu, S3Bucket,
+            S3BucketSpec, S3Connection, S3ConnectionSpec, S3Error, SetS3EndpointSchemeSnafu,
+        },
+    },
 };
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
@@ -185,12 +186,11 @@ impl S3BucketInlineOrReference {
 mod tests {
     use std::collections::BTreeMap;
 
+    use super::*;
     use crate::commons::{
         secret_class::SecretClassVolume,
         tls_verification::{CaCert, Tls, TlsClientDetails, TlsServerVerification, TlsVerification},
     };
-
-    use super::*;
 
     // We cant test the correct resolve, as we can't mock the k8s API.
     #[test]

--- a/crates/stackable-operator/src/commons/s3/mod.rs
+++ b/crates/stackable-operator/src/commons/s3/mod.rs
@@ -3,13 +3,12 @@ mod helpers;
 
 pub use crd::*;
 pub use helpers::*;
-
 use snafu::Snafu;
 use url::Url;
 
-use crate::builder::{self};
-
-use super::{secret_class::SecretClassVolumeError, tls_verification::TlsClientDetailsError};
+use crate::commons::{
+    secret_class::SecretClassVolumeError, tls_verification::TlsClientDetailsError,
+};
 
 #[derive(Debug, Snafu)]
 pub enum S3Error {
@@ -35,10 +34,10 @@ pub enum S3Error {
     AddS3TlsClientDetailsVolumes { source: TlsClientDetailsError },
 
     #[snafu(display("failed to add required volumes"))]
-    AddVolumes { source: builder::pod::Error },
+    AddVolumes { source: crate::builder::pod::Error },
 
     #[snafu(display("failed to add required volumeMounts"))]
     AddVolumeMounts {
-        source: builder::pod::container::Error,
+        source: crate::builder::pod::container::Error,
     },
 }

--- a/crates/stackable-operator/src/commons/secret_class.rs
+++ b/crates/stackable-operator/src/commons/secret_class.rs
@@ -96,8 +96,9 @@ pub struct SecretClassVolumeScope {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::BTreeMap;
+
+    use super::*;
 
     #[test]
     fn volume_to_csi_volume_source() {

--- a/crates/stackable-operator/src/config/fragment.rs
+++ b/crates/stackable-operator/src/config/fragment.rs
@@ -8,17 +8,15 @@ use std::{
     hash::Hash,
 };
 
-use super::merge::Atomic;
+use k8s_openapi::api::core::v1::PodTemplateSpec;
+use snafu::Snafu;
+pub use stackable_operator_derive::Fragment;
 
+use super::merge::Atomic;
 #[cfg(doc)]
 use super::merge::Merge;
 #[cfg(doc)]
 use crate::role_utils::{Role, RoleGroup};
-
-use k8s_openapi::api::core::v1::PodTemplateSpec;
-use snafu::Snafu;
-
-pub use stackable_operator_derive::Fragment;
 
 /// Contains context used for generating validation errors
 ///

--- a/crates/stackable-operator/src/config/merge.rs
+++ b/crates/stackable-operator/src/config/merge.rs
@@ -1,15 +1,15 @@
 //! Automatically merges objects *deeply*, especially fragments.
 
-use k8s_openapi::{
-    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity, PodTemplateSpec},
-    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
-    DeepMerge,
-};
 use std::{
     collections::{btree_map, hash_map, BTreeMap, HashMap},
     hash::Hash,
 };
 
+use k8s_openapi::{
+    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity, PodTemplateSpec},
+    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
+    DeepMerge,
+};
 pub use stackable_operator_derive::Merge;
 
 use crate::time::Duration;
@@ -162,8 +162,9 @@ impl<T: Atomic> Merge for Option<T> {
 
 #[cfg(test)]
 mod tests {
-    use k8s_openapi::api::core::v1::{PodSpec, PodTemplateSpec};
     use std::collections::{BTreeMap, HashMap};
+
+    use k8s_openapi::api::core::v1::{PodSpec, PodTemplateSpec};
 
     use super::{merge, Merge};
 

--- a/crates/stackable-operator/src/config/mod.rs
+++ b/crates/stackable-operator/src/config/mod.rs
@@ -166,8 +166,9 @@ pub mod fragment;
 pub mod merge;
 
 #[cfg(doc)]
-use crate::role_utils::{Role, RoleGroup};
-#[cfg(doc)]
 use fragment::{validate, Fragment, FromFragment};
 #[cfg(doc)]
 use merge::{Atomic, Merge};
+
+#[cfg(doc)]
+use crate::role_utils::{Role, RoleGroup};

--- a/crates/stackable-operator/src/cpu.rs
+++ b/crates/stackable-operator/src/cpu.rs
@@ -229,8 +229,9 @@ impl Sum for CpuQuantity {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::*;
+
+    use super::*;
 
     #[rstest]
     #[case("1", 1000)]

--- a/crates/stackable-operator/src/helm/mod.rs
+++ b/crates/stackable-operator/src/helm/mod.rs
@@ -78,7 +78,6 @@ mod tests {
     use std::path::PathBuf;
 
     use rstest::rstest;
-
     use stackable_shared::yaml::{serialize as ser, SerializeOptions};
 
     use super::*;

--- a/crates/stackable-operator/src/kvp/annotation/mod.rs
+++ b/crates/stackable-operator/src/kvp/annotation/mod.rs
@@ -243,34 +243,6 @@ impl From<Annotations> for BTreeMap<String, String> {
 }
 
 impl Annotations {
-    /// Creates a new empty list of [`Annotations`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates a new list of [`Annotations`] from `pairs`.
-    pub fn new_with(pairs: BTreeSet<KeyValuePair<AnnotationValue>>) -> Self {
-        Self(KeyValuePairs::new_with(pairs))
-    }
-
-    /// Tries to insert a new annotation by first parsing `annotation` as an
-    /// [`Annotation`] and then inserting it into the list. This function will
-    /// overwrite any existing annotation already present.
-    pub fn parse_insert(
-        &mut self,
-        annotation: impl TryInto<Annotation, Error = AnnotationError>,
-    ) -> Result<(), AnnotationError> {
-        self.0.insert(annotation.try_into()?.0);
-        Ok(())
-    }
-
-    /// Inserts a new [`Annotation`]. This function will overwrite any existing
-    /// annotation already present.
-    pub fn insert(&mut self, annotation: Annotation) -> &mut Self {
-        self.0.insert(annotation.0);
-        self
-    }
-
     // This forwards / delegates associated functions to the inner field. In
     // this case self.0 which is of type KeyValuePairs<T>. So calling
     // Annotations::len() will be delegated to KeyValuePair<T>::len() without
@@ -305,11 +277,39 @@ impl Annotations {
             pub fn iter(&self) -> impl Iterator<Item = KeyValuePair<AnnotationValue>> + '_;
         }
     }
+
+    /// Creates a new empty list of [`Annotations`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new list of [`Annotations`] from `pairs`.
+    pub fn new_with(pairs: BTreeSet<KeyValuePair<AnnotationValue>>) -> Self {
+        Self(KeyValuePairs::new_with(pairs))
+    }
+
+    /// Tries to insert a new annotation by first parsing `annotation` as an
+    /// [`Annotation`] and then inserting it into the list. This function will
+    /// overwrite any existing annotation already present.
+    pub fn parse_insert(
+        &mut self,
+        annotation: impl TryInto<Annotation, Error = AnnotationError>,
+    ) -> Result<(), AnnotationError> {
+        self.0.insert(annotation.try_into()?.0);
+        Ok(())
+    }
+
+    /// Inserts a new [`Annotation`]. This function will overwrite any existing
+    /// annotation already present.
+    pub fn insert(&mut self, annotation: Annotation) -> &mut Self {
+        self.0.insert(annotation.0);
+        self
+    }
 }
 
 impl IntoIterator for Annotations {
-    type Item = KeyValuePair<AnnotationValue>;
     type IntoIter = <KeyValuePairs<AnnotationValue> as IntoIterator>::IntoIter;
+    type Item = KeyValuePair<AnnotationValue>;
 
     /// Returns a consuming [`Iterator`] over [`Annotations`] moving every [`Annotation`] out.
     /// The [`Annotations`] cannot be used again after calling this.

--- a/crates/stackable-operator/src/kvp/key.rs
+++ b/crates/stackable-operator/src/kvp/key.rs
@@ -340,9 +340,8 @@ where
 mod test {
     use rstest::rstest;
 
-    use crate::kvp::Label;
-
     use super::*;
+    use crate::kvp::Label;
 
     #[test]
     fn key_with_prefix() {

--- a/crates/stackable-operator/src/kvp/label/selector.rs
+++ b/crates/stackable-operator/src/kvp/label/selector.rs
@@ -111,9 +111,11 @@ impl LabelSelectorExt for LabelSelector {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
     use std::collections::BTreeMap;
+
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
+
+    use super::*;
 
     #[test]
     fn label_selector() {

--- a/crates/stackable-operator/src/kvp/label/value.rs
+++ b/crates/stackable-operator/src/kvp/label/value.rs
@@ -89,8 +89,9 @@ impl Display for LabelValue {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("a".repeat(64), LabelValueError::ValueTooLong { length: 64 })]

--- a/crates/stackable-operator/src/kvp/mod.rs
+++ b/crates/stackable-operator/src/kvp/mod.rs
@@ -342,9 +342,9 @@ impl<T> IntoIterator for KeyValuePairs<T>
 where
     T: Value,
 {
-    type Item = KeyValuePair<T>;
     type IntoIter =
         std::iter::Map<std::collections::btree_map::IntoIter<Key, T>, fn((Key, T)) -> Self::Item>;
+    type Item = KeyValuePair<T>;
 
     /// Returns a consuming [`Iterator`] over [`KeyValuePairs`] moving every [`KeyValuePair`] out.
     /// The [`KeyValuePairs`] cannot be used again after calling this.

--- a/crates/stackable-operator/src/logging/k8s_events.rs
+++ b/crates/stackable-operator/src/logging/k8s_events.rs
@@ -92,9 +92,8 @@ mod message {
 
     #[cfg(test)]
     mod tests {
-        use crate::logging::k8s_events::message::find_start_of_char;
-
         use super::truncate_with_ellipsis;
+        use crate::logging::k8s_events::message::find_start_of_char;
 
         #[test]
         fn truncate_should_be_noop_if_string_fits() {

--- a/crates/stackable-operator/src/memory.rs
+++ b/crates/stackable-operator/src/memory.rs
@@ -8,16 +8,16 @@
 //!
 //! For details on Kubernetes quantities see: <https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go>
 
-use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
-use serde::{de::Visitor, Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
-
 use std::{
     fmt::Display,
     iter::Sum,
     ops::{Add, AddAssign, Div, Mul, Sub, SubAssign},
     str::FromStr,
 };
+
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use serde::{de::Visitor, Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt, Snafu};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -516,9 +516,9 @@ impl From<&MemoryQuantity> for Quantity {
 #[cfg(test)]
 mod tests {
     use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+    use rstest::rstest;
 
     use super::*;
-    use rstest::rstest;
 
     #[rstest]
     #[case("256Ki", MemoryQuantity { value: 256.0, unit: BinaryMultiple::Kibi })]

--- a/crates/stackable-operator/src/namespace.rs
+++ b/crates/stackable-operator/src/namespace.rs
@@ -1,7 +1,8 @@
 //! This module provides helpers and constants to deal with namespaces
-use crate::client::Client;
 use k8s_openapi::NamespaceResourceScope;
 use kube::{Api, Resource};
+
+use crate::client::Client;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum WatchNamespace {

--- a/crates/stackable-operator/src/pod_utils.rs
+++ b/crates/stackable-operator/src/pod_utils.rs
@@ -4,8 +4,7 @@ Not necessarily these exact functions, but things in here will probably stick ar
 shape or form.
  */
 
-use kube::api::Resource;
-use kube::runtime::reflector::ObjectRef;
+use kube::{api::Resource, runtime::reflector::ObjectRef};
 
 /// Returns a name that is suitable for directly passing to a log macro.
 ///

--- a/crates/stackable-operator/src/product_config_utils.rs
+++ b/crates/stackable-operator/src/product_config_utils.rs
@@ -530,12 +530,13 @@ mod tests {
         };
     }
 
-    use super::*;
-    use crate::role_utils::{GenericProductSpecificCommonConfig, Role, RoleGroup};
+    use std::{collections::HashMap, str::FromStr};
+
     use k8s_openapi::api::core::v1::PodTemplateSpec;
     use rstest::*;
-    use std::collections::HashMap;
-    use std::str::FromStr;
+
+    use super::*;
+    use crate::role_utils::{GenericProductSpecificCommonConfig, Role, RoleGroup};
 
     const ROLE_GROUP: &str = "role_group";
 

--- a/crates/stackable-operator/src/product_logging/framework.rs
+++ b/crates/stackable-operator/src/product_logging/framework.rs
@@ -13,11 +13,10 @@ use crate::{
     },
     kube::Resource,
     memory::{BinaryMultiple, MemoryQuantity},
+    product_logging::spec::{
+        AutomaticContainerLogConfig, ContainerLogConfig, ContainerLogConfigChoice, LogLevel,
+    },
     role_utils::RoleGroupRef,
-};
-
-use super::spec::{
-    AutomaticContainerLogConfig, ContainerLogConfig, ContainerLogConfigChoice, LogLevel,
 };
 
 /// Config directory used in the Vector log agent container
@@ -1525,10 +1524,12 @@ pub fn remove_vector_shutdown_file_command(stackable_log_dir: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use rstest::rstest;
+
     use super::*;
     use crate::product_logging::spec::{AppenderConfig, LoggerConfig};
-    use rstest::rstest;
-    use std::collections::BTreeMap;
 
     #[rstest]
     #[case("0Mi", &[])]

--- a/crates/stackable-operator/src/product_logging/spec.rs
+++ b/crates/stackable-operator/src/product_logging/spec.rs
@@ -2,15 +2,14 @@
 
 use std::{borrow::Cow, collections::BTreeMap, fmt::Display};
 
-use crate::config::{
-    fragment::{self, Fragment, FromFragment},
-    merge::Atomic,
-    merge::Merge,
-};
-
 use educe::Educe;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::config::{
+    fragment::{self, Fragment, FromFragment},
+    merge::{Atomic, Merge},
+};
 
 /// Logging configuration
 ///
@@ -451,8 +450,6 @@ pub fn default_container_log_config() -> ContainerLogConfigFragment {
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::config::{fragment, merge};
-
     use super::{
         AppenderConfig, AppenderConfigFragment, AutomaticContainerLogConfig,
         AutomaticContainerLogConfigFragment, ConfigMapLogConfig, ConfigMapLogConfigFragment,
@@ -460,6 +457,7 @@ mod tests {
         ContainerLogConfigFragment, CustomContainerLogConfig, CustomContainerLogConfigFragment,
         LogLevel,
     };
+    use crate::config::{fragment, merge};
 
     #[test]
     fn serialize_container_log_config() {

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -85,6 +85,14 @@ use std::{
     fmt::{Debug, Display},
 };
 
+use educe::Educe;
+use k8s_openapi::api::core::v1::PodTemplateSpec;
+use kube::{runtime::reflector::ObjectRef, Resource};
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt, Snafu};
+
 use crate::{
     commons::pdb::PdbConfig,
     config::{
@@ -94,13 +102,6 @@ use crate::{
     product_config_utils::Configuration,
     utils::crds::raw_object_schema,
 };
-use educe::Educe;
-use k8s_openapi::api::core::v1::PodTemplateSpec;
-use kube::{runtime::reflector::ObjectRef, Resource};
-use regex::Regex;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -486,9 +487,8 @@ impl<K: Resource> Display for RoleGroupRef<K> {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::role_utils::JavaCommonConfig;
-
     use super::*;
+    use crate::role_utils::JavaCommonConfig;
 
     #[test]
     fn test_merge_java_common_config() {

--- a/crates/stackable-operator/src/status/condition/daemonset.rs
+++ b/crates/stackable-operator/src/status/condition/daemonset.rs
@@ -1,11 +1,12 @@
+use std::cmp;
+
+use k8s_openapi::api::apps::v1::DaemonSet;
+use kube::ResourceExt;
+
 use crate::status::condition::{
     ClusterCondition, ClusterConditionSet, ClusterConditionStatus, ClusterConditionType,
     ConditionBuilder,
 };
-
-use k8s_openapi::api::apps::v1::DaemonSet;
-use kube::ResourceExt;
-use std::cmp;
 
 /// Default implementation to build [`ClusterCondition`]s for
 /// `DaemonSet` resources.

--- a/crates/stackable-operator/src/status/condition/operations.rs
+++ b/crates/stackable-operator/src/status/condition/operations.rs
@@ -1,7 +1,9 @@
-use crate::commons::cluster_operation::ClusterOperation;
-use crate::status::condition::{
-    ClusterCondition, ClusterConditionSet, ClusterConditionStatus, ClusterConditionType,
-    ConditionBuilder,
+use crate::{
+    commons::cluster_operation::ClusterOperation,
+    status::condition::{
+        ClusterCondition, ClusterConditionSet, ClusterConditionStatus, ClusterConditionType,
+        ConditionBuilder,
+    },
 };
 
 /// Default implementation to build [`ClusterCondition`]s for
@@ -87,8 +89,9 @@ impl<'a> ClusterOperationsConditionBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::*;
+
+    use super::*;
 
     #[rstest]
     #[case::not_paused_not_stopped(

--- a/crates/stackable-operator/src/status/condition/statefulset.rs
+++ b/crates/stackable-operator/src/status/condition/statefulset.rs
@@ -1,11 +1,12 @@
+use std::cmp;
+
+use k8s_openapi::api::apps::v1::StatefulSet;
+use kube::ResourceExt;
+
 use crate::status::condition::{
     ClusterCondition, ClusterConditionSet, ClusterConditionStatus, ClusterConditionType,
     ConditionBuilder,
 };
-
-use k8s_openapi::api::apps::v1::StatefulSet;
-use kube::ResourceExt;
-use std::cmp;
 
 /// Default implementation to build [`ClusterCondition`]s for
 /// `StatefulSet` resources.

--- a/crates/stackable-operator/src/time/duration.rs
+++ b/crates/stackable-operator/src/time/duration.rs
@@ -421,9 +421,10 @@ impl DurationUnit {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use rstest::rstest;
     use serde::{Deserialize, Serialize};
+
+    use super::*;
 
     #[test]
     fn const_from() {

--- a/crates/stackable-operator/src/utils/mod.rs
+++ b/crates/stackable-operator/src/utils/mod.rs
@@ -15,7 +15,6 @@ pub use self::bash::COMMON_BASH_TRAP_FUNCTIONS;
     since = "0.61.1"
 )]
 pub use self::logging::print_startup_string;
-
 pub use self::{option::OptionExt, url::UrlExt};
 
 /// Returns the fully qualified controller name, which should be used when a single controller needs to be referred to uniquely.

--- a/crates/stackable-operator/src/utils/option.rs
+++ b/crates/stackable-operator/src/utils/option.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, ops::Deref};
-
 #[cfg(doc)]
 use std::path::PathBuf;
+use std::{borrow::Cow, ops::Deref};
 
 /// Extension methods for [`Option`].
 pub trait OptionExt<T> {

--- a/crates/stackable-operator/src/validation.rs
+++ b/crates/stackable-operator/src/validation.rs
@@ -308,8 +308,9 @@ pub fn validate_namespace_name(name: &str, prefix: bool) -> Result {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case("")]

--- a/crates/stackable-telemetry/src/instrumentation/axum/mod.rs
+++ b/crates/stackable-telemetry/src/instrumentation/axum/mod.rs
@@ -121,9 +121,9 @@ where
     S::Error: std::error::Error + 'static,
     S::Future: Send + 'static,
 {
-    type Response = S::Response;
     type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
+    type Response = S::Response;
 
     fn poll_ready(
         &mut self,

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -19,7 +19,7 @@ use tracing::subscriber::SetGlobalDefaultError;
 use tracing_appender::rolling::{InitError, RollingFileAppender, Rotation};
 use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Layer, Registry};
 
-use settings::*;
+use crate::tracing::settings::*;
 
 pub mod settings;
 

--- a/crates/stackable-versioned-macros/src/codegen/changes.rs
+++ b/crates/stackable-versioned-macros/src/codegen/changes.rs
@@ -204,8 +204,9 @@ impl ChangesetExt for BTreeMap<Version, ItemStatus> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case(0, (None, Some(&"test1")))]

--- a/crates/stackable-versioned-macros/tests/k8s/fail/crd.rs
+++ b/crates/stackable-versioned-macros/tests/k8s/fail/crd.rs
@@ -1,6 +1,5 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 use stackable_versioned_macros::versioned;
 
 #[allow(deprecated)]

--- a/crates/stackable-versioned-macros/tests/k8s/fail/crd.stderr
+++ b/crates/stackable-versioned-macros/tests/k8s/fail/crd.stderr
@@ -1,11 +1,11 @@
 error: struct name needs to include the `Spec` suffix if Kubernetes features are enabled via `#[versioned(k8s())]`
-  --> tests/k8s/fail/crd.rs:15:16
+  --> tests/k8s/fail/crd.rs:14:16
    |
-15 |     pub struct Foo {
+14 |     pub struct Foo {
    |                ^^^
 
 error[E0433]: failed to resolve: use of undeclared type `Foo`
-  --> tests/k8s/fail/crd.rs:24:22
+  --> tests/k8s/fail/crd.rs:23:22
    |
-24 |     let merged_crd = Foo::merged_crd("v1").unwrap();
+23 |     let merged_crd = Foo::merged_crd("v1").unwrap();
    |                      ^^^ use of undeclared type `Foo`

--- a/crates/stackable-webhook/src/lib.rs
+++ b/crates/stackable-webhook/src/lib.rs
@@ -29,8 +29,8 @@ use snafu::{ResultExt, Snafu};
 use stackable_telemetry::AxumTraceLayer;
 use tokio::signal::unix::{signal, SignalKind};
 use tower::ServiceBuilder;
-// use tower_http::trace::TraceLayer;
 
+// use tower_http::trace::TraceLayer;
 use crate::tls::TlsServer;
 
 pub mod constants;

--- a/crates/stackable-webhook/src/servers/conversion.rs
+++ b/crates/stackable-webhook/src/servers/conversion.rs
@@ -1,13 +1,12 @@
 use std::fmt::Debug;
 
 use axum::{extract::State, routing::post, Json, Router};
-use tracing::instrument;
-
 // Re-export this type because users of the conversion webhook server require
 // this type to write the handler function. Instead of importing this type from
 // kube directly, consumers can use this type instead. This also eliminates
 // keeping the kube dependency version in sync between here and the operator.
 pub use kube::core::conversion::ConversionReview;
+use tracing::instrument;
 
 use crate::{options::Options, StatefulWebhookHandler, WebhookHandler, WebhookServer};
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_impl_items = true
+use_field_init_shorthand = true


### PR DESCRIPTION
This PR adds a rustfmt config file and also applies the resulting reformatting. In addition, the pre-commit config now uses a local hook to check formatting of Rust code is correct.