### PR TITLE
feat(operator): Derive Clone for OperatorEnvironmentOptions

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Derive `Clone` for `OperatorEnvironmentOptions` ([#1203]).
+
+[#1203]: https://github.com/stackabletech/operator-rs/pull/1203
+
 ## [0.111.0] - 2026-04-27
 
 ### Added

--- a/crates/stackable-operator/src/cli/environment.rs
+++ b/crates/stackable-operator/src/cli/environment.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq, clap::Parser)]
+#[derive(Clone, Debug, PartialEq, Eq, clap::Parser)]
 #[command(next_help_heading = "Environment Options")]
 pub struct OperatorEnvironmentOptions {
     /// The namespace the operator is running in, usually `stackable-operators`.


### PR DESCRIPTION
This PR derives `Clone` for `OperatorEnvironmentOptions`.

This came up in the rollout of https://github.com/stackabletech/issues/issues/716 in the superset-operator.