### PR TITLE
feat(operator): Add client-feature-gates gate

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Add `Client::{get_feature_gates,get_enabled_feature_gates,get_disabled_feature_gates}` associated
-  functions to retrieve all, enabled, or disabled feature gates from the Kubernetes apiserver ([#1207]).
+  functions to retrieve all, enabled, or disabled feature gates from the Kubernetes apiserver ([#1207], [#1208]).
 
 ### Changed
 
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 [#1206]: https://github.com/stackabletech/operator-rs/pull/1206
 [#1207]: https://github.com/stackabletech/operator-rs/pull/1207
+[#1208]: https://github.com/stackabletech/operator-rs/pull/1208
 
 ## [0.111.1] - 2026-04-28
 

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 
 [features]
 default = ["crds"]
-full = ["crds", "certs", "time", "webhook", "kube-ws"]
+full = ["client-feature-gates", "crds", "certs", "time", "webhook", "kube-ws"]
 
+client-feature-gates = ["dep:winnow"]
 crds = ["dep:stackable-versioned"]
 certs = ["dep:stackable-certs"]
 time = ["stackable-shared/time"]
@@ -54,7 +55,7 @@ tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
-winnow.workspace = true
+winnow = { workspace = true, optional = true }
 
 [dev-dependencies]
 indoc.workspace = true

--- a/crates/stackable-operator/src/client/feature_gates.rs
+++ b/crates/stackable-operator/src/client/feature_gates.rs
@@ -1,3 +1,5 @@
+//! Provides functions and types to retrieve feature gates from the Kubernetes apiserver.
+
 use std::{collections::HashMap, str::FromStr};
 
 use snafu::{OptionExt as _, ResultExt as _, Snafu};

--- a/crates/stackable-operator/src/client/feature_gates.rs
+++ b/crates/stackable-operator/src/client/feature_gates.rs
@@ -14,7 +14,7 @@ use crate::client::{
 impl Client {
     /// Retrieves and parses all feature gates via a raw request to the `/metrics` endpoint.
     ///
-    /// This list of feature gates in combination with [`KubeClient::apiserver_version`] can be used
+    /// This list of feature gates in combination with [`kube::Client::apiserver_version`] can be used
     /// to enable gated behaviour.
     pub async fn get_feature_gates(&self) -> Result<Vec<FeatureGate>> {
         let request =

--- a/crates/stackable-operator/src/client/mod.rs
+++ b/crates/stackable-operator/src/client/mod.rs
@@ -24,7 +24,8 @@ use crate::{
     utils::cluster_info::{KubernetesClusterInfo, KubernetesClusterInfoOptions},
 };
 
-mod feature_gates;
+#[cfg(feature = "client-feature-gates")]
+pub mod feature_gates;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -92,15 +93,18 @@ pub enum Error {
         source: crate::utils::cluster_info::Error,
     },
 
+    #[cfg(feature = "client-feature-gates")]
     #[snafu(display("failed to create raw {method} request"))]
     CreateRawRequest {
         source: http::Error,
         method: http::Method,
     },
 
+    #[cfg(feature = "client-feature-gates")]
     #[snafu(display("failed to perform raw request"))]
     PerformRawRequest { source: kube::Error },
 
+    #[cfg(feature = "client-feature-gates")]
     #[snafu(display("failed to parse feature gate: {error}"))]
     ParseFeatureGate { error: String },
 }

--- a/crates/stackable-operator/src/client/mod.rs
+++ b/crates/stackable-operator/src/client/mod.rs
@@ -1,3 +1,5 @@
+//! Provides additional functionality on top of [`kube::Client`].
+
 use std::{
     convert::TryFrom,
     fmt::{Debug, Display},


### PR DESCRIPTION
This PR adds a feature gate for changes from #1207.

Users now have to explicitly opt-in to use the new associated functions on `Client` as well as the `FeatureGate` and `FeatureStage` types.