### PR TITLE
chore: Release stackable-operator 0.100.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.100.1"
+version = "0.100.2"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.100.2] - 2025-10-25
+
 ### Fixed
 
 - BREAKING: Default ListenerClass `.spec.externalTrafficPolicy` to `null` so that LoadBalancers work everywhere ([#1107]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.100.1"
+version = "0.100.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## [0.100.2] - 2025-10-25

### Fixed

- BREAKING: Default ListenerClass `.spec.externalTrafficPolicy` to `null` so that LoadBalancers work everywhere ([#1107]).

[#1107]: https://github.com/stackabletech/operator-rs/pull/1107
