### PR TITLE
ci: Bump cargo-deny action to 2.0.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-      - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+      - uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # v2.0.14
         with:
           command: check ${{ matrix.checks }}
 


### PR DESCRIPTION
This bump fixes the CVSS version 4 issues. See:

- https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.0.14
- https://github.com/EmbarkStudios/cargo-deny/releases/tag/0.18.6