### PR TITLE
fix(stackable-operator): Persist the Vector state in the log directory

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Store the Vector state in the log directory to ensure it persists across container restarts ([#1149]).
+
+[#1149]: https://github.com/stackabletech/operator-rs/pull/1149
+
 ## [0.105.0] - 2026-02-03
 
 ### Added

--- a/crates/stackable-operator/src/product_logging/framework.rs
+++ b/crates/stackable-operator/src/product_logging/framework.rs
@@ -21,18 +21,26 @@ use crate::{
 
 /// Config directory used in the Vector log agent container
 const STACKABLE_CONFIG_DIR: &str = "/stackable/config";
+
 /// Directory in the Vector container which contains a subdirectory for every container which
 /// themselves contain the corresponding log files
 const STACKABLE_LOG_DIR: &str = "/stackable/log";
+
 /// Subdirectory of the log directory containing files to control the Vector instance
 const VECTOR_LOG_DIR: &str = "_vector";
+
+/// Subdirectory of the log directory containing the Vector state data
+const VECTOR_STATE_DIR: &str = "_vector-state";
+
 /// File to signal that Vector should be gracefully shut down
 const SHUTDOWN_FILE: &str = "shutdown";
 
 /// File name of the Vector config file
 pub const VECTOR_CONFIG_FILE: &str = "vector.yaml";
+
 /// Key in the discovery ConfigMap that holds the vector aggregator address
 const VECTOR_AGGREGATOR_CM_KEY: &str = "ADDRESS";
+
 /// Name of the env var in the vector container that holds the vector aggregator address
 const VECTOR_AGGREGATOR_ENV_NAME: &str = "VECTOR_AGGREGATOR_ADDRESS";
 
@@ -705,7 +713,7 @@ where
     };
 
     format!(
-        r#"data_dir: /stackable/vector/var
+        r#"data_dir: {STACKABLE_LOG_DIR}/{VECTOR_STATE_DIR}
 
 log_schema:
   host_key: pod
@@ -1436,6 +1444,7 @@ pub fn vector_container(
         // exec vector --config {STACKABLE_CONFIG_DIR}/{VECTOR_CONFIG_FILE}
         .args(vec![format!(
             "\
+mkdir --parents {STACKABLE_LOG_DIR}/{VECTOR_STATE_DIR}
 # Vector will ignore SIGTERM (as PID != 1) and must be shut down by writing a shutdown trigger file
 vector --config {STACKABLE_CONFIG_DIR}/{VECTOR_CONFIG_FILE} & vector_pid=$!
 if [ ! -f \"{STACKABLE_LOG_DIR}/{VECTOR_LOG_DIR}/{SHUTDOWN_FILE}\" ]; then


### PR DESCRIPTION
# Description

Store the Vector state in the log directory to ensure it persists across container restarts.

Part of stackabletech/issues#821

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] HDFS integration tests passed

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
