### PR TITLE
chore: Release stackable-operator 0.91.0, stackable-telemetry 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum 0.8.3",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.91.0] - 2025-04-08
+
 ### Changed
 
 - BREAKING: Remove `cli::TelemetryArguments` and `cli::RollingPeriod` which are both replaced by

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.90.0"
+version = "0.91.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-04-08
+
 ### Added
 
 - Add new `Tracing::pre_configured` method ([#1001]).

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.91.0 and stackable-telemetry 0.5.0.

## stackable-operator 0.91.0

### Changed

- BREAKING: Remove `cli::TelemetryArguments` and `cli::RollingPeriod` which are both replaced by
  types from `stackable_telemetry` ([#1001]).
- BREAKING: The `ProductOperatorRun` struct now uses `stackable_telemetry::tracing::TelemetryOptions`
  for the `telemetry_arguments` field ([#1001]).

## stackable-telemetry 0.5.0

### Added

- Add new `Tracing::pre_configured` method ([#1001]).
  - Add `TelemetryOptions` struct and `RollingPeriod` enum
  - Add `clap` feature to enable `TelemetryOptions` being used as CLI arguments

### Changed

- BREAKING: Change `FileLogSettingsBuilder::with_rotation_period` to take `impl Into<Rotation>`
  instead of `Rotation` ([#1001]).

[#1001]: https://github.com/stackabletech/operator-rs/pull/1001