### PR TITLE
chore: Bump Rust version and workflow actions

### DIFF
--- a/.github/workflows/daily_security.yml
+++ b/.github/workflows/daily_security.yml
@@ -12,7 +12,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -15,10 +15,11 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
+
       - uses: stackabletech/actions/run-prek@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/.github/workflows/pr_prek.yaml
+++ b/.github/workflows/pr_prek.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN_VERSION: "nightly-2026-02-24"
+  RUST_TOOLCHAIN_VERSION: "nightly-2026-07-01"
 
 permissions: {}
 

--- a/.github/workflows/pr_security-checks.yml
+++ b/.github/workflows/pr_security-checks.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           key: udeps
 
-      - run: cargo install --locked cargo-udeps@0.1.60
+      - run: cargo install --locked cargo-udeps@0.1.61
       - run: cargo udeps --all-targets --all-features
 
   cargo-deny:

--- a/.github/workflows/pr_security-checks.yml
+++ b/.github/workflows/pr_security-checks.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
-  RUST_TOOLCHAIN_VERSION: "1.93.0"
+  RUST_TOOLCHAIN_VERSION: "1.95.0"
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
   RUST_LOG: "info"
@@ -28,8 +28,8 @@ jobs:
           persist-credentials: false
       - name: Install rust toolchain
         run: |
-            rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
-            rustup default "${RUST_TOOLCHAIN_VERSION}"
+          rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
+          rustup default "${RUST_TOOLCHAIN_VERSION}"
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           key: udeps
@@ -54,8 +54,8 @@ jobs:
           persist-credentials: false
       - name: Install rust toolchain
         run: |
-            rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
-            rustup default "${RUST_TOOLCHAIN_VERSION}"
+          rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
+          rustup default "${RUST_TOOLCHAIN_VERSION}"
       - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/pr_security-checks.yml
+++ b/.github/workflows/pr_security-checks.yml
@@ -23,16 +23,19 @@ jobs:
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Install rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
           rustup default "${RUST_TOOLCHAIN_VERSION}"
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: udeps
+
       - run: cargo install --locked cargo-udeps@0.1.60
       - run: cargo udeps --all-targets --all-features
 
@@ -49,13 +52,15 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Install rust toolchain
         run: |
           rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
           rustup default "${RUST_TOOLCHAIN_VERSION}"
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
+
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -38,7 +38,7 @@ jobs:
         run: echo '<meta http-equiv="refresh" content="0;url=stackable_operator/index.html">' > target/doc/index.html
 
       - name: Upload Documentation Artifacts
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: target/doc
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to Github Pages
         id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ on:
       - crates/**
 
 env:
-  RUST_TOOLCHAIN_VERSION: "1.93.0"
+  RUST_TOOLCHAIN_VERSION: "1.95.0"
 
 permissions: {}
 
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install rust toolchain
         run: |
-            rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
-            rustup default "${RUST_TOOLCHAIN_VERSION}"
+          rustup toolchain install "${RUST_TOOLCHAIN_VERSION}"
+          rustup default "${RUST_TOOLCHAIN_VERSION}"
 
       - name: Build Crate Docs
         run: cargo doc --no-deps --all-features

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -172,7 +172,7 @@ repos:
         name: cargo-rustfmt
         language: system
         # Pinning to a specific rustc version, so that we get consistent formatting
-        entry: cargo +nightly-2026-02-24 fmt --all -- --check
+        entry: cargo +nightly-2026-07-01 fmt --all -- --check
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "rust-analyzer.imports.granularity.group": "crate",
   "rust-analyzer.rustfmt.overrideCommand": [
     "rustfmt",
-    "+nightly-2026-02-24",
+    "+nightly-2026-07-01",
     "--edition",
     "2024",
     "--"


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-rs/issues/1234.

This bumps both the stable and nightly toolchains.