### PR TITLE
fix: Restore colored logs, strip ANSI escape codes in Vector agent

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -12,10 +12,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Strip ANSI escape codes (e.g. colors) from captured shell stdout/stderr in the generated Vector
-  agent config, so they no longer show up as garbled text in log aggregators such as OpenSearch ([#XXX]).
+  agent config, so they no longer show up as garbled text in log aggregators such as OpenSearch ([#1237]).
 
 [#1209]: https://github.com/stackabletech/operator-rs/pull/1209
-[#XXX]: https://github.com/stackabletech/operator-rs/pull/XXX
+[#1237]: https://github.com/stackabletech/operator-rs/pull/1237
 
 ## [0.113.0] - 2026-06-22
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -9,7 +9,13 @@ All notable changes to this project will be documented in this file.
 - Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
   in the `SecretOperatorVolumeSourceBuilder` ([#1209]).
 
+### Fixed
+
+- Strip ANSI escape codes (e.g. colors) from captured shell stdout/stderr in the generated Vector
+  agent config, so they no longer show up as garbled text in log aggregators such as OpenSearch ([#XXX]).
+
 [#1209]: https://github.com/stackabletech/operator-rs/pull/1209
+[#XXX]: https://github.com/stackabletech/operator-rs/pull/XXX
 
 ## [0.113.0] - 2026-06-22
 

--- a/crates/stackable-operator/src/product_logging/framework.rs
+++ b/crates/stackable-operator/src/product_logging/framework.rs
@@ -924,6 +924,11 @@ transforms:
     source: |
       .logger = "ROOT"
       .level = "INFO"
+      # containers capture raw stdout, which can contain ANSI escape codes (colors) emitted by the
+      # tools they run (e.g. containerdebug, cert-tools). These codes are unreadable in log
+      # aggregators such as OpenSearch, so we strip them here. On failure (e.g. non-string message)
+      # we keep the original message untouched.
+      .message = strip_ansi_escape_codes(.message) ?? .message
 
   processed_files_stderr:
     inputs:
@@ -932,6 +937,8 @@ transforms:
     source: |
       .logger = "ROOT"
       .level = "ERROR"
+      # See above for why we strip ANSI escape codes.
+      .message = strip_ansi_escape_codes(.message) ?? .message
 
   processed_files_log4j:
     inputs:

--- a/crates/stackable-operator/src/product_logging/framework.rs
+++ b/crates/stackable-operator/src/product_logging/framework.rs
@@ -924,7 +924,7 @@ transforms:
     source: |
       .logger = "ROOT"
       .level = "INFO"
-      # containers capture raw stdout, which can contain ANSI escape codes (colors) emitted by the
+      # Containers capture raw stdout, which can contain ANSI escape codes (colors) emitted by the
       # tools they run (e.g. containerdebug, cert-tools). These codes are unreadable in log
       # aggregators such as OpenSearch, so we strip them here. On failure (e.g. non-string message)
       # we keep the original message untouched.

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Revert [#1183], so we again default to ANSI escape sequences, which can be turned off using
-  `NO_COLOR=1` ([#XXXX]).
+  `NO_COLOR=1` ([#1237]).
 
-[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
+[#1237]: https://github.com/stackabletech/operator-rs/pull/1237
 
 ## [0.6.4] - 2026-06-03
 

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Revert [#1183], so we again default to ANSI escape sequences, which can be turned off using
-  `NO_COLOR=1` ([#1237]).
+  `NO_COLOR=1`.
+  This way we keep colored logs for human consumption.
+  Instead we adopted the Vector config, so that the Vector sidecar strips ANSI codes ([#1237]).
 
 [#1237]: https://github.com/stackabletech/operator-rs/pull/1237
 

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert [#1183], so we again default to ANSI escape sequences, which can be turned off using
+  `NO_COLOR=1` ([#XXXX]).
+
+[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
+
 ## [0.6.4] - 2026-06-03
 
 Note: There are only dependency bumps in this release

--- a/crates/stackable-telemetry/src/tracing/mod.rs
+++ b/crates/stackable-telemetry/src/tracing/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! To get started, see [`Tracing`].
 
-use std::{io::IsTerminal, ops::Not, path::PathBuf};
+use std::{ops::Not, path::PathBuf};
 
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
@@ -436,21 +436,15 @@ impl Tracing {
 
             // NOTE (@NickLarsenNZ): There is no elegant way to build the layer depending on formats because the types
             // returned from each subscriber "modifier" function is different (sometimes with different generics).
-            // tracing-subscriber does not auto-detect whether stdout is a terminal
-            // (https://github.com/tokio-rs/tracing/issues/1160), so we check explicitly.
-            let use_ansi = std::io::stdout().is_terminal();
-
             match log_format {
                 Format::Plain => {
-                    let console_output_layer = tracing_subscriber::fmt::layer()
-                        .with_ansi(use_ansi)
-                        .with_filter(env_filter_layer);
+                    let console_output_layer =
+                        tracing_subscriber::fmt::layer().with_filter(env_filter_layer);
                     layers.push(console_output_layer.boxed());
                 }
                 Format::Json => {
                     let console_output_layer = tracing_subscriber::fmt::layer()
                         .json()
-                        .with_ansi(use_ansi)
                         .with_filter(env_filter_layer);
                     layers.push(console_output_layer.boxed());
                 }


### PR DESCRIPTION
# Description

Different take on https://github.com/stackabletech/operator-rs/pull/1183

I (once again) run into this when a customer screenshared an operator log and we just saw a big wall of (white) text. Previously I was able to tell immediately if everything is green or not.

To improve this I need to understand the motivation behind the change in https://github.com/stackabletech/operator-rs/pull/1183.

I assume it is the following, but please correct me if I'm wrong:
containerdebug runs in the *product* container and produces ANSI codes. When ingesting that into the vector agent they are kept and end up in OpenSearch/Graylog.

I propose to leave the logs colored (the operators as well as the various tools such as containerdebug or cert-tools). Vector has a built-in function, using that we can strip the ANSI escape codes in the vector sidecar, so they don't end up in OpenSearch/Graylog/whatever.

### Testing

I tested this using the `logging` demo and inspecting the `prepare` container of trino, as it's cert-tools uses ANSI stuff.
This PR worked perfectly fine, colored output in k9s and no weird characters in OpenSearch.
This solution also has the benefit that it works for all tools and not only for the stackable-specifc ones using stackable-telemetry.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Integration tests passed (for non trivial changes) - testing described above
- [x] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
