### PR TITLE
refactor(stackable-operator): Remove Result from ListenerOperatorVolumeSourceBuilder::new()

### DIFF
--- a/crates/stackable-operator/src/builder/pod/mod.rs
+++ b/crates/stackable-operator/src/builder/pod/mod.rs
@@ -396,7 +396,6 @@ impl PodBuilder {
     ) -> Result<&mut Self> {
         let listener_reference = ListenerReference::ListenerClass(listener_class.to_string());
         let volume = ListenerOperatorVolumeSourceBuilder::new(&listener_reference, labels)
-            .context(ListenerVolumeSnafu { name: volume_name })?
             .build_ephemeral()
             .context(ListenerVolumeSnafu { name: volume_name })?;
 
@@ -483,7 +482,6 @@ impl PodBuilder {
     ) -> Result<&mut Self> {
         let listener_reference = ListenerReference::ListenerName(listener_name.to_string());
         let volume = ListenerOperatorVolumeSourceBuilder::new(&listener_reference, labels)
-            .context(ListenerVolumeSnafu { name: volume_name })?
             .build_ephemeral()
             .context(ListenerVolumeSnafu { name: volume_name })?;
 

--- a/crates/stackable-operator/src/builder/pod/volume.rs
+++ b/crates/stackable-operator/src/builder/pod/volume.rs
@@ -497,11 +497,11 @@ impl ListenerOperatorVolumeSourceBuilder {
     pub fn new(
         listener_reference: &ListenerReference,
         labels: &Labels,
-    ) -> Result<ListenerOperatorVolumeSourceBuilder, ListenerOperatorVolumeSourceBuilderError> {
-        Ok(Self {
+    ) -> ListenerOperatorVolumeSourceBuilder {
+        Self {
             listener_reference: listener_reference.to_owned(),
             labels: labels.to_owned(),
-        })
+        }
     }
 
     fn build_spec(&self) -> PersistentVolumeClaimSpec {
@@ -636,8 +636,7 @@ mod tests {
         let builder = ListenerOperatorVolumeSourceBuilder::new(
             &ListenerReference::ListenerClass("public".into()),
             &labels,
-        )
-        .unwrap();
+        );
 
         let volume_source = builder.build_ephemeral().unwrap();
 


### PR DESCRIPTION
Remove Result from `ListenerOperatorVolumeSourceBuilder::new()` return because it is infallible

