### PR TITLE
chore: Release stackable-operator 0.110.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.109.0"
+version = "0.110.0"
 dependencies = [
  "base64",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.110.0] - 2026-04-10
+
 ### Added
 
 - Add generic database connection mechanism ([#1163]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.109.0"
+version = "0.110.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Added

- Add generic database connection mechanism ([#1163]).
- Add `config_overrides` module with `KeyValueOverridesProvider` trait, enabling
  structured config file formats (e.g. JSON) in addition to key-value overrides ([#1177]).
- Add `Scaler` CRD ([#1190], [#1195]).

### Changed

- BREAKING: Change signature of `ContainerBuilder::add_env_vars` from `Vec<EnvVar>` to `IntoIterator<Item = EnvVar>` ([#1163]).
- BREAKING: Remove `EXPERIMENTAL_` prefix in `CONFIG_OVERRIDE_FILE_HEADER_KEY` and `CONFIG_OVERRIDE_FILE_FOOTER_KEY` ([#1191]).
- BREAKING: Bump `kube` from a custom version (`fe69cc486ff8e62a7da61d64ec3ebbd9e64c43b5`, which is between `3.0.1` and `3.1.0`
  and was needed to pull in schema fixes) to `3.1.0`. This means that the CRD schema generation bugs
  [#1934](https://github.com/kube-rs/kube/pull/1934) and [#1942](https://github.com/kube-rs/kube/pull/1942) are fixed ([#1192]).
- BREAKING: Add `ConfigOverrides` type parameter to `CommonConfiguration`, `Role` and `RoleGroup`.
  The `config_overrides` field is now generic instead of `HashMap<String, HashMap<String, String>>` ([#1177]).
- BREAKING: In [#1178] the `clientAuthenticationMethod` was added to the `ClientAuthenticationOptions` struct,
  resulting it to show up in all product CRDs. even those that don't support configuring the client authentication method.
  With this change, operators need to opt-in to the `clientAuthenticationMethod` field by using the new
  `ClientAuthenticationMethodOption` struct for the generic type `ProductSpecificClientAuthenticationOptions` on
  `ClientAuthenticationOptions`. That way the struct definitions (as well as docs etc.) remain in stackable-operator,
  but operators can decide if they want to offer support for this field or not ([#1194]).

[#1163]: https://github.com/stackabletech/operator-rs/pull/1163
[#1177]: https://github.com/stackabletech/operator-rs/pull/1177
[#1190]: https://github.com/stackabletech/operator-rs/pull/1190
[#1191]: https://github.com/stackabletech/operator-rs/pull/1191
[#1192]: https://github.com/stackabletech/operator-rs/pull/1192
[#1194]: https://github.com/stackabletech/operator-rs/pull/1194
[#1195]: https://github.com/stackabletech/operator-rs/pull/1195