### PR TITLE
chore: Release stackable-operator 0.113.0, stackable-versioned 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.112.0"
+version = "0.113.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "convert_case",
  "convert_case_extras",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.113.0] - 2026-06-22
+
 ### Added
 
 - Add documentation for the `roleGroups` field, which now shows up as a description in the generated CRDs ([#1227]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.112.0"
+version = "0.113.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-22
+
 ### Added
 
 - BREAKING: Add a required `#[versioned(crd(doc = "..."))]` argument that sets the root

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases stackable-operator 0.113.0 and stackable-versioned 0.11.0:

# stackable-operator

## [0.113.0] - 2026-06-22

### Added

- Add documentation for the `roleGroups` field, which now shows up as a description in the generated CRDs ([#1227]).
- Add root descriptions to all CRDs defined in this crate (`AuthenticationClass`, `Listener`,
  `ListenerClass`, `PodListeners`, `S3Bucket`, `S3Connection`, `Scaler`), now that the `versioned`
  macro requires a `doc` argument ([#1228]).

### Changed

- BREAKING: Bump to kube `4.0.0`, k8s-openapi `0.28.0` and enable the Kubernetes 1.36 feature ([#1224]).

# stackable-versioned

## [0.11.0] - 2026-06-22

### Added

- BREAKING: Add a required `#[versioned(crd(doc = "..."))]` argument that sets the root
  description of the generated CRD. It is required so that every CRD carries a meaningful
  description instead of the generic auto-generated one ([#1228]).