### PR TITLE
feat!(stackable-certs): Support adding SAN entries

### DIFF
--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - BREAKING: `CertificateAuthority::generate_leaf_certificate` (and `generate_rsa_leaf_certificate` and `generate_ecdsa_leaf_certificate`)
   now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
-  this is needed for basically all modern TLS certificate validations when used with HTTPS.
+  this is needed when the HTTPS server is accessible on multiple DNS names and/or IPs.
   Pass an empty list (`[]`) to keep the existing behavior ([#1057]).
 - BREAKING: The constant `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
   Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#1057]).

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- BREAKING: `CertificateAuthority::generate_leaf_certificate` (and `generate_rsa_leaf_certificate` and `generate_ecdsa_leaf_certificate`)
+  now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
+  this is needed for basically all modern TLS certificate validations when used with HTTPS.
+  Pass an empty list (`[]`) to keep the existing behavior ([#1044]).
+- BREAKING: The constant `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
+  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#1044]).
+- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1044]).
+
 ## [0.3.1] - 2024-07-10
 
 ### Changed
@@ -11,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Bump rust-toolchain to 1.79.0 ([#822]).
 
 [#822]: https://github.com/stackabletech/operator-rs/pull/822
+[#1044]: https://github.com/stackabletech/operator-rs/pull/1044
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -6,14 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- BREAKING: `CertificateAuthority::generate_leaf_certificate` (and `generate_rsa_leaf_certificate` and `generate_ecdsa_leaf_certificate`)
-  now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
-  this is needed when the HTTPS server is accessible on multiple DNS names and/or IPs.
-  Pass an empty list (`[]`) to keep the existing behavior ([#1057]).
+- Add the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1057]).
+
+### Changed
+
+- BREAKING: The functions `generate_leaf_certificate`, `generate_rsa_leaf_certificate` and
+  `generate_ecdsa_leaf_certificate` of `CertificateAuthority` accept an additional parameter
+  `subject_alterative_dns_names` ([#1057]).
+  - The passed SANs are added to the generated certificate, this is needed when the HTTPS server is
+    accessible on multiple DNS names and/or IPs.
+  - Pass an empty list (`[]`) to keep the existing behavior.
 - BREAKING: Constants have been renamed/retyped ([#1057]):
   - `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
   - `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT`.
-- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1057]).
+
+[#1057]: https://github.com/stackabletech/operator-rs/pull/1057
 
 ## [0.3.1] - 2024-07-10
 
@@ -22,7 +29,6 @@ All notable changes to this project will be documented in this file.
 - Bump rust-toolchain to 1.79.0 ([#822]).
 
 [#822]: https://github.com/stackabletech/operator-rs/pull/822
-[#1057]: https://github.com/stackabletech/operator-rs/pull/1057
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: `CertificateAuthority::generate_leaf_certificate` (and `generate_rsa_leaf_certificate` and `generate_ecdsa_leaf_certificate`)
   now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
   this is needed for basically all modern TLS certificate validations when used with HTTPS.
-  Pass an empty list (`[]`) to keep the existing behavior ([#XXXX]).
+  Pass an empty list (`[]`) to keep the existing behavior ([#1057]).
 - BREAKING: The constant `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
-  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#XXXX]).
-- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#XXXX]).
+  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#1057]).
+- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1057]).
 
 ## [0.3.1] - 2024-07-10
 
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Bump rust-toolchain to 1.79.0 ([#822]).
 
 [#822]: https://github.com/stackabletech/operator-rs/pull/822
+[#1057]: https://github.com/stackabletech/operator-rs/pull/1057
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file.
   now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
   this is needed when the HTTPS server is accessible on multiple DNS names and/or IPs.
   Pass an empty list (`[]`) to keep the existing behavior ([#1057]).
-- BREAKING: The constant `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
-  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#1057]).
+- BREAKING: Constants have been renamed/retyped ([#1057]):
+  - `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
+  - `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT`.
 - Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1057]).
 
 ## [0.3.1] - 2024-07-10

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: `CertificateAuthority::generate_leaf_certificate` (and `generate_rsa_leaf_certificate` and `generate_ecdsa_leaf_certificate`)
   now take an additional parameter `subject_alterative_dns_names`. The passed SANs are added to the generated certificate,
   this is needed for basically all modern TLS certificate validations when used with HTTPS.
-  Pass an empty list (`[]`) to keep the existing behavior ([#1044]).
+  Pass an empty list (`[]`) to keep the existing behavior ([#XXXX]).
 - BREAKING: The constant `DEFAULT_CA_VALIDITY_SECONDS` has been renamed to `DEFAULT_CA_VALIDITY` and now is of type `stackable_operator::time::Duration`.
-  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#1044]).
-- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#1044]).
+  Also, the constant `ROOT_CA_SUBJECT` has been renamed to `SDP_ROOT_CA_SUBJECT` ([#XXXX]).
+- Added the function `CertificateAuthority::ca_cert` to easily get the CA `Certificate` ([#XXXX]).
 
 ## [0.3.1] - 2024-07-10
 
@@ -21,7 +21,6 @@ All notable changes to this project will be documented in this file.
 - Bump rust-toolchain to 1.79.0 ([#822]).
 
 [#822]: https://github.com/stackabletech/operator-rs/pull/822
-[#1044]: https://github.com/stackabletech/operator-rs/pull/1044
 
 ## [0.3.0] - 2024-05-08
 

--- a/crates/stackable-certs/src/ca/consts.rs
+++ b/crates/stackable-certs/src/ca/consts.rs
@@ -1,5 +1,7 @@
+use stackable_operator::time::Duration;
+
 /// The default CA validity time span of one hour (3600 seconds).
-pub const DEFAULT_CA_VALIDITY_SECONDS: u64 = 3600;
+pub const DEFAULT_CA_VALIDITY: Duration = Duration::from_hours_unchecked(1);
 
 /// The root CA subject name containing only the common name.
-pub const ROOT_CA_SUBJECT: &str = "CN=Stackable Data Platform Internal CA";
+pub const SDP_ROOT_CA_SUBJECT: &str = "CN=Stackable Data Platform Internal CA";

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -69,7 +69,7 @@ pub enum Error {
     ParseAuthorityKeyIdentifier { source: x509_cert::der::Error },
 
     #[snafu(display(
-        "failed to parse subject alternative DNS name \"{subject_alternative_dns_name}\" as a Ia5 string"
+        "failed to parse subject alternative DNS name {subject_alternative_dns_name:?} as a Ia5 string"
     ))]
     ParseSubjectAlternativeDnsName {
         subject_alternative_dns_name: String,

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -534,7 +534,7 @@ mod tests {
         );
 
         // Test SAN extension is present
-        let extensions = cert.extensions.as_ref().expect("cert had no extension");
+        let extensions = cert.extensions.as_ref().expect("cert must have extensions");
         assert!(
             extensions
                 .iter()

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -547,7 +547,7 @@ mod tests {
         assert_eq!(
             not_after
                 .duration_since(not_before)
-                .expect("Failed to calculate duration between notBefore and notAfter"),
+                .expect("notBefore must be before notAfter"),
             *TEST_CERT_LIFETIME
         );
     }

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -509,7 +509,9 @@ mod tests {
         let mut ca = CertificateAuthority::new_rsa().unwrap();
         let cert = ca
             .generate_rsa_leaf_certificate("Product", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
-            .expect("Must be able to generate an RSA certificate. Perhaps there was an RNG failure");
+            .expect(
+                "Must be able to generate an RSA certificate. Perhaps there was an RNG failure",
+            );
 
         assert_cert_attributes(cert.certificate());
     }

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -208,9 +208,8 @@ where
         // We don't allow customization of the CA subject by callers. Every CA
         // created by us should contain the same subject consisting a common set
         // of distinguished names (DNs).
-        let subject = Name::from_str(SDP_ROOT_CA_SUBJECT).context(ParseSubjectSnafu {
-            subject: SDP_ROOT_CA_SUBJECT,
-        })?;
+        let subject = Name::from_str(SDP_ROOT_CA_SUBJECT)
+            .expect("The SDP_ROOT_CA_SUBJECT must be a valid subject");
 
         let spki_pem = signing_key_pair
             .verifying_key()

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -521,7 +521,9 @@ mod tests {
         let mut ca = CertificateAuthority::new_ecdsa().unwrap();
         let cert = ca
             .generate_ecdsa_leaf_certificate("Product", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
-            .expect("ecdsa certificate generation failed");
+            .expect(
+                "Must be able to generate an ECDSA certificate. Perhaps there was an RNG failure",
+            );
 
         assert_cert_attributes(cert.certificate());
     }

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -502,13 +502,13 @@ mod tests {
     use super::*;
 
     const TEST_CERT_LIFETIME: Duration = Duration::from_hours_unchecked(1);
-    const TEST_SAN: &str = "airflow-0.airflow.default.svc.cluster.local";
+    const TEST_SAN: &str = "product-0.product.default.svc.cluster.local";
 
     #[tokio::test]
     async fn rsa_key_generation() {
         let mut ca = CertificateAuthority::new_rsa().unwrap();
         let cert = ca
-            .generate_rsa_leaf_certificate("Airflow", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
+            .generate_rsa_leaf_certificate("Product", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
             .expect("Must be able to generate an RSA certificate. Perhaps there was an RNG failure");
 
         assert_cert_attributes(cert.certificate());
@@ -518,7 +518,7 @@ mod tests {
     async fn ecdsa_key_generation() {
         let mut ca = CertificateAuthority::new_ecdsa().unwrap();
         let cert = ca
-            .generate_ecdsa_leaf_certificate("Airflow", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
+            .generate_ecdsa_leaf_certificate("Product", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
             .expect("ecdsa certificate generation failed");
 
         assert_cert_attributes(cert.certificate());
@@ -529,7 +529,7 @@ mod tests {
         // Test subject
         assert_eq!(
             cert.subject,
-            Name::from_str("CN=Airflow Certificate for pod").unwrap()
+            Name::from_str("CN=Product Certificate for pod").unwrap()
         );
 
         // Test SAN extension is present

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -342,11 +342,10 @@ where
         let sans = subject_alterative_dns_names
             .into_iter()
             .map(|dns_name| {
-                let ia5_dns_name = Ia5String::new(dns_name).context(
-                    ParseSubjectAlternativeDnsNameSnafu {
+                let ia5_dns_name =
+                    Ia5String::new(dns_name).context(ParseSubjectAlternativeDnsNameSnafu {
                         subject_alternative_dns_name: dns_name.to_string(),
-                    },
-                )?;
+                    })?;
                 Ok(GeneralName::DnsName(ia5_dns_name))
             })
             .collect::<Result<Vec<_>, Error>>()?;

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -342,11 +342,12 @@ where
         let sans = subject_alterative_dns_names
             .into_iter()
             .map(|dns_name| {
-                Ok(GeneralName::DnsName(Ia5String::new(dns_name).context(
+                let ia5_dns_name = Ia5String::new(dns_name).context(
                     ParseSubjectAlternativeDnsNameSnafu {
                         subject_alternative_dns_name: dns_name.to_string(),
                     },
-                )?))
+                )?;
+                Ok(GeneralName::DnsName(ia5_dns_name))
             })
             .collect::<Result<Vec<_>, Error>>()?;
         builder

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -209,7 +209,7 @@ where
         // created by us should contain the same subject consisting a common set
         // of distinguished names (DNs).
         let subject = Name::from_str(SDP_ROOT_CA_SUBJECT)
-            .expect("The SDP_ROOT_CA_SUBJECT must be a valid subject");
+            .expect("the SDP_ROOT_CA_SUBJECT must be a valid subject");
 
         let spki_pem = signing_key_pair
             .verifying_key()

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -509,7 +509,7 @@ mod tests {
         let mut ca = CertificateAuthority::new_rsa().unwrap();
         let cert = ca
             .generate_rsa_leaf_certificate("Airflow", "pod", [TEST_SAN], TEST_CERT_LIFETIME)
-            .expect("RSA certificate generation failed");
+            .expect("Must be able to generate an RSA certificate. Perhaps there was an RNG failure");
 
         assert_cert_attributes(cert.certificate());
     }

--- a/crates/stackable-certs/src/ca/mod.rs
+++ b/crates/stackable-certs/src/ca/mod.rs
@@ -68,9 +68,11 @@ pub enum Error {
     #[snafu(display("failed to parse AuthorityKeyIdentifier"))]
     ParseAuthorityKeyIdentifier { source: x509_cert::der::Error },
 
-    #[snafu(display("The subject alternative DNS name \"{dns_name}\" is not a Ia5String"))]
-    SaDnsNameNotAIa5String {
-        dns_name: String,
+    #[snafu(display(
+        "failed to parse subject alternative DNS name \"{subject_alternative_dns_name}\" as a Ia5 string"
+    ))]
+    ParseSubjectAlternativeDnsName {
+        subject_alternative_dns_name: String,
         source: x509_cert::der::Error,
     },
 }
@@ -341,8 +343,8 @@ where
             .into_iter()
             .map(|dns_name| {
                 Ok(GeneralName::DnsName(Ia5String::new(dns_name).context(
-                    SaDnsNameNotAIa5StringSnafu {
-                        dns_name: dns_name.to_string(),
+                    ParseSubjectAlternativeDnsNameSnafu {
+                        subject_alternative_dns_name: dns_name.to_string(),
                     },
                 )?))
             })

--- a/crates/stackable-webhook/src/tls.rs
+++ b/crates/stackable-webhook/src/tls.rs
@@ -8,8 +8,11 @@ use hyper::{body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use opentelemetry::trace::{FutureExt, SpanKind};
 use snafu::{ResultExt, Snafu};
-use stackable_certs::{CertificatePairError, ca::CertificateAuthority, keys::rsa};
-use stackable_operator::time::Duration;
+use stackable_certs::{
+    CertificatePairError,
+    ca::{CertificateAuthority, DEFAULT_CA_VALIDITY},
+    keys::rsa,
+};
 use tokio::net::TcpListener;
 use tokio_rustls::{
     TlsAcceptor,
@@ -106,7 +109,7 @@ impl TlsServer {
                 CertificateAuthority::new_rsa().context(CreateCertificateAuthoritySnafu)?;
 
             let leaf_certificate = certificate_authority
-                .generate_rsa_leaf_certificate("Leaf", "webhook", Duration::from_secs(3600))
+                .generate_rsa_leaf_certificate("Leaf", "webhook", [], DEFAULT_CA_VALIDITY)
                 .context(GenerateLeafCertificateSnafu)?;
 
             let certificate_der = leaf_certificate


### PR DESCRIPTION
# Description

As https://github.com/stackabletech/operator-rs/pull/1044 didn't move along, splitting the relevant change out to unblock CRD versioning.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
