### PR TITLE
chore: Remove instrumentation from trivial functions

### DIFF
--- a/crates/stackable-operator/src/builder/pod/container.rs
+++ b/crates/stackable-operator/src/builder/pod/container.rs
@@ -7,7 +7,6 @@ use k8s_openapi::api::core::v1::{
     SecurityContext, VolumeMount,
 };
 use snafu::{ResultExt as _, Snafu};
-use tracing::instrument;
 #[cfg(doc)]
 use {k8s_openapi::api::core::v1::PodSpec, std::collections::BTreeMap};
 
@@ -211,7 +210,6 @@ impl ContainerBuilder {
     ///
     /// Previously, this function unconditionally added [`VolumeMount`]s, which resulted in invalid
     /// [`PodSpec`]s.
-    #[instrument(skip(self))]
     fn add_volume_mount_impl(&mut self, volume_mount: VolumeMount) -> Result<&mut Self> {
         if let Some(existing_volume_mount) = self.volume_mounts.get(&volume_mount.mount_path) {
             if existing_volume_mount != &volume_mount {

--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -10,7 +10,6 @@ use k8s_openapi::{
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
 };
 use snafu::{OptionExt, ResultExt, Snafu};
-use tracing::warn;
 
 use crate::{
     builder::{
@@ -609,19 +608,19 @@ impl PodBuilder {
 
         pod_spec
             .check_resource_requirement(ResourceRequirementsType::Limits, "cpu")
-            .unwrap_or_else(|err| warn!("{}", err));
+            .unwrap_or_else(|err| tracing::warn!("{err}"));
 
         pod_spec
             .check_resource_requirement(ResourceRequirementsType::Limits, "memory")
-            .unwrap_or_else(|err| warn!("{}", err));
+            .unwrap_or_else(|err| tracing::warn!("{err}"));
 
         pod_spec
             .check_limit_to_request_ratio(&ComputeResource::Cpu, LIMIT_REQUEST_RATIO_CPU)
-            .unwrap_or_else(|err| warn!("{}", err));
+            .unwrap_or_else(|err| tracing::warn!("{err}"));
 
         pod_spec
             .check_limit_to_request_ratio(&ComputeResource::Memory, LIMIT_REQUEST_RATIO_MEMORY)
-            .unwrap_or_else(|err| warn!("{}", err));
+            .unwrap_or_else(|err| tracing::warn!("{err}"));
 
         pod_spec
     }

--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -10,7 +10,7 @@ use k8s_openapi::{
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
 };
 use snafu::{OptionExt, ResultExt, Snafu};
-use tracing::{instrument, warn};
+use tracing::warn;
 
 use crate::{
     builder::{
@@ -291,7 +291,6 @@ impl PodBuilder {
     ///
     /// Previously, this function unconditionally added [`Volume`]s, which resulted in invalid
     /// [`PodSpec`]s.
-    #[instrument(skip(self))]
     pub fn add_volume(&mut self, volume: Volume) -> Result<&mut Self> {
         if let Some(existing_volume) = self.volumes.get(&volume.name) {
             if existing_volume != &volume {


### PR DESCRIPTION
Loosely related to https://github.com/stackabletech/issues/issues/639

These functions are not cpu/io bound, so they are rather uninteresting in the context of tracing. This change will reduce a lot of unnecessary noise from traces.

Also fully-qualified usages of `tracing::*`