### PR TITLE
chore: Release stackable-operator 0.110.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.110.0"
+version = "0.110.1"
 dependencies = [
  "base64",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.110.1] - 2026-04-16
+
 ### Added
 
 - Derive `strum::AsRefStr` for `ClientAuthenticationMethod` ([#1197]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.110.0"
+version = "0.110.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

### Added

- Derive `strum::AsRefStr` for `ClientAuthenticationMethod` (https://github.com/stackabletech/operator-rs/pull/1197)
