### PR TITLE
chore: Release k8s-version 0.1.3 and stackable-operator 0.93.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.92.0"
+version = "0.93.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "k8s-version"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/k8s-version/CHANGELOG.md
+++ b/crates/k8s-version/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.3] - 2025-05-19
+
 ### Added
 
 - Add support for serialization and deserialization via `serde`. This feature is enabled via the

--- a/crates/k8s-version/Cargo.toml
+++ b/crates/k8s-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k8s-version"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.93.0] - 2025-05-19
+
 ### Changed
 
 - BREAKING: Version common CRD structs and enums ([#968]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.92.0"
+version = "0.93.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases k8s-version 0.1.3 and stackable-operator 0.93.0:

## k8s-version 0.1.3

### Added

- Add support for serialization and deserialization via `serde`. This feature is enabled via the
  `serde` feature flag ([#1034]).

[#1034]: https://github.com/stackabletech/operator-rs/pull/1034

## stackable-operator 0.93.0

### Changed

- BREAKING: Version common CRD structs and enums ([#968]).
  - All CRD-related types and function now reside in the `stackable_operator::crd` module.
  - Each CRD-related struct and enum has been versioned. The initial version is `v1alpha1`.
  - The `static` authentication provider must now be imported using `r#static`.
  - Import are now more granular in general.
- BREAKING: Update to `kube` to `1.0.0` and `k8s-openapi` to `0.25.0`.
  Use k8s `1.33` for compilation ([#1037]).

### Fixed

- Re-export versioned CRD-specific error types ([#1025]).
- Re-export versioned common CRD enums ([#1029]).

[#968]: https://github.com/stackabletech/operator-rs/pull/968
[#1025]: https://github.com/stackabletech/operator-rs/pull/1025
[#1029]: https://github.com/stackabletech/operator-rs/pull/1029
[#1037]: https://github.com/stackabletech/operator-rs/pull/1037