### PR TITLE
fix(stackable-versioned): Emit an error when invalid items are added to the versioned module

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/module.rs
+++ b/crates/stackable-versioned-macros/src/codegen/module.rs
@@ -108,7 +108,14 @@ impl Module {
                         ),
                     }
                 }
-                _ => continue,
+                // NOTE (@NickLarsenNZ): We throw an error here so the developer isn't surprised when items they have
+                // defined in the module are no longer accessible (because they are not re-emitted).
+                disallowed_item => errors.push(
+                    Error::custom(
+                        "Item not allowed here. Please move it ouside of the versioned module",
+                    )
+                    .with_span(&disallowed_item),
+                ),
             };
         }
 


### PR DESCRIPTION
This improves DX by emitting an error when invalid items are added to the versioned module:

![image](https://github.com/user-attachments/assets/c179716d-5412-4dd5-9c74-3b35ef459d10)
