### PR TITLE
fix(stackable-versioned): Correctly emit enum fields in From impls

### DIFF
--- a/crates/stackable-versioned-macros/src/codegen/item/variant.rs
+++ b/crates/stackable-versioned-macros/src/codegen/item/variant.rs
@@ -4,7 +4,9 @@ use darling::{FromVariant, Result, util::IdentString};
 use k8s_version::Version;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
-use syn::{Attribute, Fields, Type, TypeNever, Variant, token::Not};
+use syn::{
+    Attribute, Fields, FieldsNamed, FieldsUnnamed, Ident, Type, TypeNever, Variant, token::Not,
+};
 
 use crate::{
     attrs::item::VariantAttributes,
@@ -138,7 +140,8 @@ impl VersionedVariant {
         next_version: &VersionDefinition,
         enum_ident: &IdentString,
     ) -> Option<TokenStream> {
-        let variant_fields = self.fields_as_token_stream();
+        let from_fields = self.generate_from_fields();
+        let for_fields = self.generate_for_fields();
 
         match &self.changes {
             Some(changes) => {
@@ -154,16 +157,15 @@ impl VersionedVariant {
                         let next_variant_ident = next.get_ident();
                         let old_variant_ident = old.get_ident();
 
-                        let old = quote! {
-                            #old_version_ident::#enum_ident::#old_variant_ident #variant_fields
-                        };
-                        let next = quote! {
-                            #next_version_ident::#enum_ident::#next_variant_ident #variant_fields
-                        };
-
                         match direction {
-                            Direction::Upgrade => Some(quote! { #old => #next, }),
-                            Direction::Downgrade => Some(quote! { #next => #old, }),
+                            Direction::Upgrade => Some(quote! {
+                                #old_version_ident::#enum_ident::#old_variant_ident #from_fields
+                                    => #next_version_ident::#enum_ident::#next_variant_ident #for_fields,
+                            }),
+                            Direction::Downgrade => Some(quote! {
+                                #next_version_ident::#enum_ident::#next_variant_ident #from_fields
+                                    => #old_version_ident::#enum_ident::#old_variant_ident #from_fields,
+                            }),
                         }
                     }
                 }
@@ -173,48 +175,67 @@ impl VersionedVariant {
                 let old_version_ident = &version.idents.module;
                 let variant_ident = &*self.ident;
 
-                let old = quote! {
-                    #old_version_ident::#enum_ident::#variant_ident #variant_fields
-                };
-                let next = quote! {
-                    #next_version_ident::#enum_ident::#variant_ident #variant_fields
-                };
-
                 match direction {
-                    Direction::Upgrade => Some(quote! { #old => #next, }),
-                    Direction::Downgrade => Some(quote! { #next => #old, }),
+                    Direction::Upgrade => Some(quote! {
+                        #old_version_ident::#enum_ident::#variant_ident #from_fields
+                            => #next_version_ident::#enum_ident::#variant_ident #for_fields,
+                    }),
+                    Direction::Downgrade => Some(quote! {
+                        #next_version_ident::#enum_ident::#variant_ident #from_fields
+                            => #old_version_ident::#enum_ident::#variant_ident #for_fields,
+                    }),
                 }
             }
         }
     }
 
-    fn fields_as_token_stream(&self) -> Option<TokenStream> {
+    fn generate_for_fields(&self) -> Option<TokenStream> {
         match &self.fields {
             Fields::Named(fields_named) => {
-                let fields: Vec<_> = fields_named
-                    .named
-                    .iter()
-                    .map(|field| {
-                        field
-                            .ident
-                            .as_ref()
-                            .expect("named fields always have an ident")
-                    })
-                    .collect();
+                let fields = Self::named_field_idents(fields_named);
+                Some(quote! { { #(#fields)*: #(#fields.into()),* } })
+            }
+            Fields::Unnamed(fields_unnamed) => {
+                let fields = Self::unnamed_field_ident(fields_unnamed);
+                Some(quote! { ( #(#fields.into()),* ) })
+            }
+            Fields::Unit => None,
+        }
+    }
 
+    fn generate_from_fields(&self) -> Option<TokenStream> {
+        match &self.fields {
+            Fields::Named(fields_named) => {
+                let fields = Self::named_field_idents(fields_named);
                 Some(quote! { { #(#fields),* } })
             }
             Fields::Unnamed(fields_unnamed) => {
-                let fields: Vec<_> = fields_unnamed
-                    .unnamed
-                    .iter()
-                    .enumerate()
-                    .map(|(index, _)| format_ident!("__sv_{index}"))
-                    .collect();
-
+                let fields = Self::unnamed_field_ident(fields_unnamed);
                 Some(quote! { ( #(#fields),* ) })
             }
             Fields::Unit => None,
         }
+    }
+
+    fn named_field_idents(fields_named: &FieldsNamed) -> Vec<&Ident> {
+        fields_named
+            .named
+            .iter()
+            .map(|field| {
+                field
+                    .ident
+                    .as_ref()
+                    .expect("named fields always have an ident")
+            })
+            .collect()
+    }
+
+    fn unnamed_field_ident(fields_unnamed: &FieldsUnnamed) -> Vec<Ident> {
+        fields_unnamed
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format_ident!("__sv_{index}"))
+            .collect()
     }
 }

--- a/crates/stackable-versioned-macros/tests/inputs/pass/enum_fields.rs
+++ b/crates/stackable-versioned-macros/tests/inputs/pass/enum_fields.rs
@@ -1,0 +1,18 @@
+use stackable_versioned::versioned;
+// ---
+#[versioned(version(name = "v1alpha1"), version(name = "v1alpha2"))]
+// ---
+pub mod versioned {
+    enum MyEnum {
+        A { aa: usize },
+        B { bb: bool },
+    }
+
+    enum Bla {
+        A(A),
+    }
+
+    struct A {}
+}
+// ---
+fn main() {}

--- a/crates/stackable-versioned-macros/tests/snapshots/stackable_versioned_macros__snapshots__pass@enum_fields.rs.snap
+++ b/crates/stackable-versioned-macros/tests/snapshots/stackable_versioned_macros__snapshots__pass@enum_fields.rs.snap
@@ -1,0 +1,91 @@
+---
+source: crates/stackable-versioned-macros/src/lib.rs
+expression: formatted
+input_file: crates/stackable-versioned-macros/tests/inputs/pass/enum_fields.rs
+---
+#[automatically_derived]
+pub mod v1alpha1 {
+    use super::*;
+    pub enum MyEnum {
+        A { aa: usize },
+        B { bb: bool },
+    }
+    pub enum Bla {
+        A(A),
+    }
+    pub struct A {}
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha1::MyEnum> for v1alpha2::MyEnum {
+    fn from(__sv_myenum: v1alpha1::MyEnum) -> Self {
+        match __sv_myenum {
+            v1alpha1::MyEnum::A { aa } => {
+                v1alpha2::MyEnum::A {
+                    aa: aa.into(),
+                }
+            }
+            v1alpha1::MyEnum::B { bb } => {
+                v1alpha2::MyEnum::B {
+                    bb: bb.into(),
+                }
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha2::MyEnum> for v1alpha1::MyEnum {
+    fn from(__sv_myenum: v1alpha2::MyEnum) -> Self {
+        match __sv_myenum {
+            v1alpha2::MyEnum::A { aa } => {
+                v1alpha1::MyEnum::A {
+                    aa: aa.into(),
+                }
+            }
+            v1alpha2::MyEnum::B { bb } => {
+                v1alpha1::MyEnum::B {
+                    bb: bb.into(),
+                }
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha1::Bla> for v1alpha2::Bla {
+    fn from(__sv_bla: v1alpha1::Bla) -> Self {
+        match __sv_bla {
+            v1alpha1::Bla::A(__sv_0) => v1alpha2::Bla::A(__sv_0.into()),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha2::Bla> for v1alpha1::Bla {
+    fn from(__sv_bla: v1alpha2::Bla) -> Self {
+        match __sv_bla {
+            v1alpha2::Bla::A(__sv_0) => v1alpha1::Bla::A(__sv_0.into()),
+        }
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha1::A> for v1alpha2::A {
+    fn from(__sv_a: v1alpha1::A) -> Self {
+        Self {}
+    }
+}
+#[automatically_derived]
+impl ::core::convert::From<v1alpha2::A> for v1alpha1::A {
+    fn from(__sv_a: v1alpha2::A) -> Self {
+        Self {}
+    }
+}
+#[automatically_derived]
+pub mod v1alpha2 {
+    use super::*;
+    pub enum MyEnum {
+        A { aa: usize },
+        B { bb: bool },
+    }
+    pub enum Bla {
+        A(A),
+    }
+    pub struct A {}
+}

--- a/crates/stackable-versioned-macros/tests/trybuild.rs
+++ b/crates/stackable-versioned-macros/tests/trybuild.rs
@@ -23,6 +23,7 @@ mod inputs {
         // mod crate_overrides;
         // mod docs;
         // mod downgrade_with;
+        // mod enum_fields;
         // mod module;
         // mod module_preserve;
         // mod renamed_field;


### PR DESCRIPTION
This PR correctly emits enum variant fields in `From` impl blocks. Encountered in https://github.com/stackabletech/secret-operator/pull/634.