### PR TITLE
feat(stackable-telemetry): Allow customization of the rolling file appender rotation period

### DIFF
--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::{
 use opentelemetry_semantic_conventions::resource;
 use snafu::{ResultExt as _, Snafu};
 use tracing::subscriber::SetGlobalDefaultError;
-use tracing_appender::rolling::{InitError, RollingFileAppender, Rotation};
+use tracing_appender::rolling::{InitError, RollingFileAppender};
 use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Layer, Registry};
 
 use crate::tracing::settings::*;
@@ -275,6 +275,7 @@ impl Tracing {
         if let FileLogSettings::Enabled {
             common_settings,
             file_log_dir,
+            rotation_period,
         } = &self.file_log_settings
         {
             let env_filter_layer = env_filter_builder(
@@ -283,7 +284,7 @@ impl Tracing {
             );
 
             let file_appender = RollingFileAppender::builder()
-                .rotation(Rotation::HOURLY)
+                .rotation(rotation_period.clone())
                 .filename_prefix(self.service_name.to_string())
                 .filename_suffix("tracing-rs.json")
                 .max_log_files(6)
@@ -592,6 +593,7 @@ mod test {
     use rstest::rstest;
     use settings::Settings;
     use tracing::level_filters::LevelFilter;
+    use tracing_appender::rolling::Rotation;
 
     use super::*;
 
@@ -726,7 +728,8 @@ mod test {
                     environment_variable: "ABC_FILE",
                     default_level: LevelFilter::INFO
                 },
-                file_log_dir: PathBuf::from("/abc_file_dir")
+                file_log_dir: PathBuf::from("/abc_file_dir"),
+                rotation_period: Rotation::NEVER,
             }
         );
         assert_eq!(

--- a/crates/stackable-telemetry/src/tracing/settings/file_log.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/file_log.rs
@@ -2,6 +2,9 @@
 
 use std::path::PathBuf;
 
+/// Re-export to save the end crate
+pub use tracing_appender::rolling::Rotation;
+
 use super::{Settings, SettingsToggle};
 
 /// Configure specific settings for the File Log subscriber.
@@ -18,6 +21,9 @@ pub enum FileLogSettings {
 
         /// Path to directory for log files.
         file_log_dir: PathBuf,
+
+        /// Log rotation frequency.
+        rotation_period: Rotation,
     },
 }
 
@@ -38,14 +44,22 @@ impl SettingsToggle for FileLogSettings {
 pub struct FileLogSettingsBuilder {
     pub(crate) common_settings: Settings,
     pub(crate) file_log_dir: PathBuf,
+    pub(crate) rotation_period: Rotation,
 }
 
 impl FileLogSettingsBuilder {
+    /// Set file rotation period.
+    pub fn with_rotation_period(mut self, rotation_period: Rotation) -> Self {
+        self.rotation_period = rotation_period;
+        self
+    }
+
     /// Consumes self and returns a valid [`FileLogSettings`] instance.
     pub fn build(self) -> FileLogSettings {
         FileLogSettings::Enabled {
             common_settings: self.common_settings,
             file_log_dir: self.file_log_dir,
+            rotation_period: self.rotation_period,
         }
     }
 }
@@ -76,11 +90,13 @@ mod test {
                 default_level: LevelFilter::DEBUG,
             },
             file_log_dir: PathBuf::from("/logs"),
+            rotation_period: Rotation::HOURLY,
         };
         let result = Settings::builder()
             .with_environment_variable("hello")
             .with_default_level(LevelFilter::DEBUG)
             .file_log_settings_builder(PathBuf::from("/logs"))
+            .with_rotation_period(Rotation::HOURLY)
             .build();
 
         assert_eq!(expected, result);

--- a/crates/stackable-telemetry/src/tracing/settings/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/mod.rs
@@ -92,6 +92,7 @@ impl SettingsBuilder {
         FileLogSettingsBuilder {
             common_settings: self.build(),
             file_log_dir: path.as_ref().to_path_buf(),
+            rotation_period: Rotation::NEVER,
         }
     }
 


### PR DESCRIPTION
# Description

Part of <https://github.com/stackabletech/issues/issues/639>.

Allow the rotation period to be configurable (defaults to `Never`).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
