### PR TITLE
chore: Release workspace members for 26.7.0

### DIFF
--- a/.scripts/verify_crate_versions.sh
+++ b/.scripts/verify_crate_versions.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 # Eg: makes a list like this based on the latest release in the CHANGELOG.md files:
+# containerdebug-0.4.1
 # k8s-version-0.1.1
 # stackable-certs-0.3.1
 # stackable-operator-0.70.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "containerdebug"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "built",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.113.0"
+version = "0.113.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "insta",
  "k8s-openapi",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-versioned-macros"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "convert_case",
  "convert_case_extras",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-webhook"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stackable-certs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "const-oid",
  "ecdsa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-shared"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "jiff",
  "k8s-openapi",

--- a/crates/containerdebug/CHANGELOG.md
+++ b/crates/containerdebug/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-07-02
+## [0.4.1] - 2026-07-06
 
 Note: There are only dependency bumps in this release.
 

--- a/crates/containerdebug/CHANGELOG.md
+++ b/crates/containerdebug/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-02
+
+Note: There are only dependency bumps in this release.
+
 ## [0.4.0] - 2026-05-19
 
 ### Changed

--- a/crates/containerdebug/Cargo.toml
+++ b/crates/containerdebug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerdebug"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 
 [dependencies]

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-07-02
+## [0.4.1] - 2026-07-06
 
 Note: There are only dependency bumps in this release.
 

--- a/crates/stackable-certs/CHANGELOG.md
+++ b/crates/stackable-certs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-02
+
+Note: There are only dependency bumps in this release.
+
 ## [0.4.0] - 2025-07-10
 
 ### Added

--- a/crates/stackable-certs/Cargo.toml
+++ b/crates/stackable-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-certs"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.113.1] - 2026-07-02
+## [0.113.1] - 2026-07-06
 
 ### Added
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.113.1] - 2026-07-02
+
 ### Added
 
 - Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.113.0"
+version = "0.113.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.2] - 2027-07-02
+
+Note: There are only dependency bumps in this release.
+
 ## [0.1.1] - 2026-06-03
 
-Note: There are only dependency bumps in this release
+Note: There are only dependency bumps in this release.
 
 ## [0.1.0] - 2025-10-06
 

--- a/crates/stackable-shared/CHANGELOG.md
+++ b/crates/stackable-shared/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.2] - 2027-07-02
+## [0.1.2] - 2026-07-06
 
 Note: There are only dependency bumps in this release.
 

--- a/crates/stackable-shared/Cargo.toml
+++ b/crates/stackable-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-shared"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-telemetry/CHANGELOG.md
+++ b/crates/stackable-telemetry/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-06-03
+
+Note: There are only dependency bumps in this release.
+
 ## [0.6.4] - 2026-06-03
 
-Note: There are only dependency bumps in this release
+Note: There are only dependency bumps in this release.
 
 ## [0.6.3] - 2026-03-30
 

--- a/crates/stackable-telemetry/Cargo.toml
+++ b/crates/stackable-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-telemetry"
-version = "0.6.4"
+version = "0.6.5"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned-macros/Cargo.toml
+++ b/crates/stackable-versioned-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned-macros"
-version = "0.11.0"
+version = "0.11.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-versioned/.pre-commit-config.yaml
+++ b/crates/stackable-versioned/.pre-commit-config.yaml
@@ -9,7 +9,9 @@ repos:
       - id: cargo-doc
         name: cargo-doc
         language: system
-        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --document-private-items --package stackable-versioned
+        env:
+          K8S_OPENAPI_ENABLED_VERSION: "1.36"
+        entry: cargo doc --no-deps --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
@@ -17,7 +19,9 @@ repos:
       - id: cargo-doc-no-default-features
         name: cargo-doc-no-default-features
         language: system
-        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --no-default-features --document-private-items --package stackable-versioned
+        env:
+          K8S_OPENAPI_ENABLED_VERSION: "1.36"
+        entry: cargo doc --no-deps --no-default-features --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
@@ -25,7 +29,9 @@ repos:
       - id: cargo-doc-all-features
         name: cargo-doc-all-features
         language: system
-        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --all-features --document-private-items --package stackable-versioned
+        env:
+          K8S_OPENAPI_ENABLED_VERSION: "1.36"
+        entry: cargo doc --no-deps --all-features --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
@@ -39,7 +45,7 @@ repos:
         files: .*\.rs$|Cargo\.toml
 
       - id: cargo-test-all-features
-        name: cargo-test-no-default-features
+        name: cargo-test-all-default-features
         language: system
         entry: cargo test --all-features --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]

--- a/crates/stackable-versioned/.pre-commit-config.yaml
+++ b/crates/stackable-versioned/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: cargo-doc
         name: cargo-doc
         language: system
-        entry: cargo doc --no-deps --document-private-items --package stackable-versioned
+        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
@@ -17,7 +17,7 @@ repos:
       - id: cargo-doc-no-default-features
         name: cargo-doc-no-default-features
         language: system
-        entry: cargo doc --no-deps --no-default-features --document-private-items --package stackable-versioned
+        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --no-default-features --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
@@ -25,7 +25,7 @@ repos:
       - id: cargo-doc-all-features
         name: cargo-doc-all-features
         language: system
-        entry: cargo doc --no-deps --all-features --document-private-items --package stackable-versioned
+        entry: K8S_OPENAPI_ENABLED_VERSION="1.36" cargo doc --no-deps --all-features --document-private-items --package stackable-versioned
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.11.1] - 2027-07-02
+## [0.11.1] - 2026-07-06
 
 Note: There are only dependency bumps in this release.
 

--- a/crates/stackable-versioned/CHANGELOG.md
+++ b/crates/stackable-versioned/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.1] - 2027-07-02
+
+Note: There are only dependency bumps in this release.
+
 ## [0.11.0] - 2026-06-22
 
 ### Added

--- a/crates/stackable-versioned/Cargo.toml
+++ b/crates/stackable-versioned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-versioned"
-version = "0.11.0"
+version = "0.11.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.9.2] - 2026-07-02
+## [0.9.2] - 2026-07-06
 
 Note: There are only dependency bumps in this release.
 

--- a/crates/stackable-webhook/CHANGELOG.md
+++ b/crates/stackable-webhook/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-07-02
+
+Note: There are only dependency bumps in this release.
+
 ## [0.9.1] - 2026-04-07
 
 ### Changed

--- a/crates/stackable-webhook/Cargo.toml
+++ b/crates/stackable-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackable-webhook"
-version = "0.9.1"
+version = "0.9.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-rs/issues/1234.

## containerdebug 0.4.1

Note: There are only dependency bumps in this release.

## stackable-certs 0.4.1

Note: There are only dependency bumps in this release.

## stackable-operator 0.113.1

### Added
- Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
  in the `SecretOperatorVolumeSourceBuilder` ([#1209]).
- Add `Role::fixed_replica_count` and `Role::estimated_replica_count` helper functions ([#1241]).

[#1209]: https://github.com/stackabletech/operator-rs/pull/1209
[#1241]: https://github.com/stackabletech/operator-rs/pull/1241

[#1209]: https://github.com/stackabletech/operator-rs/pull/1209

## stackable-shared 0.2.1

Note: There are only dependency bumps in this release.

## stackable-telemetry 0.6.5

Note: There are only dependency bumps in this release.

## stackable-versioned 0.11.1

Note: There are only dependency bumps in this release.

## stackable-webhook 0.9.2

Note: There are only dependency bumps in this release.