### PR TITLE
chore: Release stackable-operator 0.104.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.103.0"
+version = "0.104.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.104.0] - 2026-01-26
+
 ### Added
 
 - Add `serviceOverrides` field of type `Service` to `ListenerClass.spec.serviceOverrides` ([#1142]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.103.0"
+version = "0.104.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Added

- Add `serviceOverrides` field of type `Service` to `ListenerClass.spec.serviceOverrides` ([#1142]).

### Changed

- BREAKING: `ListenerClassSpec` no longer implements `Eq` ([#1142]).

[#1142]: https://github.com/stackabletech/operator-rs/pull/1142
