### PR TITLE
feat: Add re-exports to stackable-operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "stackable-operator-derive",
  "stackable-shared",
  "stackable-telemetry",
+ "stackable-versioned",
  "strum",
  "tempfile",
  "time",

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -8,10 +8,15 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
+full = ["time", "telemetry", "versioned"]
+default = ["telemetry", "versioned"]
 time = ["dep:time"]
+telemetry = []
+versioned = []
 
 [dependencies]
-stackable-telemetry = { path = "../stackable-telemetry", features = ["clap"]}
+stackable-telemetry = { path = "../stackable-telemetry", features = ["clap"] }
+stackable-versioned = { path = "../stackable-versioned", features = ["k8s"] }
 stackable-operator-derive = { path = "../stackable-operator-derive" }
 stackable-shared = { path = "../stackable-shared" }
 

--- a/crates/stackable-operator/src/lib.rs
+++ b/crates/stackable-operator/src/lib.rs
@@ -1,3 +1,11 @@
+//! ## Crate Features
+//!
+//! - `default` enables a default set of features which most operators need.
+//! - `full` enables all available features.
+//! - `time` enables interoperability between [`time::Duration`] and the `time` crate.
+//! - `telemetry` enables various helpers for emitting telemetry data.
+//! - `versioned` enables the macro for CRD versioning.
+
 pub mod builder;
 pub mod cli;
 pub mod client;
@@ -21,14 +29,16 @@ pub mod time;
 pub mod utils;
 pub mod validation;
 
-// Internal re-exports
-pub use stackable_shared::{crd::CustomResourceExt, yaml::YamlSchema};
-
-pub mod shared {
-    pub use stackable_shared::*;
-}
-
 // External re-exports
-pub use ::k8s_openapi;
-pub use ::kube;
-pub use ::schemars;
+pub use k8s_openapi;
+pub use kube;
+pub use schemars;
+// Internal re-exports
+// TODO (@Techassi): Ideally we would want webhook and certs exported here as
+// well, but that would require some restructuring of crates.
+pub use stackable_shared as shared;
+pub use stackable_shared::{crd::CustomResourceExt, yaml::YamlSchema};
+#[cfg(feature = "telemetry")]
+pub use stackable_telemetry as telemetry;
+#[cfg(feature = "versioned")]
+pub use stackable_versioned as versioned;


### PR DESCRIPTION
This PR adds the following:

- Two new re-exports:
	- `stackable-telemetry` as `telemetry`
	- `stackable-versioned` as `versioned`
- Four new features:
	- `default`, which provides sane default features
	- `full`, which enables all features
	- `telemetry` which enables the `telemetry` re-export
	- `versioned` which enables the `versioned` re-export