### PR TITLE
chore(webhook): Hide ByteString in instrumentation

### DIFF
--- a/crates/stackable-webhook/src/webhooks/conversion_webhook.rs
+++ b/crates/stackable-webhook/src/webhooks/conversion_webhook.rs
@@ -244,7 +244,7 @@ where
         self.options.disable_crd_maintenance
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, new_ca_bundle))]
     async fn handle_certificate_rotation(
         &mut self,
         new_ca_bundle: &ByteString,

--- a/crates/stackable-webhook/src/webhooks/mutating_webhook.rs
+++ b/crates/stackable-webhook/src/webhooks/mutating_webhook.rs
@@ -206,7 +206,7 @@ where
         self.options.disable_mwc_maintenance
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, new_ca_bundle))]
     async fn handle_certificate_rotation(
         &mut self,
         new_ca_bundle: &ByteString,


### PR DESCRIPTION
This is a little chatty.

In the future we might want to instead include structured data for the certificate instead.