### PR TITLE
chore: Release stackable-operator 0.101.0, stackable-webhook 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.100.3"
+version = "0.101.0"
 dependencies = [
  "chrono",
  "clap",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.101.0] - 2025-12-23
+
 ### Added
 
 - Support `objectOverrides`, a list of generic Kubernetes objects, which are merged into the objects created by the operator.
@@ -11,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Bump stackable-webhook to 0.8.0, refer to its [changelog](../stackable-webhook/CHANGELOG.md) ([#1117]).
 - BREAKING: `ClusterResources` now requires the objects added to implement `DeepMerge`.
   This is very likely a stackable-operator internal change, but technically breaking ([#1118]).
 - Depend on the patched version of kube-rs available at <https://github.com/stackabletech/kube-rs>,

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.100.3"
+version = "0.101.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-12-32
+
 ### Added
 
 - Add support for mutating webhooks ([#1119]).

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.7.1"
+version = "0.8.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# stackable-operator 0.101.0

### Added

- Support `objectOverrides`, a list of generic Kubernetes objects, which are merged into the objects created by the operator.
  Alongside, a `deep_merger` module was added, which takes a Kubernetes object and a list of overrides and merges them into the provided object ([#1118]).

### Changed

- Bump stackable-webhook to 0.8.0, refer to its [changelog](../stackable-webhook/CHANGELOG.md) ([#1117]).
- BREAKING: `ClusterResources` now requires the objects added to implement `DeepMerge`.
  This is very likely a stackable-operator internal change, but technically breaking ([#1118]).
- Depend on the patched version of kube-rs available at <https://github.com/stackabletech/kube-rs>,
  ensuring the operators automatically benefit from the fixes ([#1124]).

### Removed

- BREAKING: `ClusterResources` no longer derives `Eq` ([#1118]).

[#1118]: https://github.com/stackabletech/operator-rs/pull/1118
[#1124]: https://github.com/stackabletech/operator-rs/pull/1124


# stackable-webhook 0.8.0

### Added

- Add support for mutating webhooks ([#1119]).

### Changed

- BREAKING: Refactor the entire `WebhookServer` mechanism, so multiple webhooks can run in parallel.
  Put individual webhooks (currently `ConversionWebhook` and `MutatingWebhook`) behind the `Webhook` trait ([#1119]).

[#1119]: https://github.com/stackabletech/operator-rs/pull/1119
