### PR TITLE
chore: Release stackable-operator 0.87.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.87.0"
+version = "0.87.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.87.1] - 2025-03-10
+
 ### Changed
 
 - Refactor `region` field in S3ConnectionSpec ([#976]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.87.0"
+version = "0.87.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.87.1:

### Changed

- Refactor `region` field in S3ConnectionSpec ([#976]).

[#976]: https://github.com/stackabletech/operator-rs/pull/976