### PR TITLE
docs: Add documentation for the roleGroups CRD field.

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Add `Client::{get_feature_gates,get_enabled_feature_gates,get_disabled_feature_gates}` associated
   functions to retrieve all, enabled, or disabled feature gates from the Kubernetes apiserver ([#1207], [#1208]).
 - Add a new `v2` module that provides more type-safe variants of the existing functions ([#1225]).
+- Add documentation for the `roleGroups` field, which now shows up as a description in the generated CRDs ([#1227]).
 
 ### Changed
 
@@ -18,6 +19,7 @@ All notable changes to this project will be documented in this file.
 [#1207]: https://github.com/stackabletech/operator-rs/pull/1207
 [#1208]: https://github.com/stackabletech/operator-rs/pull/1208
 [#1225]: https://github.com/stackabletech/operator-rs/pull/1225
+[#1227]: https://github.com/stackabletech/operator-rs/pull/1227
 
 ## [0.111.1] - 2026-04-28
 

--- a/crates/stackable-operator/crds/DummyCluster.yaml
+++ b/crates/stackable-operator/crds/DummyCluster.yaml
@@ -1751,6 +1751,21 @@ spec:
                           nullable: true
                           type: integer
                       type: object
+                    description: |-
+                      The set of role groups for this role, keyed by their name.
+
+                      A role group is a subset of the replicas of a role that share the same configuration,
+                      allowing finer-grained control than the role level. This is useful to e.g. schedule groups
+                      onto different classes of nodes or into different regions, or to run them with different
+                      settings. Configuration set on a role group is merged on top of the role-level `config`,
+                      with the more specific role group values taking precedence.
+
+                      Every role needs at least one role group. A role with a single role group conventionally
+                      names it `default`.
+
+                      Read the
+                      [roles and role groups concept documentation](https://docs.stackable.tech/home/nightly/concepts/roles-and-role-groups)
+                      for more details.
                     type: object
                 required:
                 - roleGroups

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -327,6 +327,20 @@ pub struct Role<
     #[serde(default)]
     pub role_config: RoleConfig,
 
+    /// The set of role groups for this role, keyed by their name.
+    ///
+    /// A role group is a subset of the replicas of a role that share the same configuration,
+    /// allowing finer-grained control than the role level. This is useful to e.g. schedule groups
+    /// onto different classes of nodes or into different regions, or to run them with different
+    /// settings. Configuration set on a role group is merged on top of the role-level `config`,
+    /// with the more specific role group values taking precedence.
+    ///
+    /// Every role needs at least one role group. A role with a single role group conventionally
+    /// names it `default`.
+    ///
+    /// Read the
+    /// [roles and role groups concept documentation](DOCS_BASE_URL_PLACEHOLDER/concepts/roles-and-role-groups)
+    /// for more details.
     pub role_groups: HashMap<String, RoleGroup<Config, CommonConfig, ConfigOverrides>>,
 }
 


### PR DESCRIPTION
# Description

The generated CRDs don't show documentation for roleGroups. This is mostly taken from the current docs roles concept page.
I ran the `typos` tool and it stumbled over something that was just committed today - I decided to fix the typo here as well, fyi @siegfriedweber 