### PR TITLE
fix: make missing v2 framework utils pub

### DIFF
--- a/crates/stackable-operator/src/v2/cluster_resources.rs
+++ b/crates/stackable-operator/src/v2/cluster_resources.rs
@@ -1,15 +1,12 @@
-use stackable_operator::{
-    cluster_resources::{ClusterResourceApplyStrategy, ClusterResources},
-    deep_merger::ObjectOverrides,
-    k8s_openapi::api::core::v1::ObjectReference,
-};
-
 use super::types::{
     kubernetes::{NamespaceName, Uid},
     operator::{ClusterName, ControllerName, OperatorName, ProductName},
 };
-use crate::framework::{
-    NameIsValidLabelValue, macros::attributed_string_type::MAX_LABEL_VALUE_LENGTH,
+use crate::{
+    cluster_resources::{ClusterResourceApplyStrategy, ClusterResources},
+    deep_merger::ObjectOverrides,
+    k8s_openapi::api::core::v1::ObjectReference,
+    v2::{NameIsValidLabelValue, macros::attributed_string_type::MAX_LABEL_VALUE_LENGTH},
 };
 
 /// Infallible variant of [`stackable_operator::cluster_resources::ClusterResources::new`]

--- a/crates/stackable-operator/src/v2/controller_utils.rs
+++ b/crates/stackable-operator/src/v2/controller_utils.rs
@@ -3,12 +3,14 @@
 use std::str::FromStr;
 
 use snafu::{OptionExt, ResultExt, Snafu};
-use stackable_operator::kube::runtime::reflector::Lookup;
 use strum::{EnumDiscriminants, IntoStaticStr};
 
-use crate::framework::types::{
-    kubernetes::{NamespaceName, Uid},
-    operator::ClusterName,
+use crate::{
+    kube::runtime::reflector::Lookup,
+    v2::types::{
+        kubernetes::{NamespaceName, Uid},
+        operator::ClusterName,
+    },
 };
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -25,17 +27,17 @@ pub enum Error {
 
     #[snafu(display("failed to set the cluster name"))]
     ParseClusterName {
-        source: crate::framework::macros::attributed_string_type::Error,
+        source: crate::v2::macros::attributed_string_type::Error,
     },
 
     #[snafu(display("failed to set the namespace"))]
     ParseNamespace {
-        source: crate::framework::macros::attributed_string_type::Error,
+        source: crate::v2::macros::attributed_string_type::Error,
     },
 
     #[snafu(display("failed to set the UID"))]
     ParseUid {
-        source: crate::framework::macros::attributed_string_type::Error,
+        source: crate::v2::macros::attributed_string_type::Error,
     },
 }
 
@@ -67,13 +69,15 @@ pub fn get_uid(resource: &impl Lookup) -> Result<Uid> {
 
 #[cfg(test)]
 mod tests {
-    use stackable_operator::kube::runtime::reflector::Lookup;
     use uuid::uuid;
 
     use super::{ErrorDiscriminants, get_cluster_name, get_namespace, get_uid};
-    use crate::framework::types::{
-        kubernetes::{NamespaceName, Uid},
-        operator::ClusterName,
+    use crate::{
+        kube::runtime::reflector::Lookup,
+        v2::types::{
+            kubernetes::{NamespaceName, Uid},
+            operator::ClusterName,
+        },
     };
 
     #[derive(Debug, Default)]

--- a/crates/stackable-operator/src/v2/kvp/label.rs
+++ b/crates/stackable-operator/src/v2/kvp/label.rs
@@ -1,12 +1,11 @@
-use stackable_operator::{
+use crate::{
     kube::Resource,
     kvp::{Labels, ObjectLabels},
-};
-
-use crate::framework::{
-    HasName, NameIsValidLabelValue,
-    types::operator::{
-        ControllerName, OperatorName, ProductName, ProductVersion, RoleGroupName, RoleName,
+    v2::{
+        HasName, NameIsValidLabelValue,
+        types::operator::{
+            ControllerName, OperatorName, ProductName, ProductVersion, RoleGroupName, RoleName,
+        },
     },
 };
 
@@ -69,15 +68,15 @@ pub fn role_group_selector(
 mod tests {
     use std::{borrow::Cow, collections::BTreeMap};
 
-    use stackable_operator::{
-        k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta, kube::Resource,
-    };
-
-    use crate::framework::{
-        HasName, NameIsValidLabelValue,
-        kvp::label::{recommended_labels, role_group_selector, role_selector},
-        types::operator::{
-            ControllerName, OperatorName, ProductName, ProductVersion, RoleGroupName, RoleName,
+    use crate::{
+        k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
+        kube::Resource,
+        v2::{
+            HasName, NameIsValidLabelValue,
+            kvp::label::{recommended_labels, role_group_selector, role_selector},
+            types::operator::{
+                ControllerName, OperatorName, ProductName, ProductVersion, RoleGroupName, RoleName,
+            },
         },
     };
 
@@ -87,7 +86,7 @@ mod tests {
 
     impl Cluster {
         fn new() -> Self {
-            Cluster {
+            Self {
                 object_meta: ObjectMeta {
                     name: Some("cluster-name".to_owned()),
                     ..ObjectMeta::default()

--- a/crates/stackable-operator/src/v2/mod.rs
+++ b/crates/stackable-operator/src/v2/mod.rs
@@ -1,8 +1,12 @@
 use crate::v2::types::kubernetes::Uid;
 
 pub mod builder;
+pub mod cluster_resources;
 pub mod config_overrides;
+pub mod controller_utils;
+pub mod kvp;
 pub mod macros;
+pub mod product_logging;
 pub mod role_group_utils;
 pub mod role_utils;
 pub mod types;

--- a/crates/stackable-operator/src/v2/product_logging/framework.rs
+++ b/crates/stackable-operator/src/v2/product_logging/framework.rs
@@ -1,9 +1,12 @@
 use std::{fmt::Display, str::FromStr};
 
 use snafu::{OptionExt, ResultExt, Snafu};
-use stackable_operator::{
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+use crate::{
     builder::pod::{container::FieldPathEnvVar, resources::ResourceRequirementsBuilder},
     commons::product_image_selection::ResolvedProductImage,
+    constant,
     k8s_openapi::api::core::v1::{Container, VolumeMount},
     product_logging::{
         framework::VECTOR_CONFIG_FILE,
@@ -12,12 +15,7 @@ use stackable_operator::{
             ContainerLogConfigChoice, CustomContainerLogConfig, LogLevel, Logging,
         },
     },
-};
-use strum::{EnumDiscriminants, IntoStaticStr};
-
-use crate::{
-    constant,
-    framework::{
+    v2::{
         builder::pod::container::{EnvVarName, EnvVarSet, new_container_builder},
         role_group_utils,
         types::kubernetes::{ConfigMapKey, ConfigMapName, ContainerName, VolumeName},
@@ -54,7 +52,7 @@ pub enum Error {
 
     #[snafu(display("failed to parse the container name"))]
     ParseContainerName {
-        source: crate::framework::macros::attributed_string_type::Error,
+        source: crate::v2::macros::attributed_string_type::Error,
     },
 }
 
@@ -63,7 +61,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Validated [`ContainerLogConfigChoice`]
 ///
 /// The ConfigMap name in the Custom variant is valid.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ValidatedContainerLogConfigChoice {
     Automatic(AutomaticContainerLogConfig),
     Custom(ConfigMapName),
@@ -72,7 +70,7 @@ pub enum ValidatedContainerLogConfigChoice {
 /// Validated [`ContainerLogConfigChoice`] for the Vector container
 ///
 /// It includes the discovery ConfigMap name of the Vector aggregator.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VectorContainerLogConfig {
     pub log_config: ValidatedContainerLogConfigChoice,
     pub vector_aggregator_config_map_name: ConfigMapName,
@@ -81,14 +79,14 @@ pub struct VectorContainerLogConfig {
 /// Validates the log configuration of the container
 pub fn validate_logging_configuration_for_container<T>(
     logging: &Logging<T>,
-    container: T,
+    container: &T,
 ) -> Result<ValidatedContainerLogConfigChoice>
 where
     T: Clone + Display + Ord,
 {
     let container_log_config_choice = logging
         .containers
-        .get(&container)
+        .get(container)
         .and_then(|container_log_config| container_log_config.choice.as_ref())
         // This should never happen because default configurations should have been set for all
         // containers.
@@ -111,6 +109,7 @@ where
 }
 
 /// Builds the Vector container
+#[expect(clippy::too_many_lines)]
 pub fn vector_container(
     container_name: &ContainerName,
     image: &ResolvedProductImage,
@@ -152,7 +151,7 @@ pub fn vector_container(
         .with_value(&EnvVarName::from_str_unsafe("LOG_DIR"), STACKABLE_LOG_DIR)
         .with_field_path(
             &EnvVarName::from_str_unsafe("NAMESPACE"),
-            FieldPathEnvVar::Namespace,
+            &FieldPathEnvVar::Namespace,
         )
         .with_value(
             &EnvVarName::from_str_unsafe("ROLE_GROUP_NAME"),
@@ -235,27 +234,26 @@ pub fn vector_container(
 mod tests {
     use std::str::FromStr;
 
-    use pretty_assertions::assert_eq;
     use serde_json::json;
-    use stackable_operator::{
+
+    use super::{
+        ErrorDiscriminants, ValidatedContainerLogConfigChoice, VectorContainerLogConfig,
+        validate_logging_configuration_for_container, vector_container,
+    };
+    use crate::{
         commons::product_image_selection::ResolvedProductImage,
         kvp::LabelValue,
         product_logging::spec::{
             AutomaticContainerLogConfig, ConfigMapLogConfig, ContainerLogConfig,
             ContainerLogConfigChoice, CustomContainerLogConfig, Logging,
         },
-    };
-
-    use super::{
-        ErrorDiscriminants, ValidatedContainerLogConfigChoice, VectorContainerLogConfig,
-        validate_logging_configuration_for_container, vector_container,
-    };
-    use crate::framework::{
-        builder::pod::container::{EnvVarName, EnvVarSet},
-        role_group_utils,
-        types::{
-            kubernetes::{ConfigMapName, ContainerName, VolumeName},
-            operator::{ClusterName, RoleGroupName, RoleName},
+        v2::{
+            builder::pod::container::{EnvVarName, EnvVarSet},
+            role_group_utils,
+            types::{
+                kubernetes::{ConfigMapName, ContainerName, VolumeName},
+                operator::{ClusterName, RoleGroupName, RoleName},
+            },
         },
     };
 
@@ -276,7 +274,7 @@ mod tests {
 
         assert_eq!(
             ValidatedContainerLogConfigChoice::Automatic(AutomaticContainerLogConfig::default()),
-            validate_logging_configuration_for_container(&logging, "container")
+            validate_logging_configuration_for_container(&logging, &"container")
                 .expect("should be a valid log config")
         );
     }
@@ -302,7 +300,7 @@ mod tests {
             ValidatedContainerLogConfigChoice::Custom(ConfigMapName::from_str_unsafe(
                 "valid-config-map-name"
             )),
-            validate_logging_configuration_for_container(&logging, "container")
+            validate_logging_configuration_for_container(&logging, &"container")
                 .expect("should be a valid log config")
         );
     }
@@ -320,7 +318,7 @@ mod tests {
 
         assert_eq!(
             Err(ErrorDiscriminants::GetContainerLogConfiguration),
-            validate_logging_configuration_for_container(&logging_without_container, "container")
+            validate_logging_configuration_for_container(&logging_without_container, &"container")
                 .map_err(ErrorDiscriminants::from)
         );
 
@@ -328,7 +326,7 @@ mod tests {
             Err(ErrorDiscriminants::GetContainerLogConfiguration),
             validate_logging_configuration_for_container(
                 &logging_without_container_log_config_choice,
-                "container"
+                &"container"
             )
             .map_err(ErrorDiscriminants::from)
         );
@@ -353,12 +351,13 @@ mod tests {
 
         assert_eq!(
             Err(ErrorDiscriminants::ParseContainerName),
-            validate_logging_configuration_for_container(&logging, "container")
+            validate_logging_configuration_for_container(&logging, &"container")
                 .map_err(ErrorDiscriminants::from)
         );
     }
 
     #[test]
+    #[expect(clippy::too_many_lines)]
     fn test_vector_container() {
         let image = ResolvedProductImage {
             product_version: "1.0.0".to_owned(),


### PR DESCRIPTION
# Description

- export missing v2 framework functionality

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
