### PR TITLE
chore: Release stackable-operator-0.87.0 and stackable-versioned-0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.86.2"
+version = "0.87.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3328,14 +3328,14 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "stackable-versioned-macros",
 ]
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.87.0] - 2025-02-28
+
 ### Changed
 
 - BREAKING: Update `strum` to `0.27.1` (clients need to also update strum!), `rand` to `0.9.0` and `convert_case` to `0.8.0` ([#972]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.86.2"
+version = "0.87.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.5.1"
+version = "0.6.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-02-28
+
 ### Added
 
 - Add support for re-emitting and merging modules defined in versioned modules ([#971]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.5.1"
+version = "0.6.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Part of <https://github.com/stackabletech/operator-rs/issues/970>

## stackable-operator 0.87.0

### Changed

- BREAKING: Update `strum` to `0.27.1` (clients need to also update strum!), `rand` to `0.9.0` and `convert_case` to `0.8.0` ([#972]).

[#972]: https://github.com/stackabletech/operator-rs/pull/972

## stackable-versioned 0.6.0

### Added

- Add support for re-emitting and merging modules defined in versioned modules ([#971]).
- Add basic support for generic types in struct and enum definitions ([#969]).

### Changed

- BREAKING: Move `preserve_module` option into `options` to unify option interface ([#961]).

[#961]: https://github.com/stackabletech/operator-rs/pull/961
[#969]: https://github.com/stackabletech/operator-rs/pull/969
[#971]: https://github.com/stackabletech/operator-rs/pull/971