### PR TITLE
fix(stackable-telemetry): Disable ANSI colors when stdout is not a terminal

### DIFF
--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Only use ANSI escape sequences if stdout is a terminal/tty. Piping the output to a file will now
+  result in plain text log messages ([#1183]).
+
+[#1183]: https://github.com/stackabletech/operator-rs/pull/1183
+
 ## [0.6.2] - 2026-03-09
 
 ### Fixed

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! To get started, see [`Tracing`].
 
-use std::{ops::Not, path::PathBuf};
+use std::{io::IsTerminal, ops::Not, path::PathBuf};
 
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
@@ -432,15 +432,21 @@ impl Tracing {
 
             // NOTE (@NickLarsenNZ): There is no elegant way to build the layer depending on formats because the types
             // returned from each subscriber "modifier" function is different (sometimes with different generics).
+            // tracing-subscriber does not auto-detect whether stdout is a terminal
+            // (https://github.com/tokio-rs/tracing/issues/1160), so we check explicitly.
+            let use_ansi = std::io::stdout().is_terminal();
+
             match log_format {
                 Format::Plain => {
-                    let console_output_layer =
-                        tracing_subscriber::fmt::layer().with_filter(env_filter_layer);
+                    let console_output_layer = tracing_subscriber::fmt::layer()
+                        .with_ansi(use_ansi)
+                        .with_filter(env_filter_layer);
                     layers.push(console_output_layer.boxed());
                 }
                 Format::Json => {
                     let console_output_layer = tracing_subscriber::fmt::layer()
                         .json()
+                        .with_ansi(use_ansi)
                         .with_filter(env_filter_layer);
                     layers.push(console_output_layer.boxed());
                 }


### PR DESCRIPTION
## Summary

- Only emit ANSI escape codes in console log output when stdout is actually a terminal
- Applies to both `Plain` and `Json` console log formats

## Problem

`tracing_subscriber::fmt::layer()` enables ANSI colors by default whenever the `ansi` feature is enabled and `NO_COLOR` is unset ([source](https://docs.rs/tracing-subscriber/0.3.23/src/tracing_subscriber/fmt/fmt_layer.rs.html#743)):

```rust
let ansi = cfg!(feature = "ansi") && env::var("NO_COLOR").map_or(true, |v| v.is_empty());
```

There is no automatic TTY detection — this is a [known upstream issue](https://github.com/tokio-rs/tracing/issues/1160) open since 2021. As a result, containerdebug (and any other consumer of stackable-telemetry) emits raw ANSI codes when running in containers where logs are collected by aggregation systems like Graylog or Vector:

```
[2m2026-03-29T18:26:23.658052Z[0m [32m INFO[0m [1mcontainerdebug run[0m...
```

## Fix

Explicitly check `std::io::stdout().is_terminal()` before configuring the subscriber, so ANSI is only used when writing to an actual terminal.

## Test plan

- [x] `cargo check -p stackable-telemetry` passes
- [x] Verify in a terminal: colored output still works
- [x] Verify in a container/pipe: ANSI codes are suppressed