### PR TITLE
chore: Use the default profile for the stable Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.85.0"
+profile = "default"


### PR DESCRIPTION
This fixes the current pre-commit (clippy) failures by installing the "default" profile.

In the future, we want to instead explicitly list the components for each toolchain in the `pre-commit` action instead. This will internally most likely use a custom "install rust" action which allows to install multiple toolchains at once.