### PR TITLE
chore: Release workspace members (stackable-operator 0.97.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.96.0"
+version = "0.97.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "convert_case",
  "darling 0.21.2",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.9.0"
+version = "0.8.2"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.9.0"
+version = "0.8.2"
 dependencies = [
  "convert_case",
  "darling 0.21.2",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.97.0] - 2025-09-09
+
 ### Added
 
 - BREAKING: Add a new CLI flag/env to disabling CRD maintenance: `--disable-crd-maintenance` ([#1085]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.96.0"
+version = "0.97.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.9.0"
+version = "0.8.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.8.1"
+version = "0.9.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.9.0] - 2025-09-09
+## [0.8.2] - 2025-09-09
 
 ### Added
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] - 2025-09-09
+
 ### Added
 
 - Add new `#[versioned(hint)]` argument to provide type hints for struct fields ([#1089]).

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.9.0"
+version = "0.8.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.8.1"
+version = "0.9.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-09-09
+
 ### Added
 
 - BREAKING: Support disabling CRD maintenance using a new boolean flag in `ConversionWebhookOptions` ([#1085]).

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## stackable-operator 0.97.0

### Added

- BREAKING: Add a new CLI flag/env to disabling CRD maintenance: `--disable-crd-maintenance` ([#1085]).

### Removed

- BREAKING: Remove the Merge implementation for PodTemplateSpec ([#1087]).
  It was broken because the instance was overridden by the given defaults.
  This function is not used by the Stackable operators.

### Fixed

- Don't default the `termination_grace_period` of the `ProbeBuilder` to 0, as this is an invalid value ([#1090]).

[#1085]: https://github.com/stackabletech/operator-rs/pull/1085
[#1087]: https://github.com/stackabletech/operator-rs/pull/1087
[#1090]: https://github.com/stackabletech/operator-rs/pull/1090

## stackable-versioned 0.8.2

### Added

- Add new `#[versioned(hint)]` argument to provide type hints for struct fields ([#1089]).
  - `#[versioned(hint(option))]` for fields wrapped in an `Option`. Generates `.map(Into::into)`.
  - `#[versioned(hint(vec))]` for fields wrapped in an `Vec`. Generates `.into_iter().map(Into::into).collect()`.

### Fixed

- Correctly emit enum variant fields in `From` impl blocks ([#1086]).

[#1086]: https://github.com/stackabletech/operator-rs/pull/1086
[#1089]: https://github.com/stackabletech/operator-rs/pull/1089

## stackable-webhook 0.6.0

### Added

- BREAKING: Support disabling CRD maintenance using a new boolean flag in `ConversionWebhookOptions` ([#1085]).

[#1085]: https://github.com/stackabletech/operator-rs/pull/1085
