### PR TITLE
Use the local kubelet's cluster domain, rather than a random one

### DIFF
--- a/crates/stackable-operator/src/utils/cluster_info.rs
+++ b/crates/stackable-operator/src/utils/cluster_info.rs
@@ -18,10 +18,13 @@ pub struct KubernetesClusterInfo {
 #[derive(clap::Parser, Debug, Default, PartialEq, Eq)]
 pub struct KubernetesClusterInfoOpts {
     /// Kubernetes cluster domain, usually this is `cluster.local`.
-    // We are not using a default value here, as operators will probably do an more advanced
-    // auto-detection of the cluster domain in case it is not specified in the future.
+    // We are not using a default value here, as we query the cluster if it is not specified.
     #[arg(long, env)]
     pub kubernetes_cluster_domain: Option<DomainName>,
+
+    /// Name of the Kubernetes Node that the operator is running on.
+    #[arg(long, env)]
+    pub kubernetes_node_name: String,
 }
 
 impl KubernetesClusterInfo {
@@ -29,14 +32,21 @@ impl KubernetesClusterInfo {
         client: &Client,
         cluster_info_opts: &KubernetesClusterInfoOpts,
     ) -> Result<Self, Error> {
-        let cluster_domain = match &cluster_info_opts.kubernetes_cluster_domain {
-            Some(cluster_domain) => {
+        let cluster_domain = match cluster_info_opts {
+            KubernetesClusterInfoOpts {
+                kubernetes_cluster_domain: Some(cluster_domain),
+                ..
+            } => {
                 tracing::info!(%cluster_domain, "Using configured Kubernetes cluster domain");
 
                 cluster_domain.clone()
             }
-            None => {
-                let kubelet_config = kubelet::KubeletConfig::fetch(client)
+            KubernetesClusterInfoOpts {
+                kubernetes_node_name: node_name,
+                ..
+            } => {
+                tracing::info!(%node_name, "Fetching Kubernetes cluster domain from the local kubelet");
+                let kubelet_config = kubelet::KubeletConfig::fetch(client, node_name)
                     .await
                     .context(KubeletConfigSnafu)?;
 


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/issues/issues/662, followup to https://github.com/stackabletech/operator-rs/pull/1068.

This is a breaking change (towards operators); they must now (in addition to the requirements from #1068) also provide the following environment variable:

```yaml
env:
  - name: KUBERNETES_NODE_NAME
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName

```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
