### PR TITLE
feat: Remove the Merge implementation for PodTemplateSpec

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,7 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - BREAKING: Add a new CLI flag/env to disabling CRD maintenance: `--disable-crd-maintenance` ([#1085]).
 
+### Removed
+
+- BREAKING: Remove the Merge implementation for PodTemplateSpec ([#1087]).
+  It was broken because the instance was overriden by the given defaults.
+  This function is not used by the Stackable operators.
+
 [#1085]: https://github.com/stackabletech/operator-rs/pull/1085
+[#1087]: https://github.com/stackabletech/operator-rs/pull/1087
 
 ## [0.96.0] - 2025-08-25
 

--- a/crates/stackable-operator/src/config/merge.rs
+++ b/crates/stackable-operator/src/config/merge.rs
@@ -6,8 +6,7 @@ use std::{
 };
 
 use k8s_openapi::{
-    DeepMerge,
-    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity, PodTemplateSpec},
+    api::core::v1::{NodeAffinity, PodAffinity, PodAntiAffinity},
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::LabelSelector},
 };
 pub use stackable_operator_derive::Merge;
@@ -85,11 +84,6 @@ impl<K: Hash + Eq + Clone, V: Merge + Clone> Merge for HashMap<K, V> {
                 }
             }
         }
-    }
-}
-impl Merge for PodTemplateSpec {
-    fn merge(&mut self, defaults: &Self) {
-        self.merge_from(defaults.clone())
     }
 }
 
@@ -435,61 +429,6 @@ mod tests {
                 &[("a", Acc(3)), ("c", Acc(5))].into()
             ),
             BTreeMap::from([("a", Acc(4)), ("b", Acc(2)), ("c", Acc(5))])
-        );
-    }
-
-    #[test]
-    fn merge_pod_template_spec() {
-        assert_eq!(
-            merge(
-                PodTemplateSpec {
-                    spec: Some(PodSpec {
-                        service_account_name: Some("my-sa".to_string()),
-                        ..PodSpec::default()
-                    }),
-                    ..PodTemplateSpec::default()
-                },
-                &PodTemplateSpec {
-                    spec: Some(PodSpec {
-                        priority: Some(3000),
-                        ..PodSpec::default()
-                    }),
-                    ..PodTemplateSpec::default()
-                }
-            ),
-            PodTemplateSpec {
-                spec: Some(PodSpec {
-                    service_account_name: Some("my-sa".to_string()),
-                    priority: Some(3000),
-                    ..PodSpec::default()
-                }),
-                ..PodTemplateSpec::default()
-            }
-        );
-        assert_eq!(
-            merge(
-                PodTemplateSpec {
-                    spec: Some(PodSpec {
-                        service_account_name: Some("sa-to-be-overridden".to_string()),
-                        ..PodSpec::default()
-                    }),
-                    ..PodTemplateSpec::default()
-                },
-                &PodTemplateSpec {
-                    spec: Some(PodSpec {
-                        service_account_name: Some("sa-override".to_string()),
-                        ..PodSpec::default()
-                    }),
-                    ..PodTemplateSpec::default()
-                }
-            ),
-            PodTemplateSpec {
-                spec: Some(PodSpec {
-                    service_account_name: Some("sa-override".to_string()),
-                    ..PodSpec::default()
-                }),
-                ..PodTemplateSpec::default()
-            }
         );
     }
 }

--- a/crates/stackable-operator/src/config/merge.rs
+++ b/crates/stackable-operator/src/config/merge.rs
@@ -157,8 +157,6 @@ impl<T: Atomic> Merge for Option<T> {
 mod tests {
     use std::collections::{BTreeMap, HashMap};
 
-    use k8s_openapi::api::core::v1::{PodSpec, PodTemplateSpec};
-
     use super::{Merge, merge};
 
     #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
# Description

Remove the Merge implementation for PodTemplateSpec

It was broken because the instance was overriden by the given defaults.

This function is not used by the Stackable operators. Even if it is used by other operators, it is better to remove it than to "silently" switch the parameters.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
