### PR TITLE
feat(stackable-versioned): Add support for generics

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/default/generics_enum.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/generics_enum.rs
@@ -1,0 +1,9 @@
+#[versioned(version(name = "v1alpha1"), version(name = "v1"))]
+// ---
+pub enum Foo<T>
+where
+    T: Default,
+{
+    Bar(T),
+    Baz,
+}

--- a/crates/stackable-versioned-macros/fixtures/inputs/default/generics_module.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/generics_module.rs
@@ -1,0 +1,23 @@
+#[versioned(
+    version(name = "v1alpha1"),
+    version(name = "v1"),
+    options(preserve_module)
+)]
+// ---
+pub mod versioned {
+    struct Foo<T>
+    where
+        T: Default,
+    {
+        bar: T,
+        baz: u8,
+    }
+
+    enum Boom<T>
+    where
+        T: Default,
+    {
+        Big(T),
+        Shaq,
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/inputs/default/generics_struct.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/generics_struct.rs
@@ -1,0 +1,9 @@
+#[versioned(version(name = "v1alpha1"), version(name = "v1"))]
+// ---
+pub struct Foo<T>
+where
+    T: Default,
+{
+    bar: T,
+    baz: u8,
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_enum.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_enum.rs.snap
@@ -1,0 +1,39 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/generics_enum.rs
+---
+#[automatically_derived]
+pub mod v1alpha1 {
+    use super::*;
+    pub enum Foo<T>
+    where
+        T: Default,
+    {
+        Bar(T),
+        Baz,
+    }
+}
+#[automatically_derived]
+impl<T> ::std::convert::From<v1alpha1::Foo<T>> for v1::Foo<T>
+where
+    T: Default,
+{
+    fn from(__sv_foo: v1alpha1::Foo<T>) -> Self {
+        match __sv_foo {
+            v1alpha1::Foo::Bar(__sv_0) => v1::Foo::Bar(__sv_0),
+            v1alpha1::Foo::Baz => v1::Foo::Baz,
+        }
+    }
+}
+#[automatically_derived]
+pub mod v1 {
+    use super::*;
+    pub enum Foo<T>
+    where
+        T: Default,
+    {
+        Bar(T),
+        Baz,
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_module.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_module.rs.snap
@@ -1,0 +1,64 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/generics_module.rs
+---
+#[automatically_derived]
+pub mod versioned {
+    pub mod v1alpha1 {
+        use super::*;
+        pub struct Foo<T>
+        where
+            T: Default,
+        {
+            pub bar: T,
+            pub baz: u8,
+        }
+        pub enum Boom<T>
+        where
+            T: Default,
+        {
+            Big(T),
+            Shaq,
+        }
+    }
+    impl<T> ::std::convert::From<v1alpha1::Foo<T>> for v1::Foo<T>
+    where
+        T: Default,
+    {
+        fn from(__sv_foo: v1alpha1::Foo<T>) -> Self {
+            Self {
+                bar: __sv_foo.bar.into(),
+                baz: __sv_foo.baz.into(),
+            }
+        }
+    }
+    impl<T> ::std::convert::From<v1alpha1::Boom<T>> for v1::Boom<T>
+    where
+        T: Default,
+    {
+        fn from(__sv_boom: v1alpha1::Boom<T>) -> Self {
+            match __sv_boom {
+                v1alpha1::Boom::Big(__sv_0) => v1::Boom::Big(__sv_0),
+                v1alpha1::Boom::Shaq => v1::Boom::Shaq,
+            }
+        }
+    }
+    pub mod v1 {
+        use super::*;
+        pub struct Foo<T>
+        where
+            T: Default,
+        {
+            pub bar: T,
+            pub baz: u8,
+        }
+        pub enum Boom<T>
+        where
+            T: Default,
+        {
+            Big(T),
+            Shaq,
+        }
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_struct.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_struct.rs.snap
@@ -1,0 +1,39 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/generics_struct.rs
+---
+#[automatically_derived]
+pub mod v1alpha1 {
+    use super::*;
+    pub struct Foo<T>
+    where
+        T: Default,
+    {
+        pub bar: T,
+        pub baz: u8,
+    }
+}
+#[automatically_derived]
+impl<T> ::std::convert::From<v1alpha1::Foo<T>> for v1::Foo<T>
+where
+    T: Default,
+{
+    fn from(__sv_foo: v1alpha1::Foo<T>) -> Self {
+        Self {
+            bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
+        }
+    }
+}
+#[automatically_derived]
+pub mod v1 {
+    use super::*;
+    pub struct Foo<T>
+    where
+        T: Default,
+    {
+        pub bar: T,
+        pub baz: u8,
+    }
+}

--- a/crates/stackable-versioned-macros/src/codegen/container/struct.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/struct.rs
@@ -3,7 +3,7 @@ use std::ops::Not;
 use darling::{util::IdentString, Error, FromAttributes, Result};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{parse_quote, ItemStruct, Path, Visibility};
+use syn::{parse_quote, Generics, ItemStruct, Path, Visibility};
 
 use crate::{
     attrs::container::NestedContainerAttributes,
@@ -58,6 +58,7 @@ impl Container {
         };
 
         Ok(Self::Struct(Struct {
+            generics: item_struct.generics,
             fields: versioned_fields,
             common,
         }))
@@ -113,6 +114,7 @@ impl Container {
         };
 
         Ok(Self::Struct(Struct {
+            generics: item_struct.generics,
             fields: versioned_fields,
             common,
         }))
@@ -123,10 +125,12 @@ impl Container {
 pub(crate) struct Struct {
     /// List of fields defined in the original struct. How, and if, an item
     /// should generate code, is decided by the currently generated version.
-    pub(crate) fields: Vec<VersionedField>,
+    pub fields: Vec<VersionedField>,
+
+    pub generics: Generics,
 
     /// Common container data which is shared between structs and enums.
-    pub(crate) common: CommonContainerData,
+    pub common: CommonContainerData,
 }
 
 // Common token generation

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add basic support for generic types in struct and enum definitions ([#969]).
+
 ### Changed
 
 - BREAKING: Move `preserve_module` option into `options` to unify option interface ([#961]).
 
 [#961]: https://github.com/stackabletech/operator-rs/pull/961
+[#969]: https://github.com/stackabletech/operator-rs/pull/969
 
 ## [0.5.1] - 2025-02-14
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642, came up in https://github.com/stackabletech/operator-rs/pull/968

This PR adds basic support for generic types in struct and enum definitions. More complex topics involving field actions are not covered by this. This (might) eventually come in follow-up PR.