### PR TITLE
chore: Release stackable-operator 0.89.0, stackable-telemetry 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.88.0"
+version = "0.89.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum 0.8.3",
  "futures-util",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.88.0] - 2025-04-02
+## [0.89.0] - 2025-04-02
 
 ### Added
 
@@ -14,13 +14,6 @@ All notable changes to this project will be documented in this file.
   - `--rolling-logs-period`: Sets the time period after which log files are rolled over
   - `--otlp-traces`: Enables exporting of traces via OTLP
   - `--otlp-logs`: Enables exporting of logs via OTLP
-- Add Deployments to `ClusterResource`s ([#992]).
-- Add `DeploymentConditionBuilder`  ([#993]).
-
-### Changed
-
-- Deprecate `stackable_operator::logging::initialize_logging()`.
-  It's recommended to use `stackable-telemetry` or `#[allow(deprecated)]` instead ([#950], [#989]).
 
 ### Removed
 
@@ -29,8 +22,21 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Remove `initialize_logging` helper function from `stackable_operator::logging` ([#977]).
 - Remove `opentelemetry-jaeger` dependency ([#977]).
 
-[#950]: https://github.com/stackabletech/operator-rs/pull/950
 [#977]: https://github.com/stackabletech/operator-rs/pull/977
+
+## [0.88.0] - 2025-04-02
+
+### Added
+
+- Add Deployments to `ClusterResource`s ([#992]).
+- Add `DeploymentConditionBuilder`  ([#993]).
+
+### Changed
+
+- Deprecate `stackable_operator::logging::initialize_logging()`.
+  It's recommended to use `stackable-telemetry` or `#[allow(deprecated)]` instead ([#950], [#989]).
+
+[#950]: https://github.com/stackabletech/operator-rs/pull/950
 [#989]: https://github.com/stackabletech/operator-rs/pull/989
 [#992]: https://github.com/stackabletech/operator-rs/pull/992
 [#993]: https://github.com/stackabletech/operator-rs/pull/993

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.88.0"
+version = "0.89.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-04-02
+
 ### Added
 
 - BREAKING: Allow customization of the rolling file appender [#995].

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.89.0 and stackable-telemetry 0.4.0.

## stackable-operator 0.89.0

### Added

- Add more granular telemetry related arguments to `ProductOperatorRun` ([#977]).
  - `--no-console-output`: Disables output of `tracing` events to the console (stdout)
  - `--rolling-logs`: Enables output `tracing` events to a rolling log file
  - `--rolling-logs-period`: Sets the time period after which log files are rolled over
  - `--otlp-traces`: Enables exporting of traces via OTLP
  - `--otlp-logs`: Enables exporting of logs via OTLP

### Removed

- BREAKING: Remove `--tracing-target` argument and field from `ProductOperatorRun`.
  Use the new, more granular arguments instead ([#977]).
- BREAKING: Remove `initialize_logging` helper function from `stackable_operator::logging` ([#977]).
- Remove `opentelemetry-jaeger` dependency ([#977]).

[#977]: https://github.com/stackabletech/operator-rs/pull/977

## stackable-telemetry 0.4.0

### Added

- BREAKING: Allow customization of the rolling file appender [#995].
  - Add required `filename_suffix` field.
  - Add `with_rotation_period` method.
  - Add `with_max_log_files` method.

### Changed

- Bump OpenTelemetry related dependencies ([#977]).
  - `opentelemetry` to 0.28.0
  - `opentelemetry_sdk` to 0.28.0
  - `opentelemetry-appender-tracing` to 0.28.0
  - `opentelemetry-otlp` to 0.28.0
  - `opentelemetry-semantic-conventions` to 0.28.0
  - `tracing-opentelemetry` to 0.29.0

[#977]: https://github.com/stackabletech/operator-rs/pull/977
[#995]: https://github.com/stackabletech/operator-rs/pull/995