### PR TITLE
chore: Address rustsec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -20,34 +20,6 @@ ignore = [
     # TODO: Remove after https://github.com/RustCrypto/RSA/pull/394 is merged and v0.10.0 is released
     "RUSTSEC-2023-0071",
 
-    # https://rustsec.org/advisories/RUSTSEC-2024-0384
-    # "instant" is unmaintained
-    #
-    # The upstream "kube" crate also silenced this in https://github.com/kube-rs/kube/commit/4f1e889f265da8f19f03f60683569cae1a154fda
-    # They/we are actively working on migrating kube from backoff to backon, which removes the transitive dependency on
-    # instant, in https://github.com/kube-rs/kube/pull/1653.
-    #
-    # TODO: Remove after https://github.com/kube-rs/kube/pull/1653 is released
-    "RUSTSEC-2024-0384",
-
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0012
-    # The [backoff](https://crates.io/crates/backoff) crate is no longer actively maintained. For exponential backoffs/retrying, you can use the [backon](https://crates.io/crates/backon) crate.
-    # Announcement: https://github.com/ihrwein/backoff/issues/66
-    #
-    # TODO: Remove after https://github.com/kube-rs/kube/pull/1653 is released
-    "RUSTSEC-2025-0012",
-
-    # Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
-    # The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md)
-    # that this project is not longer maintained as well as archived the repository
-    # Announcement: https://github.com/dtolnay/paste
-    #
-    # This comes in via aws-lc-rs. There is a PR open to migrate from `paste` to `concat-idents`.
-    # https://github.com/aws/aws-lc-rs/pull/723
-    #
-    # TODO: Remove after the migration is done and aws-lc-rs doesn't use paste anymore.
-    "RUSTSEC-2024-0436",
-
 ]
 
 [bans]


### PR DESCRIPTION
# Description

- Remove advisories RUSTSEC-2024-0384, RUSTSEC-2024-0436 & RUSTSEC-2025-0012 from ignore list as they are no longer encountered.
- bump `tokio` to `1.44.2`
