### PR TITLE
fix(stackable-versioned): Correctly emit `#[kube(status = ...)]` attribute

### DIFF
--- a/crates/stackable-versioned-macros/tests/inputs/k8s/pass/basic.rs
+++ b/crates/stackable-versioned-macros/tests/inputs/k8s/pass/basic.rs
@@ -8,6 +8,7 @@ use stackable_versioned::versioned;
         group = "stackable.tech",
         singular = "foo",
         plural = "foos",
+        status = FooStatus,
         namespaced,
     )
 )]
@@ -25,6 +26,11 @@ pub(crate) struct FooSpec {
 }
 // ---
 fn main() {}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct FooStatus {
+    is_foo: bool,
+}
 
 fn usize_to_u16(input: usize) -> u16 {
     input.try_into().unwrap()

--- a/crates/stackable-versioned-macros/tests/snapshots/stackable_versioned_macros__snapshot_tests__k8s@basic.rs.snap
+++ b/crates/stackable-versioned-macros/tests/snapshots/stackable_versioned_macros__snapshot_tests__k8s@basic.rs.snap
@@ -20,7 +20,8 @@ pub(crate) mod v1alpha1 {
         kind = "Foo",
         singular = "foo",
         plural = "foos",
-        namespaced
+        namespaced,
+        status = FooStatus
     )]
     pub struct FooSpec {
         pub baz: bool,
@@ -60,7 +61,8 @@ pub(crate) mod v1beta1 {
         kind = "Foo",
         singular = "foo",
         plural = "foos",
-        namespaced
+        namespaced,
+        status = FooStatus
     )]
     pub struct FooSpec {
         pub bah: u16,
@@ -102,7 +104,8 @@ pub(crate) mod v1 {
         kind = "Foo",
         singular = "foo",
         plural = "foos",
-        namespaced
+        namespaced,
+        status = FooStatus
     )]
     pub struct FooSpec {
         pub bar: usize,

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix regression introduced in [#1033]. The `#[kube(status = ...)]` attribute is generated correctly
+  again ([#1046]).
 - Correctly handle fields added in later versions ([#1031]).
 
 ### Removed
@@ -41,6 +43,7 @@ All notable changes to this project will be documented in this file.
 [#1033]: https://github.com/stackabletech/operator-rs/pull/1033
 [#1038]: https://github.com/stackabletech/operator-rs/pull/1038
 [#1041]: https://github.com/stackabletech/operator-rs/pull/1041
+[#1046]: https://github.com/stackabletech/operator-rs/pull/1046
 
 ## [0.7.1] - 2025-04-02
 


### PR DESCRIPTION
With this fix, the macro correctly generates the `#[kube(status = ...)]` attribute again. This regression was accidentally introduced in #1033.