### PR TITLE
chore: Release stackable-operator 0.93.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.93.1] - 2025-05-20
+
 ### Added
 
 - Add git-sync support ([#1024]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.93.0"
+version = "0.93.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.93.1:

### Added

- Add git-sync support ([#1024]).

[#1024]: https://github.com/stackabletech/operator-rs/pull/1024