### PR TITLE
Change KeyValueConfigOverrides to `BTreeMap<String, String>`

### DIFF
--- a/crates/stackable-operator/src/v2/config_overrides.rs
+++ b/crates/stackable-operator/src/v2/config_overrides.rs
@@ -15,9 +15,6 @@ use crate::{
 // Variant of [`crate::config_overrides::KeyValueConfigOverrides`] that implements
 // Merge
 /// Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-///
-/// This is backwards-compatible with the existing flat key-value YAML format
-/// used by `HashMap<String, String>`.
 #[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct KeyValueConfigOverrides {
     #[serde(flatten)]

--- a/crates/stackable-operator/src/v2/config_overrides.rs
+++ b/crates/stackable-operator/src/v2/config_overrides.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, btree_map},
+    mem,
+};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -15,11 +18,54 @@ use crate::{
 ///
 /// This is backwards-compatible with the existing flat key-value YAML format
 /// used by `HashMap<String, String>`.
-#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, Merge, PartialEq, Serialize)]
-#[merge(path_overrides(merge = "crate::config::merge"))]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 pub struct KeyValueConfigOverrides {
     #[serde(flatten)]
-    pub overrides: BTreeMap<String, Option<String>>,
+    pub overrides: BTreeMap<String, String>,
+}
+
+impl<'a> KeyValueConfigOverrides {
+    pub fn iter(&'a self) -> btree_map::Iter<'a, String, String> {
+        self.into_iter()
+    }
+}
+
+impl Merge for KeyValueConfigOverrides {
+    fn merge(&mut self, defaults: &Self) {
+        let mut overrides = defaults.overrides.clone();
+        overrides.extend(mem::take(&mut self.overrides));
+        self.overrides = overrides;
+    }
+}
+
+impl IntoIterator for KeyValueConfigOverrides {
+    type IntoIter = btree_map::IntoIter<String, String>;
+    type Item = (String, String);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.overrides.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a KeyValueConfigOverrides {
+    type IntoIter = btree_map::Iter<'a, String, String>;
+    type Item = (&'a String, &'a String);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.overrides.iter()
+    }
+}
+
+impl<K, V, const N: usize> From<[(K, V); N]> for KeyValueConfigOverrides
+where
+    K: Into<String>,
+    V: Into<String>,
+{
+    fn from(value: [(K, V); N]) -> Self {
+        Self {
+            overrides: value.map(|(k, v)| (k.into(), v.into())).into(),
+        }
+    }
 }
 
 // Variant of [`crate::config_overrides::JsonConfigOverrides`] with the following
@@ -398,7 +444,7 @@ mod tests {
     #[test]
     fn test_json_config_overrides_from_key_value_config_overrides() {
         let key_value_config_overrides = KeyValueConfigOverrides {
-            overrides: [("key".to_owned(), Some("value".to_owned()))].into(),
+            overrides: [("key".to_owned(), "value".to_owned())].into(),
         };
 
         let actual_json_config_overrides: JsonConfigOverrides = key_value_config_overrides.into();
@@ -413,7 +459,7 @@ mod tests {
     fn test_json_config_overrides_from_json_or_key_value_config_overrides() {
         let key_value_config_overrides =
             JsonOrKeyValueConfigOverrides::KeyValue(KeyValueConfigOverrides {
-                overrides: [("key".to_owned(), Some("value".to_owned()))].into(),
+                overrides: [("key".to_owned(), "value".to_owned())].into(),
             });
 
         let actual_json_config_overrides: JsonConfigOverrides = key_value_config_overrides.into();
@@ -427,11 +473,11 @@ mod tests {
     #[test]
     fn test_json_or_key_value_config_overrides_merge() {
         let base = JsonOrKeyValueConfigOverrides::KeyValue(KeyValueConfigOverrides {
-            overrides: [("key".to_owned(), Some("base".to_owned()))].into(),
+            overrides: [("key".to_owned(), "base".to_owned())].into(),
         });
 
         let patch = JsonOrKeyValueConfigOverrides::KeyValue(KeyValueConfigOverrides {
-            overrides: [("key".to_owned(), Some("patch".to_owned()))].into(),
+            overrides: [("key".to_owned(), "patch".to_owned())].into(),
         });
 
         // The merge implementation internally converts KeyValueConfigOverrides to

--- a/crates/stackable-operator/src/v2/role_utils.rs
+++ b/crates/stackable-operator/src/v2/role_utils.rs
@@ -260,7 +260,7 @@ mod tests {
         let mut cli_overrides = BTreeMap::new();
 
         if let Some(value) = override_value {
-            config_file_overrides.insert("property".to_owned(), Some(value.to_owned()));
+            config_file_overrides.insert("property".to_owned(), value.to_owned());
             env_overrides.insert("PROPERTY".to_owned(), value.to_owned());
             cli_overrides.insert("--property".to_owned(), value.to_owned());
         }


### PR DESCRIPTION
# Description

Change KeyValueConfigOverrides to `BTreeMap<String, String>` and add `IntoIterator` implementations.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
