### PR TITLE
chore: Release stackable-operator 0.90.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.89.1"
+version = "0.90.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.90.0] - 2025-04-07
+
 ### Added
 
 - BREAKING: Inject vector aggregator address into vector config file using an environment variable ([#1000]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.89.1"
+version = "0.90.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.90.0

### Changed

- BREAKING: Inject vector aggregator address into vector config file using an environment variable ([#1000]).

[#1000]: https://github.com/stackabletech/operator-rs/pull/1000