### PR TITLE
refactor(stackable-versioned): Move preserve_module into options()

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/default/module_preserve.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/module_preserve.rs
@@ -2,7 +2,7 @@
     version(name = "v1alpha1"),
     version(name = "v1"),
     version(name = "v2alpha1"),
-    preserve_module
+    options(preserve_module)
 )]
 // ---
 pub(crate) mod versioned {

--- a/crates/stackable-versioned-macros/fixtures/inputs/k8s/module_preserve.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/k8s/module_preserve.rs
@@ -2,7 +2,7 @@
     version(name = "v1alpha1"),
     version(name = "v1"),
     version(name = "v2alpha1"),
-    preserve_module
+    options(preserve_module)
 )]
 // ---
 pub(crate) mod versioned {

--- a/crates/stackable-versioned-macros/src/attrs/container.rs
+++ b/crates/stackable-versioned-macros/src/attrs/container.rs
@@ -1,7 +1,7 @@
-use darling::{Error, FromAttributes, FromMeta, Result};
+use darling::{util::Flag, Error, FromAttributes, FromMeta, Result};
 
 use crate::attrs::{
-    common::{CommonRootArguments, SkipArguments},
+    common::{CommonOptions, CommonRootArguments, SkipArguments},
     k8s::KubernetesArguments,
 };
 
@@ -12,7 +12,7 @@ pub(crate) struct StandaloneContainerAttributes {
     pub(crate) kubernetes_arguments: Option<KubernetesArguments>,
 
     #[darling(flatten)]
-    pub(crate) common_root_arguments: CommonRootArguments,
+    pub(crate) common: CommonRootArguments<StandaloneContainerOptions>,
 }
 
 impl StandaloneContainerAttributes {
@@ -22,6 +22,18 @@ impl StandaloneContainerAttributes {
         }
 
         Ok(self)
+    }
+}
+
+#[derive(Debug, FromMeta, Default)]
+pub(crate) struct StandaloneContainerOptions {
+    pub(crate) allow_unsorted: Flag,
+    pub(crate) skip: Option<SkipArguments>,
+}
+
+impl CommonOptions for StandaloneContainerOptions {
+    fn allow_unsorted(&self) -> Flag {
+        self.allow_unsorted
     }
 }
 

--- a/crates/stackable-versioned-macros/src/attrs/module.rs
+++ b/crates/stackable-versioned-macros/src/attrs/module.rs
@@ -1,10 +1,22 @@
 use darling::{util::Flag, FromMeta};
 
-use crate::attrs::common::CommonRootArguments;
+use crate::attrs::common::{CommonOptions, CommonRootArguments, SkipArguments};
 
 #[derive(Debug, FromMeta)]
 pub(crate) struct ModuleAttributes {
     #[darling(flatten)]
-    pub(crate) common_root_arguments: CommonRootArguments,
+    pub(crate) common: CommonRootArguments<ModuleOptions>,
+}
+
+#[derive(Debug, FromMeta, Default)]
+pub(crate) struct ModuleOptions {
+    pub(crate) allow_unsorted: Flag,
+    pub(crate) skip: Option<SkipArguments>,
     pub(crate) preserve_module: Flag,
+}
+
+impl CommonOptions for ModuleOptions {
+    fn allow_unsorted(&self) -> Flag {
+        self.allow_unsorted
+    }
 }

--- a/crates/stackable-versioned-macros/src/codegen/container/enum.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/enum.rs
@@ -31,7 +31,7 @@ impl Container {
         let options = ContainerOptions {
             kubernetes_options: None,
             skip_from: attributes
-                .common_root_arguments
+                .common
                 .options
                 .skip
                 .map_or(false, |s| s.from.is_present()),

--- a/crates/stackable-versioned-macros/src/codegen/container/struct.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/struct.rs
@@ -44,7 +44,7 @@ impl Container {
 
         let options = ContainerOptions {
             skip_from: attributes
-                .common_root_arguments
+                .common
                 .options
                 .skip
                 .map_or(false, |s| s.from.is_present()),

--- a/crates/stackable-versioned-macros/src/codegen/mod.rs
+++ b/crates/stackable-versioned-macros/src/codegen/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct VersionDefinition {
 impl From<&StandaloneContainerAttributes> for Vec<VersionDefinition> {
     fn from(attributes: &StandaloneContainerAttributes) -> Self {
         attributes
-            .common_root_arguments
+            .common
             .versions
             .iter()
             .map(|v| VersionDefinition {
@@ -53,7 +53,7 @@ impl From<&StandaloneContainerAttributes> for Vec<VersionDefinition> {
 impl From<&ModuleAttributes> for Vec<VersionDefinition> {
     fn from(attributes: &ModuleAttributes) -> Self {
         attributes
-            .common_root_arguments
+            .common
             .versions
             .iter()
             .map(|v| VersionDefinition {

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -239,7 +239,7 @@ mod utils;
 /// #[versioned(
 ///     version(name = "v1alpha1"),
 ///     version(name = "v1"),
-///     preserve_module
+///     options(preserve_module)
 /// )]
 /// mod versioned {
 ///     struct Foo {
@@ -732,9 +732,14 @@ fn versioned_impl(attrs: proc_macro2::TokenStream, input: Item) -> proc_macro2::
             };
 
             let versions: Vec<VersionDefinition> = (&module_attributes).into();
-            let preserve_modules = module_attributes.preserve_module.is_present();
+            let preserve_modules = module_attributes
+                .common
+                .options
+                .preserve_module
+                .is_present();
+
             let skip_from = module_attributes
-                .common_root_arguments
+                .common
                 .options
                 .skip
                 .as_ref()

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: Move `preserve_module` option into `options` to unify option interface ([#961]).
+
+[#961]: https://github.com/stackabletech/operator-rs/pull/961
+
 ## [0.5.1] - 2025-02-14
 
 ### Added


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642

This PR unifies the option interface and moves the `preserve_module` option (which is only available when the macro is used on modules) into the list of `options()`.

**Before**

```rust
#[versioned(
    version(name = "v1alpha1"),
    preserve_module
)]
mod versioned {
    pub struct Foo {
        bar: Option<u16>,
    }
}
```

**After**

```rust
#[versioned(
    version(name = "v1alpha1"),
    options(preserve_module)
)]
mod versioned {
    pub struct Foo {
        bar: Option<u16>,
    }
}
```