### PR TITLE
chore: Release workspace members (stackable-operator 0.95.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.94.0"
+version = "0.95.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-shared"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "k8s-openapi",
  "kube",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "convert_case",
  "darling 0.21.2",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "axum",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.95.0] - 2025-08-21
+
 ### Added
 
 - Add `ProbeBuilder` to build Kubernetes container probes ([#1078]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.94.0"
+version = "0.95.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.2] - 2025-08-21
+
+### Added
+
+- Some modules have been moved into the `stackable-shared` crate, so that they can also be
+  used in `stackable-certs` and `stackable-webhook` ([#1074]):
+  - The module `stackable_operator::time` has moved to `stackable_operator::shared::time`
+  - The module `stackable_operator::commons::secret` has moved to `stackable_operator::shared::secret`
+
+[#1074]: https://github.com/stackabletech/operator-rs/pull/1074
+
 ## [0.0.1]
 
 ### Added

--- a/crates/stackable-shared/Cargo.toml
+++ b/crates/stackable-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-shared"
-version = "0.0.1"
+version = "0.0.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.1] - 2025-08-21
+
 ### Fixed
 
 - Replace the hardcoded `::stackable_versioned` path in the `tracking_from` function with the configurable crate override ([#1079]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-08-21
+
 ### Changed
 
 - BREAKING: Re-write the `ConversionWebhookServer`.

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases

## `stackable-operator` 0.95.0

### Added

- Add `ProbeBuilder` to build Kubernetes container probes ([#1078]).
- Re-export `stackable-certs` and `stackable-webhook` crates ([#1074]).
- BREAKING: Add two new required CLI arguments: `--operator-namespace` and `--operator-service-name`.
  These two values are used to construct the service name in the CRD conversion webhook ([#1066]).
- Re-export `stackable-certs` and `stackable-webhook` crates ([#1074]).

### Changed

- BREAKING: The `ResolvedProductImage` field `app_version_label` was renamed to `app_version_label_value` to match changes to its type ([#1076]).
- BREAKING: Rename two fields of the `ProductOperatorRun` struct for consistency and clarity ([#1066]):
  - `telemetry_arguments` -> `telemetry`
  - `cluster_info_opts` -> `cluster_info`
- BREAKING: Some modules have been moved into the `stackable-shared` crate, so that they can also be
  used in `stackable-certs` and `stackable-webhook` ([#1074]):
  - The module `stackable_operator::time` has moved to `stackable_operator::shared::time`
  - The module `stackable_operator::commons::secret` has moved to `stackable_operator::shared::secret`

### Fixed

- BREAKING: Fix bug where `ResolvedProductImage::app_version_label` could not be used as a label value because it can contain invalid characters.
  This is the case when referencing custom images via a `@sha256:...` hash. As such, the `product_image_selection::resolve` function is now fallible ([#1076]).

[#1066]: https://github.com/stackabletech/operator-rs/pull/1066
[#1074]: https://github.com/stackabletech/operator-rs/pull/1074
[#1076]: https://github.com/stackabletech/operator-rs/pull/1076
[#1078]: https://github.com/stackabletech/operator-rs/pull/1078

## `stackable-shared` 0.0.2

### Added

- Some modules have been moved into the `stackable-shared` crate, so that they can also be
  used in `stackable-certs` and `stackable-webhook` ([#1074]):
  - The module `stackable_operator::time` has moved to `stackable_operator::shared::time`
  - The module `stackable_operator::commons::secret` has moved to `stackable_operator::shared::secret`

[#1074]: https://github.com/stackabletech/operator-rs/pull/1074

## `stackable-versioned` 0.8.1

### Fixed

- Replace the hardcoded `::stackable_versioned` path in the `tracking_from` function with the configurable crate override ([#1079]).

[#1079]: https://github.com/stackabletech/operator-rs/pull/1079

## `stackable-versioned-macros` 0.8.1
## `stackable-webhook` 0.5.0

### Changed

- BREAKING: Re-write the `ConversionWebhookServer`.
  It can now do CRD conversions, handle multiple CRDs and takes care of reconciling the CRDs ([#1066]).
- BREAKING: The `TlsServer` can now handle certificate rotation.
  To achieve this, a new `CertificateResolver` was added.
  Also, `TlsServer::new` now returns an additional `mpsc::Receiver<Certificate>`, so that the caller
  can get notified about certificate rotations happening ([#1066]).
- `stackable_webhook::Options` has been renamed to `stackable_webhook::WebhookOptions`, as well as
  `OptionsBuilder` to `WebhookOptionsBuilder` ([#1066]).

### Removed

- Remove `StatefulWebhookHandler` to reduce maintenance effort.
  Also, webhooks are ideally stateless, so that they can be scaled horizontally.
  It can be re-added once needed ([#1066]).

[#1066]: https://github.com/stackabletech/operator-rs/pull/1066
