### PR TITLE
chore: Release stackable-operator 0.99.0, stackable-shared 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-shared"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chrono",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.98.0"
+version = "0.99.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.99.0] - 2025-10-06
+
 ### Added
 
 - Add CLI argument and env var to disable the end-of-support checker: `EOS_DISABLED` (`--eos-disabled`) ([#1101]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.98.0"
+version = "0.99.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [Unreleased]
+
+## [0.0.3] - 2025-10-06
 
 ### Added
 

--- a/crates/stackable-shared/Cargo.toml
+++ b/crates/stackable-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-shared"
-version = "0.0.2"
+version = "0.0.3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This releases stackable-operator 0.99.0 and stackable-shared 0.0.3:

## stackable-operator 0.99.0

### Added

- Add CLI argument and env var to disable the end-of-support checker: `EOS_DISABLED` (`--eos-disabled`) ([#1101]).
- Add end-of-support checker ([#1096]).
  - The EoS checker can be constructed using `EndOfSupportChecker::new()`.
  - Add new `MaintenanceOptions` and `EndOfSupportOptions` structs.
  - Add new CLI arguments and env vars:
    - `EOS_CHECK_MODE` (`--eos-check-mode`) to set the EoS check mode. Currently, only "offline" is supported.
    - `EOS_INTERVAL` (`--eos-interval`) to set the interval in which the operator checks if it is EoS.

### Changed

- Update the end-of-support warning message ([#1103])
- BREAKING: `ProductOperatorRun` was renamed to `RunArguments` ([#1096]).
- BREAKING: The `disable_crd_maintenance` field was moved from `RunArguments` into `MaintenanceOptions`.
  The CLI interface is unchanged ([#1096]).
- BREAKING: Integration of `KubernetesClusterInfoOptions` with `clap` is now gated behind the `clap` feature flag.
  This is only breaking if default features for `stackable-operator` are disabled ([#1096]).
- BREAKING: Bump `product-config` to 0.8.0 ([#1098]).

[#1096]: https://github.com/stackabletech/operator-rs/pull/1096
[#1098]: https://github.com/stackabletech/operator-rs/pull/1098
[#1101]: https://github.com/stackabletech/operator-rs/pull/1101
[#1103]: https://github.com/stackabletech/operator-rs/pull/1103

## stackable-shared 0.0.3

### Added

- Add conversion implementations between `Duration` and `chrono::TimeDelta` ([#1103]).

[#1103]: https://github.com/stackabletech/operator-rs/pull/1103