### PR TITLE
chore: Release stackable-operators 0.96.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.95.1"
+version = "0.96.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.96.0] - 2025-08-25
+
 ### Added
 
 - Add a `cli::CommonOptions` struct, which can be used for non-operator Stackable tools ([#1083]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.95.1"
+version = "0.96.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Added

- Add a `cli::CommonOptions` struct, which can be used for non-operator Stackable tools ([#1083]).

### Changed

- BREAKING: The `telemetry` and `cluster_info` fields of `ProductOperatorRun` have moved below the `common` field ([#1083]).

[#1083]: https://github.com/stackabletech/operator-rs/pull/1083
