### PR TITLE
chore: Release stackable-operator 0.102.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.101.2"
+version = "0.102.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.102.0] - 2026-01-14
+
 ### Added
 
 - BREAKING: Add `objectOverrides` field to `ListenerSpec` ([#1136]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.101.2"
+version = "0.102.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Added

- BREAKING: Add `objectOverrides` field to `ListenerSpec` ([#1136]).
- Added `stackable_operator::constants::RESTART_CONTROLLER_ENABLED_LABEL` constant, which represents the `restarter.stackable.tech/enabled=true` label ([#1139]).

### Changed

- Revert and pin k8s-openapi to 0.26.0 ([#1135]).
- BREAKING: `ListenerSpec` no longer derives `Eq` ([#1136]).

[#1135]: https://github.com/stackabletech/operator-rs/pull/1135
[#1136]: https://github.com/stackabletech/operator-rs/pull/1136
[#1139]: https://github.com/stackabletech/operator-rs/pull/1139