### PR TITLE
feat(stackable-versioned): Re-emit and merge modules in versioned modules

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/default/submodule.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/submodule.rs
@@ -1,0 +1,11 @@
+#[versioned(version(name = "v1alpha1"), version(name = "v1"))]
+// ---
+mod versioned {
+    mod v1alpha1 {
+        pub use my::reexport::v1alpha1::*;
+    }
+
+    struct Foo {
+        bar: usize,
+    }
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@submodule.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@submodule.rs.snap
@@ -1,0 +1,26 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/submodule.rs
+---
+#[automatically_derived]
+mod v1alpha1 {
+    use super::*;
+    pub use my::reexport::v1alpha1::*;
+    pub struct Foo {
+        pub bar: usize,
+    }
+}
+#[automatically_derived]
+impl ::std::convert::From<v1alpha1::Foo> for v1::Foo {
+    fn from(__sv_foo: v1alpha1::Foo) -> Self {
+        Self { bar: __sv_foo.bar.into() }
+    }
+}
+#[automatically_derived]
+mod v1 {
+    use super::*;
+    pub struct Foo {
+        pub bar: usize,
+    }
+}

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -261,6 +261,75 @@ mod utils;
 /// }
 /// ```
 ///
+/// ### Re-emitting and merging Submodules
+///
+/// Modules defined in the versioned module will be re-emitted. This allows for
+/// composition of re-exports to compose easier to use imports for downstream
+/// consumers of versioned containers. The following rules apply:
+///
+/// 1. Only modules named the same like defined versions will be re-emitted.
+///    Modules named differently will be ignored and won't produce any code. In
+///    the future, this might return an error instead.
+/// 2. Only `use` statements defined in the module will be emitted. Other items
+///    will be ignored and won't produce any code. In the future, this might
+///    return an error instead.
+///
+/// ```
+/// # use stackable_versioned_macros::versioned;
+/// # mod a {
+/// #     pub mod v1alpha1 {}
+/// # }
+/// # mod b {
+/// #     pub mod v1alpha1 {}
+/// # }
+/// #[versioned(
+///     version(name = "v1alpha1"),
+///     version(name = "v1")
+/// )]
+/// mod versioned {
+///     mod v1alpha1 {
+///         pub use a::v1alpha1::*;
+///         pub use b::v1alpha1::*;
+///     }
+///
+///     struct Foo {
+///         bar: usize,
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// <details>
+/// <summary>Expand Generated Code</summary>
+///
+/// ```ignore
+/// mod v1alpha1 {
+///     use super::*;
+///     pub use a::v1alpha1::*;
+///     pub use b::v1alpha1::*;
+///     pub struct Foo {
+///         pub bar: usize,
+///     }
+/// }
+///
+/// impl ::std::convert::From<v1alpha1::Foo> for v1::Foo {
+///     fn from(__sv_foo: v1alpha1::Foo) -> Self {
+///         Self {
+///             bar: __sv_foo.bar.into(),
+///         }
+///     }
+/// }
+///
+/// mod v1 {
+///     use super::*;
+///     pub struct Foo {
+///         pub bar: usize,
+///     }
+/// }
+/// ```
+///
+/// </details>
+///
 /// ## Item Actions
 ///
 /// This crate currently supports three different item actions. Items can

--- a/crates/stackable-versioned-macros/src/lib.rs
+++ b/crates/stackable-versioned-macros/src/lib.rs
@@ -268,11 +268,9 @@ mod utils;
 /// consumers of versioned containers. The following rules apply:
 ///
 /// 1. Only modules named the same like defined versions will be re-emitted.
-///    Modules named differently will be ignored and won't produce any code. In
-///    the future, this might return an error instead.
-/// 2. Only `use` statements defined in the module will be emitted. Other items
-///    will be ignored and won't produce any code. In the future, this might
-///    return an error instead.
+///    Using modules with invalid names will return an error.
+/// 2. Only `use` statements defined in the module will be emitted. Declaring
+///    other items will return an error.
 ///
 /// ```
 /// # use stackable_versioned_macros::versioned;

--- a/crates/stackable-versioned-macros/tests/default/fail/submodule_invalid_name.rs
+++ b/crates/stackable-versioned-macros/tests/default/fail/submodule_invalid_name.rs
@@ -1,0 +1,8 @@
+use stackable_versioned_macros::versioned;
+
+fn main() {
+    #[versioned(version(name = "v1alpha1"))]
+    mod versioned {
+        mod v1alpha2 {}
+    }
+}

--- a/crates/stackable-versioned-macros/tests/default/fail/submodule_invalid_name.stderr
+++ b/crates/stackable-versioned-macros/tests/default/fail/submodule_invalid_name.stderr
@@ -1,0 +1,5 @@
+error: submodules must use names which are defined as `version`s
+ --> tests/default/fail/submodule_invalid_name.rs:6:9
+  |
+6 |         mod v1alpha2 {}
+  |         ^^^

--- a/crates/stackable-versioned-macros/tests/default/fail/submodule_use_statement.rs
+++ b/crates/stackable-versioned-macros/tests/default/fail/submodule_use_statement.rs
@@ -1,0 +1,10 @@
+use stackable_versioned::versioned;
+
+fn main() {
+    #[versioned(version(name = "v1alpha1"))]
+    mod versioned {
+        mod v1alpha1 {
+            struct Foo;
+        }
+    }
+}

--- a/crates/stackable-versioned-macros/tests/default/fail/submodule_use_statement.stderr
+++ b/crates/stackable-versioned-macros/tests/default/fail/submodule_use_statement.stderr
@@ -1,0 +1,5 @@
+error: submodules must only define `use` statements
+ --> tests/default/fail/submodule_use_statement.rs:7:13
+  |
+7 |             struct Foo;
+  |             ^^^^^^

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add support for re-emitting and merging modules defined in versioned modules ([#xxx]).
+- Add support for re-emitting and merging modules defined in versioned modules ([#971]).
 - Add basic support for generic types in struct and enum definitions ([#969]).
 
 ### Changed
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 [#961]: https://github.com/stackabletech/operator-rs/pull/961
 [#969]: https://github.com/stackabletech/operator-rs/pull/969
-[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
+[#971]: https://github.com/stackabletech/operator-rs/pull/971
 
 ## [0.5.1] - 2025-02-14
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add support for re-emitting and merging modules defined in versioned modules ([#xxx]).
 - Add basic support for generic types in struct and enum definitions ([#969]).
 
 ### Changed
@@ -14,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 [#961]: https://github.com/stackabletech/operator-rs/pull/961
 [#969]: https://github.com/stackabletech/operator-rs/pull/969
+[#xxx]: https://github.com/stackabletech/operator-rs/pull/xxx
 
 ## [0.5.1] - 2025-02-14
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642

This PR allows users to define modules in the `versioned` module, which allows composition of imports which then produces easier to consume imports in downstream code.

**Example**

```rust
// In crate/crd/mod.rs

#[versioned(
    version(name = "v1alpha1"),
    version(name = "v1")
)]
mod versioned {
    mod v1alpha1 {
        pub use crate::crd::oidc::v1alpha1::*
        pub use crate::crd::tls::v1alpha1::*
    }

    struct Foo {
        bar: usize,
    }
}
```