### PR TITLE
chore: Release stackable-operator 0.103.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.102.0"
+version = "0.103.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.103.0] - 2026-01-16
+
 ### Changed
 
 - BREAKING: Add support for the SSH protocol for pulling git content ([#1121]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.102.0"
+version = "0.103.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

### Changed

- BREAKING: Add support for the SSH protocol for pulling git content ([#1121]).
  This is a user-facing breaking change and should also be highlighted by operators using this functionality.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
