### PR TITLE
feat: add DeploymentConditionBuilder

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add Deployments to `ClusterResource`s ([#992]).
+- Add `DeploymentConditionBuilder`  ([#993]).
 
 [#992]: https://github.com/stackabletech/operator-rs/pull/992
+[#993]: https://github.com/stackabletech/operator-rs/pull/993
 
 ## [0.87.5] - 2025-03-19
 

--- a/crates/stackable-operator/src/cluster_resources.rs
+++ b/crates/stackable-operator/src/cluster_resources.rs
@@ -27,10 +27,7 @@ use strum::Display;
 use tracing::{debug, info, warn};
 
 #[cfg(doc)]
-use crate::k8s_openapi::api::{
-    apps::v1::Deployment,
-    core::v1::{NodeSelector, Pod},
-};
+use crate::k8s_openapi::api::core::v1::{NodeSelector, Pod};
 use crate::{
     client::{Client, GetApi},
     commons::{

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -116,10 +116,10 @@ mod tests {
 
     #[test]
     fn available() {
-        let dplmt = build_deployment(3, 3);
+        let deployment = build_deployment(3, 3);
 
         assert_eq!(
-            DeploymentConditionBuilder::deployment_available(&dplmt),
+            DeploymentConditionBuilder::deployment_available(&deployment),
             ClusterConditionStatus::True
         );
     }

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -1,0 +1,191 @@
+use std::cmp;
+
+use k8s_openapi::api::apps::v1::Deployment;
+use kube::ResourceExt;
+
+use crate::status::condition::{
+    ClusterCondition, ClusterConditionSet, ClusterConditionStatus, ClusterConditionType,
+    ConditionBuilder,
+};
+
+/// Default implementation to build [`ClusterCondition`]s for
+/// `Deployment` resources.
+///
+/// Currently only the `ClusterConditionType::Available` is implemented. This will be extended
+/// to support all `ClusterConditionType`s in the future.
+#[derive(Default)]
+pub struct DeploymentConditionBuilder {
+    deployments: Vec<Deployment>,
+}
+
+impl ConditionBuilder for DeploymentConditionBuilder {
+    fn build_conditions(&self) -> ClusterConditionSet {
+        vec![self.available()].into()
+    }
+}
+
+impl DeploymentConditionBuilder {
+    pub fn add(&mut self, dplmt: Deployment) {
+        self.deployments.push(dplmt);
+    }
+
+    fn available(&self) -> ClusterCondition {
+        let mut available = ClusterConditionStatus::True;
+        let mut unavailable_resources = vec![];
+        for dplmt in &self.deployments {
+            let current_status = Self::deployment_available(dplmt);
+
+            if current_status != ClusterConditionStatus::True {
+                unavailable_resources.push(dplmt.name_any())
+            }
+
+            available = cmp::max(available, current_status);
+        }
+
+        // We need to sort here to make sure roles and role groups are not changing position
+        // due to the HashMap (random order) logic.
+        unavailable_resources.sort();
+
+        let message = match available {
+            ClusterConditionStatus::True => {
+                "All Deployments have the requested amount of ready replicas.".to_string()
+            }
+            ClusterConditionStatus::False => {
+                format!("Deployment {unavailable_resources:?} missing ready replicas.")
+            }
+            ClusterConditionStatus::Unknown => {
+                "Deployment status cannot be determined.".to_string()
+            }
+        };
+
+        ClusterCondition {
+            reason: None,
+            message: Some(message),
+            status: available,
+            type_: ClusterConditionType::Available,
+            last_transition_time: None,
+            last_update_time: None,
+        }
+    }
+
+    /// Returns a condition "Available: True" if the number of requested replicas matches
+    /// the number of available replicas. In addition, there needs to be at least one replica
+    /// available.
+    fn deployment_available(dplmt: &Deployment) -> ClusterConditionStatus {
+        let requested_replicas = dplmt
+            .spec
+            .as_ref()
+            .and_then(|spec| spec.replicas)
+            .unwrap_or_default();
+        let available_replicas = dplmt
+            .status
+            .as_ref()
+            .and_then(|status| status.available_replicas)
+            .unwrap_or_default();
+
+        if requested_replicas == available_replicas && requested_replicas != 0 {
+            ClusterConditionStatus::True
+        } else {
+            ClusterConditionStatus::False
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStatus};
+
+    use crate::status::condition::{
+        deployment::DeploymentConditionBuilder, ClusterCondition, ClusterConditionStatus,
+        ClusterConditionType, ConditionBuilder,
+    };
+
+    fn build_deployment(spec_replicas: i32, available_replicas: i32) -> Deployment {
+        Deployment {
+            spec: Some(DeploymentSpec {
+                replicas: Some(spec_replicas),
+                ..DeploymentSpec::default()
+            }),
+            status: Some(DeploymentStatus {
+                available_replicas: Some(available_replicas),
+                ..DeploymentStatus::default()
+            }),
+            ..Deployment::default()
+        }
+    }
+
+    #[test]
+    fn available() {
+        let dplmt = build_deployment(3, 3);
+
+        assert_eq!(
+            DeploymentConditionBuilder::deployment_available(&dplmt),
+            ClusterConditionStatus::True
+        );
+    }
+
+    #[test]
+    fn unavailable() {
+        let dplmt = build_deployment(3, 2);
+
+        assert_eq!(
+            DeploymentConditionBuilder::deployment_available(&dplmt),
+            ClusterConditionStatus::False
+        );
+
+        let dplmt = build_deployment(3, 4);
+
+        assert_eq!(
+            DeploymentConditionBuilder::deployment_available(&dplmt),
+            ClusterConditionStatus::False
+        );
+    }
+
+    #[test]
+    fn condition_available() {
+        let mut dplmt_condition_builder = DeploymentConditionBuilder::default();
+        dplmt_condition_builder.add(build_deployment(3, 3));
+
+        let conditions = dplmt_condition_builder.build_conditions();
+
+        let got = conditions
+            .conditions
+            .get::<usize>(ClusterConditionType::Available.into())
+            .cloned()
+            .unwrap()
+            .unwrap();
+
+        let expected = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::True,
+            ..ClusterCondition::default()
+        };
+
+        assert_eq!(got.type_, expected.type_);
+        assert_eq!(got.status, expected.status);
+    }
+
+    #[test]
+    fn condition_unavailable() {
+        let mut dplmt_condition_builder = DeploymentConditionBuilder::default();
+        dplmt_condition_builder.add(build_deployment(3, 2));
+
+        let conditions = dplmt_condition_builder.build_conditions();
+
+        let got = conditions
+            .conditions
+            .get::<usize>(ClusterConditionType::Available.into())
+            .cloned()
+            .unwrap()
+            .unwrap();
+
+        let expected = ClusterCondition {
+            type_: ClusterConditionType::Available,
+            status: ClusterConditionStatus::False,
+            ..ClusterCondition::default()
+        };
+
+        assert_eq!(got.type_, expected.type_);
+        assert_eq!(got.status, expected.status);
+    }
+}

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -167,10 +167,10 @@ mod tests {
 
     #[test]
     fn condition_unavailable() {
-        let mut dplmt_condition_builder = DeploymentConditionBuilder::default();
-        dplmt_condition_builder.add(build_deployment(3, 2));
+        let mut deployment_condition_builder = DeploymentConditionBuilder::default();
+        deployment_condition_builder.add(build_deployment(3, 2));
 
-        let conditions = dplmt_condition_builder.build_conditions();
+        let conditions = deployment_condition_builder.build_conditions();
 
         let got = conditions
             .conditions

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -25,8 +25,8 @@ impl ConditionBuilder for DeploymentConditionBuilder {
 }
 
 impl DeploymentConditionBuilder {
-    pub fn add(&mut self, dplmt: Deployment) {
-        self.deployments.push(dplmt);
+    pub fn add(&mut self, deployment: Deployment) {
+        self.deployments.push(deployment);
     }
 
     fn available(&self) -> ClusterCondition {

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -126,17 +126,17 @@ mod tests {
 
     #[test]
     fn unavailable() {
-        let dplmt = build_deployment(3, 2);
+        let deployment = build_deployment(3, 2);
 
         assert_eq!(
-            DeploymentConditionBuilder::deployment_available(&dplmt),
+            DeploymentConditionBuilder::deployment_available(&deployment),
             ClusterConditionStatus::False
         );
 
         let dplmt = build_deployment(3, 4);
 
         assert_eq!(
-            DeploymentConditionBuilder::deployment_available(&dplmt),
+            DeploymentConditionBuilder::deployment_available(&deployment),
             ClusterConditionStatus::False
         );
     }

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -143,10 +143,10 @@ mod tests {
 
     #[test]
     fn condition_available() {
-        let mut dplmt_condition_builder = DeploymentConditionBuilder::default();
-        dplmt_condition_builder.add(build_deployment(3, 3));
+        let mut deployment_condition_builder = DeploymentConditionBuilder::default();
+        deployment_condition_builder.add(build_deployment(3, 3));
 
-        let conditions = dplmt_condition_builder.build_conditions();
+        let conditions = deployment_condition_builder.build_conditions();
 
         let got = conditions
             .conditions

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -32,11 +32,11 @@ impl DeploymentConditionBuilder {
     fn available(&self) -> ClusterCondition {
         let mut available = ClusterConditionStatus::True;
         let mut unavailable_resources = vec![];
-        for dplmt in &self.deployments {
-            let current_status = Self::deployment_available(dplmt);
+        for deployment in &self.deployments {
+            let current_status = Self::deployment_available(deployment);
 
             if current_status != ClusterConditionStatus::True {
-                unavailable_resources.push(dplmt.name_any())
+                unavailable_resources.push(deployment.name_any())
             }
 
             available = cmp::max(available, current_status);

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -133,7 +133,7 @@ mod tests {
             ClusterConditionStatus::False
         );
 
-        let dplmt = build_deployment(3, 4);
+        let deployment = build_deployment(3, 4);
 
         assert_eq!(
             DeploymentConditionBuilder::deployment_available(&deployment),

--- a/crates/stackable-operator/src/status/condition/deployment.rs
+++ b/crates/stackable-operator/src/status/condition/deployment.rs
@@ -71,13 +71,13 @@ impl DeploymentConditionBuilder {
     /// Returns a condition "Available: True" if the number of requested replicas matches
     /// the number of available replicas. In addition, there needs to be at least one replica
     /// available.
-    fn deployment_available(dplmt: &Deployment) -> ClusterConditionStatus {
-        let requested_replicas = dplmt
+    fn deployment_available(deployment: &Deployment) -> ClusterConditionStatus {
+        let requested_replicas = deployment
             .spec
             .as_ref()
             .and_then(|spec| spec.replicas)
             .unwrap_or_default();
-        let available_replicas = dplmt
+        let available_replicas = deployment
             .status
             .as_ref()
             .and_then(|status| status.available_replicas)

--- a/crates/stackable-operator/src/status/condition/mod.rs
+++ b/crates/stackable-operator/src/status/condition/mod.rs
@@ -1,4 +1,5 @@
 pub mod daemonset;
+pub mod deployment;
 pub mod operations;
 pub mod statefulset;
 


### PR DESCRIPTION
# Description

Part of : https://github.com/stackabletech/spark-k8s-operator/issues/284

This is a literal adaptation of the `StatefulSetConditionBuilder` because cleanup and consolidation are out of scope for the issue above.

Condition builders are used by SDP operators to monitor workloads and update stacklet status fields in a standardized way. This adds a condition builder for `Deployments`.
 
## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
