### PR TITLE
chore: Release stackable-operator 0.111.0, stackable-versioned 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.110.1"
+version = "0.111.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "convert_case",
  "convert_case_extras",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.111.0] - 2026-04-27
+
 ### Added
 
 - BREAKING: Add CLI argument and env var to set the image repository used to construct final product

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.110.1"
+version = "0.111.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-27
+
 ### Added
 
 - BREAKING: The `versioned` macro now automatically generates tests to test roundtrip converts for

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases stackable-operator 0.111.0 and stackable-versioned 0.10.0:

## stackable-operator 0.111.0

### Added

- BREAKING: Add CLI argument and env var to set the image repository used to construct final product
  image names: `IMAGE_REPOSITORY` (`--image-repository`), eg. `oci.example.org/my/namespace` ([#1199]).

### Changed

- BREAKING: The product image selection mechanism via `ProductImage::resolve` now takes three
  parameters instead of two. The new parameters are: `image_name`, `image_repository`, and
  `operator_version` ([#1199]).

[#1199]: https://github.com/stackabletech/operator-rs/pull/1199

## stackable-versioned 0.10.0

### Added

- BREAKING: The `versioned` macro now automatically generates tests to test roundtrip converts for
  every versioned struct. This requires you to implement the `RoundtripTestData` trait for all
  structs, which returns some test data to be used for the roundtrip tests.
  Read on the `RoundtripTestData` documentation for details ([#1172]).

[#1172]: https://github.com/stackabletech/operator-rs/pull/1172