### PR TITLE
fix(stackable-operator): Improve AwsRegion::name() ergonomics 

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fix
+
+- BREAKING: Improve `AwsRegion::name()` ergonomics: borrow self and return `Option<&str>` ([#963]).
+
+[#963]: https://github.com/stackabletech/operator-rs/pull/963
+
 ## [0.86.1] - 2025-02-21
 
 ### Added

--- a/crates/stackable-operator/src/commons/s3/crd.rs
+++ b/crates/stackable-operator/src/commons/s3/crd.rs
@@ -124,7 +124,7 @@ impl AwsRegion {
     ///
     /// ```
     /// # use stackable_operator::commons::s3::AwsRegion;
-    /// # fn set_property(key: &str, value: String) {}
+    /// # fn set_property(key: &str, value: &str) {}
     /// # fn example(aws_region: AwsRegion) {
     /// if let Some(region_name) = aws_region.name() {
     ///     // set some property if the region is set, or is the default.

--- a/crates/stackable-operator/src/commons/s3/crd.rs
+++ b/crates/stackable-operator/src/commons/s3/crd.rs
@@ -132,7 +132,7 @@ impl AwsRegion {
     /// };
     /// # }
     /// ```
-    pub fn name(self) -> Option<String> {
+    pub fn name(&self) -> Option<&str> {
         match self {
             AwsRegion::Name(name) => Some(name),
             AwsRegion::Source(_) => None,


### PR DESCRIPTION
# Description

BREAKING: Improve `AwsRegion::name()` ergonomics: borrow self and return `Option<&str>`.
