### PR TITLE
fix(stackable-versioned): Emit type parameter defaults

### DIFF
--- a/crates/stackable-versioned-macros/fixtures/inputs/default/generics_defaults.rs
+++ b/crates/stackable-versioned-macros/fixtures/inputs/default/generics_defaults.rs
@@ -1,0 +1,9 @@
+#[versioned(version(name = "v1alpha1"), version(name = "v1"))]
+// ---
+pub struct Foo<T = String>
+where
+    T: Default,
+{
+    bar: T,
+    baz: u8,
+}

--- a/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_defaults.rs.snap
+++ b/crates/stackable-versioned-macros/fixtures/snapshots/stackable_versioned_macros__test__default_snapshots@generics_defaults.rs.snap
@@ -1,0 +1,39 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/fixtures/inputs/default/generics_defaults.rs
+---
+#[automatically_derived]
+pub mod v1alpha1 {
+    use super::*;
+    pub struct Foo<T = String>
+    where
+        T: Default,
+    {
+        pub bar: T,
+        pub baz: u8,
+    }
+}
+#[automatically_derived]
+impl<T> ::std::convert::From<v1alpha1::Foo<T>> for v1::Foo<T>
+where
+    T: Default,
+{
+    fn from(__sv_foo: v1alpha1::Foo<T>) -> Self {
+        Self {
+            bar: __sv_foo.bar.into(),
+            baz: __sv_foo.baz.into(),
+        }
+    }
+}
+#[automatically_derived]
+pub mod v1 {
+    use super::*;
+    pub struct Foo<T = String>
+    where
+        T: Default,
+    {
+        pub bar: T,
+        pub baz: u8,
+    }
+}

--- a/crates/stackable-versioned-macros/src/codegen/container/enum.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/enum.rs
@@ -104,7 +104,9 @@ pub(crate) struct Enum {
 impl Enum {
     /// Generates code for the enum definition.
     pub(crate) fn generate_definition(&self, version: &VersionDefinition) -> TokenStream {
-        let (_, type_generics, where_clause) = self.generics.split_for_impl();
+        let where_clause = self.generics.where_clause.as_ref();
+        let type_generics = &self.generics;
+
         let original_attributes = &self.common.original_attributes;
         let ident = &self.common.idents.original;
         let version_docs = &version.docs;

--- a/crates/stackable-versioned-macros/src/codegen/container/struct.rs
+++ b/crates/stackable-versioned-macros/src/codegen/container/struct.rs
@@ -135,7 +135,9 @@ pub(crate) struct Struct {
 impl Struct {
     /// Generates code for the struct definition.
     pub(crate) fn generate_definition(&self, version: &VersionDefinition) -> TokenStream {
-        let (_, type_generics, where_clause) = self.generics.split_for_impl();
+        let where_clause = self.generics.where_clause.as_ref();
+        let type_generics = &self.generics;
+
         let original_attributes = &self.common.original_attributes;
         let ident = &self.common.idents.original;
         let version_docs = &version.docs;

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly emit generic type parameter defaults in enum/struct definition blocks ([#991]).
+
+[#991]: https://github.com/stackabletech/operator-rs/pull/991
+
 ## [0.7.0] - 2025-03-17
 
 ### Changed


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642, needed for #968 

Correctly emit type parameter defaults in generated enum and struct definitions.