### PR TITLE
chore: Release stackable-operators 0.98.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.97.0"
+version = "0.98.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.98.0] - 2025-09-22
+
 ### Added
 
 - Extend `ObjectMetaBuilder` with `finalizers` ([#1094]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.97.0"
+version = "0.98.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Added

- Extend `ObjectMetaBuilder` with `finalizers` ([#1094]).

### Changed

- BREAKING: Upgrade to `schemars` 1.0, `kube` 2.0 and `k8s-openapi` 0.26 (using Kubernetes 1.34) ([#1091]).

### Fixed

- BREAKING: Don't allow uppercase characters in Kubernetes object names ([#1095]).