### PR TITLE
chore: Release stackable-shared 0.1.1 and stackable-telemetry 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-shared"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "axum",
  "clap",

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.1] - 2026-02-06
+## [0.1.1] - 2026-06-03
 
 Note: There are only dependency bumps in this release
 

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-02-06
+
+Note: There are only dependency bumps in this release
+
 ## [0.1.0] - 2025-10-06
 
 ### Changed

--- a/crates/stackable-shared/Cargo.toml
+++ b/crates/stackable-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-shared"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.4] - 2026-02-06
+## [0.6.4] - 2026-06-03
 
 Note: There are only dependency bumps in this release
 

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-02-06
+
+Note: There are only dependency bumps in this release
+
 ## [0.6.3] - 2026-03-30
 
 ### Fixed

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.6.3"
+version = "0.6.4"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

Requested in https://github.com/stackabletech/containerdebug/pull/63#discussion_r3268412526

## stackable-shared 0.1.1 - 2026-06-03

Note: There are only dependency bumps in this release

## stackable-telemetry 0.6.4 - 2026-06-03

Note: There are only dependency bumps in this release

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
