### PR TITLE
chore(stackable-operator): Separate some developer docs from CRD descriptions

### DIFF
--- a/crates/stackable-operator/src/crd/authentication/core/mod.rs
+++ b/crates/stackable-operator/src/crd/authentication/core/mod.rs
@@ -127,11 +127,13 @@ pub mod versioned {
     #[serde(rename_all = "camelCase")]
     #[schemars(description = "")]
     pub struct ClientAuthenticationDetails<O = ()> {
-        /// Name of the [AuthenticationClass](https://docs.stackable.tech/home/nightly/concepts/authentication) used to
-        /// authenticate users.
+        /// Name of the [`AuthenticationClass`] used to authenticate users.
         ///
         /// To get the concrete [`AuthenticationClass`], we must resolve it. This resolution can be
         /// achieved by using [`ClientAuthenticationDetails::resolve_class`].
+        #[schemars(
+            description = "Name of the [AuthenticationClass](DOCS_BASE_URL_PLACEHOLDER/concepts/authentication) used to authenticate users"
+        )]
         #[serde(rename = "authenticationClass")]
         authentication_class_ref: String,
 
@@ -145,6 +147,9 @@ pub mod versioned {
         // added, so that user can not configure multiple options at the same time (yes we are aware
         // that this makes a changing the type of an AuthenticationClass harder). This is a
         // non-breaking change though :)
+        #[schemars(
+            description = "This field contains OIDC-specific configuration. It is only required in case OIDC is used."
+        )]
         oidc: Option<oidc::v1alpha1::ClientAuthenticationOptions<O>>,
     }
 }

--- a/crates/stackable-operator/src/crd/authentication/oidc/mod.rs
+++ b/crates/stackable-operator/src/crd/authentication/oidc/mod.rs
@@ -105,6 +105,9 @@ pub mod versioned {
         /// defined in the [`AuthenticationClass`][1].
         ///
         /// [1]: crate::crd::authentication::core::v1alpha1::AuthenticationClass
+        #[schemars(
+            description = "An optional list of extra scopes which get merged with the scopes defined in the `AuthenticationClass`."
+        )]
         #[serde(default)]
         pub extra_scopes: Vec<String>,
 


### PR DESCRIPTION
The audience for doc-comments are quite different to those for the hosted CRD docs, so we should override CRD descriptions when they contain developer-level details.

> [!NOTE]
> There are likely more changes required, but these are the few I noticed when bumping stackable-operator for druid-operator.

![image](https://github.com/user-attachments/assets/fb9ed9f9-2a67-4c77-b61f-5e46b382005b)

# Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
