### PR TITLE
revert: Temporarily revert #950

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,19 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- Deprecate `stackable_operator::logging::initialize_logging()`. It's recommended to use `stackable-telemetry` instead ([#950]).
-
-[#950]: https://github.com/stackabletech/operator-rs/pull/950
-
 ## [0.87.4] - 2025-03-17
-
-### Changed
-
-- Bump `kube` to 0.99.0 and `json-patch` to 4.0.0 ([#982]).
-
-[#982]: https://github.com/stackabletech/operator-rs/pull/982
 
 ## [0.87.3] - 2025-03-14
 

--- a/crates/stackable-operator/src/logging/mod.rs
+++ b/crates/stackable-operator/src/logging/mod.rs
@@ -28,7 +28,6 @@ impl Default for TracingTarget {
 ///
 /// Log output can be copied to a file by setting `{env}_DIRECTORY` (e.g. `FOOBAR_OPERATOR_DIRECTORY`)
 /// to a directory path. This file will be rotated regularly.
-#[deprecated(note = "Use stackable-telemetry instead, use OTLP instead of Jaeger protocol")]
 pub fn initialize_logging(env: &str, app_name: &str, tracing_target: TracingTarget) {
     let filter = match EnvFilter::try_from_env(env) {
         Ok(env_filter) => env_filter,
@@ -95,7 +94,6 @@ mod tests {
     //      NOT_SET=debug cargo test default_tracing -- --nocapture
     // to see them all.
     #[test]
-    #[allow(deprecated)]
     fn default_tracing_level_is_set_to_info() {
         super::initialize_logging("NOT_SET", "test", TracingTarget::None);
 


### PR DESCRIPTION
This reverts commit cbb7cc5da1a9452886f2917e5c39cf0d992926db.

This revert is needed, because another `stackable-operator` release before SDP 25.3.0 is required to fix a breaking change in `kube` which is only encountered during runtime.

```
2025-03-19T14:37:07.285064Z  INFO stackable_operator::utils::logging: Starting Stackable Operator for Apache Superset
2025-03-19T14:37:07.285095Z  INFO stackable_operator::utils::logging: This is version 0.0.0-dev (Git information: c7273b5), built for x86_64-unknown-linux-gnu by rustc 1.84.1 (e71f9a9a9 2025-01-27) at Wed, 19 Mar 2025 14:14:33 +0000
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.25/src/crypto/mod.rs:249:14:
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

A more detailed explanation of the issue and how it is fixed will be provided in the upcoming fix PR: https://github.com/stackabletech/operator-rs/pull/988.
