### PR TITLE
feat!: Add cli::CommonOptions struct

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add a `CommonStackableCliArgs` struct, which can be used for non-operator Stackable tools ([#1083]).
+- Add a `cli::CommonOptions` struct, which can be used for non-operator Stackable tools ([#1083]).
 
 ### Changed
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add a `CommonStackableCliArgs` struct, which can be used for non-operator Stackable tools ([#10XX]).
+
+### Changed
+
+- BREAKING: The `telemetry` and `cluster_info` fields of `ProductOperatorRun` have moved below the `common` field ([#10XX]).
+
+[#10XX]: https://github.com/stackabletech/operator-rs/pull/10XX
+
 ## [0.95.0] - 2025-08-21
 
 ### Added

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -195,7 +195,7 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 /// assert_eq!(opts, Command::Run(Run {
 ///     name: "foo".to_string(),
 ///     common: ProductOperatorRun {
-///         common: CommonStackableCliArgs {
+///         common: CommonOptions {
 ///             telemetry: TelemetryOptions::default(),
 ///             cluster_info: KubernetesClusterInfoOptions {
 ///                 kubernetes_cluster_domain: None,
@@ -233,7 +233,7 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 #[command(long_about = "")]
 pub struct ProductOperatorRun {
     #[command(flatten)]
-    pub common: CommonStackableCliArgs,
+    pub common: CommonOptions,
 
     #[command(flatten)]
     pub operator_environment: OperatorEnvironmentOptions,
@@ -253,7 +253,7 @@ pub struct ProductOperatorRun {
 /// utilities such as `user-info-fetcher` or `opa-bundle-builder`. So this struct offers a limited
 /// set, that should be shared across all Stackable tools running on Kubernetes.
 #[derive(clap::Parser, Debug, PartialEq, Eq)]
-pub struct CommonStackableCliArgs {
+pub struct CommonOptions {
     #[command(flatten)]
     pub telemetry: TelemetryOptions,
 

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -230,6 +230,12 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 #[derive(clap::Parser, Debug, PartialEq, Eq)]
 #[command(long_about = "")]
 pub struct ProductOperatorRun {
+    #[command(flatten)]
+    pub common: CommonStackableCliArgs,
+
+    #[command(flatten)]
+    pub operator_environment: OperatorEnvironmentOptions,
+
     /// Provides the path to a product-config file
     #[arg(long, short = 'p', value_name = "FILE", default_value = "", env)]
     pub product_config: ProductConfigPath,
@@ -237,10 +243,15 @@ pub struct ProductOperatorRun {
     /// Provides a specific namespace to watch (instead of watching all namespaces)
     #[arg(long, env, default_value = "")]
     pub watch_namespace: WatchNamespace,
+}
 
-    #[command(flatten)]
-    pub operator_environment: OperatorEnvironmentOptions,
-
+/// All the CLI arguments that all (or at least most) Stackable applications use.
+///
+/// [`ProductOperatorRun`] is intended for operators, but it has fields that are not needed for
+/// utilities such as `user-info-fetcher` or `opa-bundle-builder`. So this struct offers a limited
+/// set, that should be shared across all Stackable tools running in Kubernetes.
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+pub struct CommonStackableCliArgs {
     #[command(flatten)]
     pub telemetry: TelemetryOptions,
 

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -251,7 +251,7 @@ pub struct ProductOperatorRun {
 ///
 /// [`ProductOperatorRun`] is intended for operators, but it has fields that are not needed for
 /// utilities such as `user-info-fetcher` or `opa-bundle-builder`. So this struct offers a limited
-/// set, that should be shared across all Stackable tools running in Kubernetes.
+/// set, that should be shared across all Stackable tools running on Kubernetes.
 #[derive(clap::Parser, Debug, PartialEq, Eq)]
 pub struct CommonStackableCliArgs {
     #[command(flatten)]

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -163,7 +163,7 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 /// Can be embedded into an extended argument set:
 ///
 /// ```rust
-/// # use stackable_operator::cli::{Command, OperatorEnvironmentOptions, ProductOperatorRun, ProductConfigPath};
+/// # use stackable_operator::cli::{Command, CommonStackableCliArgs, OperatorEnvironmentOptions, ProductOperatorRun, ProductConfigPath};
 /// # use stackable_operator::{namespace::WatchNamespace, utils::cluster_info::KubernetesClusterInfoOptions};
 /// # use stackable_telemetry::tracing::TelemetryOptions;
 /// use clap::Parser;
@@ -195,13 +195,15 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 /// assert_eq!(opts, Command::Run(Run {
 ///     name: "foo".to_string(),
 ///     common: ProductOperatorRun {
+///         common: CommonStackableCliArgs {
+///             telemetry: TelemetryOptions::default(),
+///             cluster_info: KubernetesClusterInfoOptions {
+///                 kubernetes_cluster_domain: None,
+///                 kubernetes_node_name: "baz".to_string(),
+///             },
+///         },
 ///         product_config: ProductConfigPath::from("bar".as_ref()),
 ///         watch_namespace: WatchNamespace::One("foobar".to_string()),
-///         telemetry: TelemetryOptions::default(),
-///         cluster_info: KubernetesClusterInfoOptions {
-///             kubernetes_cluster_domain: None,
-///             kubernetes_node_name: "baz".to_string(),
-///         },
 ///         operator_environment: OperatorEnvironmentOptions {
 ///             operator_namespace: "stackable-operators".to_string(),
 ///             operator_service_name: "foo-operator".to_string(),

--- a/crates/stackable-operator/src/cli.rs
+++ b/crates/stackable-operator/src/cli.rs
@@ -163,7 +163,7 @@ pub enum Command<Run: Args = ProductOperatorRun> {
 /// Can be embedded into an extended argument set:
 ///
 /// ```rust
-/// # use stackable_operator::cli::{Command, CommonStackableCliArgs, OperatorEnvironmentOptions, ProductOperatorRun, ProductConfigPath};
+/// # use stackable_operator::cli::{Command, CommonOptions, OperatorEnvironmentOptions, ProductOperatorRun, ProductConfigPath};
 /// # use stackable_operator::{namespace::WatchNamespace, utils::cluster_info::KubernetesClusterInfoOptions};
 /// # use stackable_telemetry::tracing::TelemetryOptions;
 /// use clap::Parser;


### PR DESCRIPTION
# Description

We currently have a bug that opa-bundle-builder or user-info-fetcher take an `ProductOperatorRun`, causing
```bash
bundle-builder error: the following required arguments were not provided:                                                                                                
bundle-builder   --operator-namespace <OPERATOR_NAMESPACE>                                                                                                               
bundle-builder   --operator-service-name <OPERATOR_SERVICE_NAME>                                                                                                         
bundle-builder                                                                                                                                                           
bundle-builder Usage: stackable-opa-bundle-builder --operator-namespace <OPERATOR_NAMESPACE> --operator-service-name <OPERATOR_SERVICE_NAME> --kubernetes-node-name <KUBE
RNETES_NODE_NAME> --watch-namespace <WATCH_NAMESPACE> --file-log-directory <DIRECTORY> --kubernetes-cluster-domain <KUBERNETES_CLUSTER_DOMAIN> 
```

We could create a custom struct in every tool (we did that for some tools in the past), but it makes sense to have it as a common struct.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
