### PR TITLE
chore: Release stackable-operator 0.100.0, stackable-webhook 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.99.0"
+version = "0.100.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "axum",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.100.0] - 2025-10-16
+
 ### Added
 
 - Add `LabelExt` trait which enables adding validated labels to any Kubernetes resource ([#1106]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.99.0"
+version = "0.100.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-10-16
+
 ### Added
 
 - Add `CustomResourceDefinitionMaintainer` which applies and patches CRDs triggered by TLS

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## stackable-operator 0.100.0

### Added

- Add `LabelExt` trait which enables adding validated labels to any Kubernetes resource ([#1106]).
- Add new associated convenience functions to `Label` ([#1106]).
  - `Label::stackable_vendor`: stackable.tech/vendor=Stackable
  - `Label::instance`: app.kubernetes.io/instance
  - `Label::name`: app.kubernetes.io/name
- Add a `Client::create_if_missing` associated function to create a resource if it doesn't
  exist ([#1099]).
- BREAKING: Add new ListenerClass `.spec.pinnedNodePorts` field ([#1105]).

[#1105]: https://github.com/stackabletech/operator-rs/pull/1105
[#1106]: https://github.com/stackabletech/operator-rs/pull/1106

## stackable-webhook 0.7.0

### Added

- Add `CustomResourceDefinitionMaintainer` which applies and patches CRDs triggered by TLS
  certificate rotations of the `ConversionWebhookServer`. It additionally provides a `oneshot`
  channel which can for example be used to trigger creation/patching of any custom resources
  deployed by the operator ([#1099]).
- Add `ConversionWebhookServer::with_maintainer` which creates a conversion webhook server and a CRD
  maintainer ([#1099]).

### Changed

- BREAKING: `ConversionWebhookServer::new` now returns a pair of values ([#1099]):
  - The conversion webhook server itself
  - A `mpsc::Receiver<Certificate>` to provide consumers the newly generated TLS certificate
- BREAKING: Constants for ports, IP addresses and socket addresses are now associated constants on
  `(Conversion)WebhookServer` instead of free-standing ones ([#1099]).

### Removed

- BREAKING: The `maintain_crds` and `field_manager` fields in `ConversionWebhookOptions`
  are removed ([#1099]).

[#1099]: https://github.com/stackabletech/operator-rs/pull/1099