### PR TITLE
chore: Release stackable-operator 0.92.0, stackable-telemetry 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.91.1"
+version = "0.92.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum 0.8.3",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.92.0] - 2025-04-14
+
 ### Added
 
 - Adds new CLI arguments and environment variables ([#1010], [#1012]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.91.1"
+version = "0.92.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-04-14
+
 ### Added
 
 - Add support for JSON console log output ([#1012]).

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.92.0 and stackable-telemetry 0.6.0.

## stackable-operator 0.92.0

### Added

- Adds new CLI arguments and environment variables ([#1010], [#1012]).
  - Use `--file-log-max-files` (or `FILE_LOG_MAX_FILES`) to limit the number of log files kept.
  - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
  - See detailed [stackable-telemetry changelog](../stackable-telemetry/CHANGELOG.md).

### Changed

- BREAKING: Update and align telemetry related CLI arguments of `ProductOperatorRun`, see detailed
  changelog [stackable-telemetry changelog](../stackable-telemetry/CHANGELOG.md) ([#1009]).

[#1009]: https://github.com/stackabletech/operator-rs/pull/1009
[#1010]: https://github.com/stackabletech/operator-rs/pull/1010
[#1012]: https://github.com/stackabletech/operator-rs/pull/1012

## stackable-telemetry 0.6.0

### Added

- Add support for JSON console log output ([#1012]).
  - A new CLI argument was added: `--console-log-format`. It can be set to `plain` (default),
    or `json`.

### Changed

- BREAKING: Update and align telemetry related CLI arguments in `TelemetryOptions` ([#1009]).
  - `--console-log-disabled` instead of `--no-console-output`.
  - `--file-log-directory` instead of `--rolling-logs`.
  - `--file-log-rotation-period` instead of `--rolling-logs-period`.
  - `--otel-log-exporter-enabled` instead of `--otlp-logs`.
  - `--otel-trace-exporter-enabled` instead of `--otlp-traces`.
- BREAKING: Update and align telemetry related environment variables ([#1009]).
  - `CONSOLE_LOG_LEVEL` instead of `CONSOLE_LOG`.
  - `FILE_LOG_LEVEL` instead of `FILE_LOG`.
  - `OTEL_LOG_EXPORTER_LEVEL` instead of `OTLP_LOG`.
  - `OTEL_TRACE_EXPORTER_LEVEL` instead of `OTLP_TRACE`.
- BREAKING: Allow configuration of `file_log_max_files` ([#1010]).
  - Adds the `--file-log-max-files` CLI argument (env: `FILE_LOG_MAX_FILES`).
  - `FileLogSettingsBuilder::with_max_log_files` which took a `usize` was renamed to
    `FileLogSettingsBuilder::with_max_files` and now takes an `impl Into<Option<usize>>`
    for improved builder ergonomics.

[#1009]: https://github.com/stackabletech/operator-rs/pull/1009
[#1010]: https://github.com/stackabletech/operator-rs/pull/1010
[#1012]: https://github.com/stackabletech/operator-rs/pull/1012