### PR TITLE
chore: Correct stackable-operator changelog

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: Version common CRD structs and enums ([#968]).
+  - All CRD-related types and function now reside in the `stackable_operator::crd` module.
+  - Each CRD-related struct and enum has been versioned. The initial version is `v1alpha1`.
+  - The `static` authentication provider must now be imported using `r#static`.
+  - Import are now more granular in general.
+
+[#968]: https://github.com/stackabletech/operator-rs/pull/968
+
 ## [0.92.0] - 2025-04-14
 
 ### Added
@@ -48,15 +58,6 @@ All notable changes to this project will be documented in this file.
 
 - BREAKING: Inject vector aggregator address into vector config file using an environment variable ([#1000]).
 
-### Changed
-
-- BREAKING: Version common CRD structs and enums ([#968]).
-  - All CRD-related types and function now reside in the `stackable_operator::crd` module.
-  - Each CRD-related struct and enum has been versioned. The initial version is `v1alpha1`.
-  - The `static` authentication provider must now be imported using `r#static`.
-  - Import are now more granular in general.
-
-[#968]: https://github.com/stackabletech/operator-rs/pull/968
 [#1000]: https://github.com/stackabletech/operator-rs/pull/1000
 
 ## [0.89.1] - 2025-04-02


### PR DESCRIPTION
#968 introduced a slightly wrong changelog which is corrected by this PR.