### PR TITLE
Fix: make rolegroup replicas optional

### DIFF
--- a/crates/stackable-operator/src/v2/role_utils.rs
+++ b/crates/stackable-operator/src/v2/role_utils.rs
@@ -44,12 +44,11 @@ pub struct JavaCommonConfig {
 /// Variant of [`crate::role_utils::RoleGroup`] that is easier to work with
 ///
 /// Differences are:
-/// * `replicas` is non-optional.
 /// * `config` is flattened.
 /// * The [`HashMap`] in `env_overrides` is replaced with an [`EnvVarSet`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct RoleGroupConfig<Config, CommonConfig, ConfigOverrides> {
-    pub replicas: u16,
+    pub replicas: Option<u16>,
     pub config: Config,
     pub config_overrides: ConfigOverrides,
     pub env_overrides: EnvVarSet,


### PR DESCRIPTION
# Description

- make v2 rolegroup replicas optional again to keep existing behavior and possible HPA support.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
