### PR TITLE
chore: Release stackable-operator 0.88.0, stackable-versioned 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.87.5"
+version = "0.88.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3346,14 +3346,14 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "stackable-versioned-macros",
 ]
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "convert_case",
  "darling",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Deprecate `stackable_operator::logging::initialize_logging()`. It's recommended to use `stackable-telemetry` instead ([#950], [#989]).
+- Deprecate `stackable_operator::logging::initialize_logging()`.
+  It's recommended to use `stackable-telemetry` or `#[allow(deprecated)]` instead ([#950], [#989]).
 
 [#950]: https://github.com/stackabletech/operator-rs/pull/950
 [#989]: https://github.com/stackabletech/operator-rs/pull/989

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.88.0] - 2025-04-01
+## [0.88.0] - 2025-04-02
 
 ### Added
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.88.0] - 2025-04-01
+
 ### Added
 
 - Add Deployments to `ClusterResource`s ([#992]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.87.5"
+version = "0.88.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -149,7 +149,7 @@ pub enum Error {
 ///             Settings::builder()
 ///                 .with_environment_variable("TEST_FILE_LOG")
 ///                 .with_default_level(LevelFilter::INFO)
-///                 .file_log_settings_builder("/tmp/logs")
+///                 .file_log_settings_builder("/tmp/logs", "tracing-rs.log")
 ///                 .build()
 ///         )
 ///         .with_otlp_log_exporter(otlp_log_flag.then(|| {

--- a/crates/stackable-telemetry/src/tracing/settings/file_log.rs
+++ b/crates/stackable-telemetry/src/tracing/settings/file_log.rs
@@ -113,7 +113,7 @@ mod test {
         let result = Settings::builder()
             .with_environment_variable("hello")
             .with_default_level(LevelFilter::DEBUG)
-            .file_log_settings_builder(PathBuf::from("/logs"), "tracing-rs.json")
+            .file_log_settings_builder(PathBuf::from("/logs"), "tracing-rs.log")
             .with_rotation_period(Rotation::HOURLY)
             .with_max_log_files(6)
             .build();

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.7.0"
+version = "0.7.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.7.1] - 2025-04-01
+## [0.7.1] - 2025-04-02
 
 ### Fixed
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-04-01
+
 ### Fixed
 
 - Correctly emit generic type parameter defaults in enum/struct definition blocks ([#991]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.7.0"
+version = "0.7.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.88.0 and stackable-versioned 0.7.1.

## stackable-operator 0.88.0

### Added

- Add Deployments to `ClusterResource`s ([#992]).
- Add `DeploymentConditionBuilder`  ([#993]).

### Changed

- Deprecate `stackable_operator::logging::initialize_logging()`.
  It's recommended to use `stackable-telemetry` or `#[allow(deprecated)]` instead ([#950], [#989]).

[#950]: https://github.com/stackabletech/operator-rs/pull/950
[#989]: https://github.com/stackabletech/operator-rs/pull/989
[#992]: https://github.com/stackabletech/operator-rs/pull/992
[#993]: https://github.com/stackabletech/operator-rs/pull/993

## stackable-versioned 0.7.1

### Fixed

- Correctly emit generic type parameter defaults in enum/struct definition blocks ([#991]).

[#991]: https://github.com/stackabletech/operator-rs/pull/991