### PR TITLE
feat(operator): Add `Role::{fixed,estimated}_replica_count`

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
   in the `SecretOperatorVolumeSourceBuilder` ([#1209]).
-- Add `Role::fixed_replica_count` function that returns (optionally) the number of fixed replicas ([#XXXX]).
+- Add `Role::fixed_replica_count` and `Role::estimated_replica_count` helper functions ([#XXXX]).
 
 [#1209]: https://github.com/stackabletech/operator-rs/pull/1209
 [#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,10 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
   in the `SecretOperatorVolumeSourceBuilder` ([#1209]).
-- Add `Role::fixed_replica_count` and `Role::estimated_replica_count` helper functions ([#XXXX]).
+- Add `Role::fixed_replica_count` and `Role::estimated_replica_count` helper functions ([#1241]).
 
 [#1209]: https://github.com/stackabletech/operator-rs/pull/1209
-[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
+[#1241]: https://github.com/stackabletech/operator-rs/pull/1241
 
 ## [0.113.0] - 2026-06-22
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Support the annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
   in the `SecretOperatorVolumeSourceBuilder` ([#1209]).
+- Add `Role::fixed_replica_count` function that returns (optionally) the number of fixed replicas ([#XXXX]).
 
 [#1209]: https://github.com/stackabletech/operator-rs/pull/1209
+[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
 
 ## [0.113.0] - 2026-06-22
 

--- a/crates/stackable-operator/crds/AuthenticationClass.yaml
+++ b/crates/stackable-operator/crds/AuthenticationClass.yaml
@@ -104,7 +104,7 @@ spec:
                                 type: array
                             type: object
                           secretClass:
-                            description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) containing the LDAP bind credentials.'
+                            description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) providing the requested secrets.'
                             type: string
                         required:
                         - secretClass

--- a/crates/stackable-operator/crds/DummyCluster.yaml
+++ b/crates/stackable-operator/crds/DummyCluster.yaml
@@ -1932,7 +1932,7 @@ spec:
                         type: array
                     type: object
                   secretClass:
-                    description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) containing the LDAP bind credentials.'
+                    description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) providing the requested secrets.'
                     type: string
                 required:
                 - secretClass

--- a/crates/stackable-operator/crds/S3Bucket.yaml
+++ b/crates/stackable-operator/crds/S3Bucket.yaml
@@ -93,7 +93,7 @@ spec:
                                 type: array
                             type: object
                           secretClass:
-                            description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) containing the LDAP bind credentials.'
+                            description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) providing the requested secrets.'
                             type: string
                         required:
                         - secretClass

--- a/crates/stackable-operator/crds/S3Connection.yaml
+++ b/crates/stackable-operator/crds/S3Connection.yaml
@@ -77,7 +77,7 @@ spec:
                         type: array
                     type: object
                   secretClass:
-                    description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) containing the LDAP bind credentials.'
+                    description: '[SecretClass](https://docs.stackable.tech/home/nightly/secret-operator/secretclass) providing the requested secrets.'
                     type: string
                 required:
                 - secretClass

--- a/crates/stackable-operator/src/builder/pdb.rs
+++ b/crates/stackable-operator/src/builder/pdb.rs
@@ -154,7 +154,7 @@ impl PodDisruptionBudgetBuilder<ObjectMeta, LabelSelector, ()> {
     /// Mutually exclusive with [`PodDisruptionBudgetBuilder::with_max_unavailable`].
     #[deprecated(
         since = "0.51.0",
-        note = "It is strongly recommended to use [`max_unavailable`]. Please read the ADR on Pod disruptions before using this function."
+        note = "It is strongly recommended to use [`PodDisruptionBudgetBuilder::with_max_unavailable`]. Please read the ADR on Pod disruptions before using this function."
     )]
     pub fn with_min_available(
         self,

--- a/crates/stackable-operator/src/commons/secret_class.rs
+++ b/crates/stackable-operator/src/commons/secret_class.rs
@@ -20,7 +20,7 @@ pub enum SecretClassVolumeError {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SecretClassVolume {
-    /// [SecretClass](DOCS_BASE_URL_PLACEHOLDER/secret-operator/secretclass) containing the LDAP bind credentials.
+    /// [SecretClass](DOCS_BASE_URL_PLACEHOLDER/secret-operator/secretclass) providing the requested secrets.
     pub secret_class: String,
 
     /// [Scope](DOCS_BASE_URL_PLACEHOLDER/secret-operator/scope) of the

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -434,6 +434,18 @@ where
             })
             .sum()
     }
+
+    /// Returns the estimated total number of replicas across all role groups.
+    ///
+    /// Unlike [`Self::fixed_replica_count`], this always returns a value: a role group with an unset
+    /// (i.e. [`None`]) replica count is assumed to run a single replica. Use this when a best-effort
+    /// estimate is needed even though the exact number of replicas is not hard-coded.
+    pub fn estimated_replica_count(&self) -> u32 {
+        self.role_groups
+            .values()
+            .map(|rg| u32::from(rg.replicas.unwrap_or(1)))
+            .sum()
+    }
 }
 
 impl<Config, ConfigOverrides, RoleConfig>
@@ -689,44 +701,49 @@ mod tests {
     }
 
     #[test]
-    fn fixed_replica_count_sums_all_set_replicas() {
+    fn replica_counts_with_all_replicas_set() {
         let role = construct_role_with_replicas([Some(3), Some(2), Some(5)]);
 
         assert_eq!(role.fixed_replica_count(false), Some(10));
         assert_eq!(role.fixed_replica_count(true), Some(10));
+        assert_eq!(role.estimated_replica_count(), 10);
     }
 
     #[test]
-    fn fixed_replica_count_is_none_if_any_replica_is_unset() {
+    fn replica_counts_with_one_replica_unset() {
         let role = construct_role_with_replicas([Some(3), None, Some(2)]);
 
         assert_eq!(role.fixed_replica_count(false), None);
         assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.estimated_replica_count(), 6);
     }
 
     #[test]
-    fn fixed_replica_count_treats_zero_according_to_flag() {
+    fn replica_counts_with_a_zero_replica() {
         let role = construct_role_with_replicas([Some(3), Some(0)]);
 
         assert_eq!(role.fixed_replica_count(false), Some(3));
         // With treat_zero_as_none the zero turns the whole count into None.
         assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.estimated_replica_count(), 3);
     }
 
     #[test]
-    fn fixed_replica_count_of_single_zero_role_group() {
+    fn replica_counts_with_a_single_zero_role_group() {
         let role = construct_role_with_replicas([Some(0)]);
 
         assert_eq!(role.fixed_replica_count(false), Some(0));
         assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.estimated_replica_count(), 0);
     }
 
     #[test]
-    fn fixed_replica_count_of_role_without_role_groups_is_zero() {
+    fn replica_counts_without_role_groups() {
         let role = construct_role_with_replicas(vec![]);
 
         assert_eq!(role.fixed_replica_count(false), Some(0));
         assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.estimated_replica_count(), 0);
     }
 
     /// Builds a [`Role`] with one role group per passed `replicas` entry, so tests only need to

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -418,12 +418,11 @@ where
     /// The argument `zero_replicas_counting` is a safety mechanism, which allows the caller to
     /// decide if an explicit replica count of `0` should be treated as [`None`]. It also means that
     /// [`None`] is returned in case no roleGroups are configured at all.
-    pub fn fixed_replica_count(
-        &self,
-        zero_replicas_counting: ZeroReplicasCounting,
-    ) -> Option<u32> {
+    pub fn fixed_replica_count(&self, zero_replicas_counting: ZeroReplicasCounting) -> Option<u32> {
         // An empty role has no fixed replica count when zeros are treated as None.
-        if zero_replicas_counting == ZeroReplicasCounting::TreatAsNone && self.role_groups.is_empty() {
+        if zero_replicas_counting == ZeroReplicasCounting::TreatAsNone
+            && self.role_groups.is_empty()
+        {
             return None;
         }
 
@@ -716,8 +715,14 @@ mod tests {
     fn replica_counts_with_all_replicas_set() {
         let role = construct_role_with_replicas([Some(3), Some(2), Some(5)]);
 
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(10));
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), Some(10));
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero),
+            Some(10)
+        );
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone),
+            Some(10)
+        );
         assert_eq!(role.estimated_replica_count(), 10);
     }
 
@@ -725,8 +730,14 @@ mod tests {
     fn replica_counts_with_one_replica_unset() {
         let role = construct_role_with_replicas([Some(3), None, Some(2)]);
 
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), None);
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero),
+            None
+        );
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone),
+            None
+        );
         assert_eq!(role.estimated_replica_count(), 6);
     }
 
@@ -734,9 +745,15 @@ mod tests {
     fn replica_counts_with_a_zero_replica() {
         let role = construct_role_with_replicas([Some(3), Some(0)]);
 
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(3));
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero),
+            Some(3)
+        );
         // With treat_zero_as_none the zero turns the whole count into None.
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone),
+            None
+        );
         assert_eq!(role.estimated_replica_count(), 3);
     }
 
@@ -744,8 +761,14 @@ mod tests {
     fn replica_counts_with_a_single_zero_role_group() {
         let role = construct_role_with_replicas([Some(0)]);
 
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(0));
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero),
+            Some(0)
+        );
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone),
+            None
+        );
         assert_eq!(role.estimated_replica_count(), 0);
     }
 
@@ -753,8 +776,14 @@ mod tests {
     fn replica_counts_without_role_groups() {
         let role = construct_role_with_replicas(vec![]);
 
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(0));
-        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero),
+            Some(0)
+        );
+        assert_eq!(
+            role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone),
+            None
+        );
         assert_eq!(role.estimated_replica_count(), 0);
     }
 

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -403,6 +403,39 @@ where
     }
 }
 
+impl<Config, ConfigOverrides, RoleConfig, CommonConfig>
+    Role<Config, ConfigOverrides, RoleConfig, CommonConfig>
+where
+    RoleConfig: Default + JsonSchema + Serialize,
+    CommonConfig: Default + JsonSchema + Serialize,
+    ConfigOverrides: Default + JsonSchema + Serialize,
+{
+    /// Returns [`Some<u32>`] in case the number of nodes is hard-coded to a certain value.
+    ///
+    /// This is the case when all `replicas` are set to [`Some<u16>`], in which case they are simply
+    /// summed.
+    ///
+    /// The argument `treat_zero_as_none` is a safety mechanism, which allows the caller to decide
+    /// if an explicit replica count of `0` should be treated as [`None`]. It also means that
+    /// [`None`] is returned in case no roleGroups are configured at all.
+    pub fn fixed_replica_count(&self, treat_zero_as_none: bool) -> Option<u32> {
+        // An empty role has no fixed replica count when zeros are treated as None.
+        if treat_zero_as_none && self.role_groups.is_empty() {
+            return None;
+        }
+
+        self.role_groups
+            .values()
+            .map(|rg| match rg.replicas {
+                None => None,
+                Some(0) if treat_zero_as_none => None,
+                // The individual replicas are [`u16`]s, so a [`u32`] sum has plenty of space.
+                Some(replicas) => Some(u32::from(replicas)),
+            })
+            .sum()
+    }
+}
+
 impl<Config, ConfigOverrides, RoleConfig>
     Role<Config, ConfigOverrides, RoleConfig, JavaCommonConfig>
 where
@@ -653,5 +686,70 @@ mod tests {
                 "-Xms3m".to_owned()
             ]
         );
+    }
+
+    #[test]
+    fn fixed_replica_count_sums_all_set_replicas() {
+        let role = construct_role_with_replicas([Some(3), Some(2), Some(5)]);
+
+        assert_eq!(role.fixed_replica_count(false), Some(10));
+        assert_eq!(role.fixed_replica_count(true), Some(10));
+    }
+
+    #[test]
+    fn fixed_replica_count_is_none_if_any_replica_is_unset() {
+        let role = construct_role_with_replicas([Some(3), None, Some(2)]);
+
+        assert_eq!(role.fixed_replica_count(false), None);
+        assert_eq!(role.fixed_replica_count(true), None);
+    }
+
+    #[test]
+    fn fixed_replica_count_treats_zero_according_to_flag() {
+        let role = construct_role_with_replicas([Some(3), Some(0)]);
+
+        assert_eq!(role.fixed_replica_count(false), Some(3));
+        // With treat_zero_as_none the zero turns the whole count into None.
+        assert_eq!(role.fixed_replica_count(true), None);
+    }
+
+    #[test]
+    fn fixed_replica_count_of_single_zero_role_group() {
+        let role = construct_role_with_replicas([Some(0)]);
+
+        assert_eq!(role.fixed_replica_count(false), Some(0));
+        assert_eq!(role.fixed_replica_count(true), None);
+    }
+
+    #[test]
+    fn fixed_replica_count_of_role_without_role_groups_is_zero() {
+        let role = construct_role_with_replicas(vec![]);
+
+        assert_eq!(role.fixed_replica_count(false), Some(0));
+        assert_eq!(role.fixed_replica_count(true), None);
+    }
+
+    /// Builds a [`Role`] with one role group per passed `replicas` entry, so tests only need to
+    /// care about the replica counts that [`Role::fixed_replica_count`] operates on.
+    fn construct_role_with_replicas(
+        replicas: impl IntoIterator<Item = Option<u16>>,
+    ) -> Role<(), EmptyConfigOverrides, GenericRoleConfig, GenericCommonConfig> {
+        Role {
+            config: CommonConfiguration::default(),
+            role_config: GenericRoleConfig::default(),
+            role_groups: replicas
+                .into_iter()
+                .enumerate()
+                .map(|(index, replicas)| {
+                    (
+                        format!("role-group-{index}"),
+                        RoleGroup {
+                            config: CommonConfiguration::default(),
+                            replicas,
+                        },
+                    )
+                })
+                .collect(),
+        }
     }
 }

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -410,7 +410,7 @@ where
     CommonConfig: Default + JsonSchema + Serialize,
     ConfigOverrides: Default + JsonSchema + Serialize,
 {
-    /// Returns [`Some<u32>`] in case the number of nodes is hard-coded to a certain value.
+    /// Returns [`Some<u32>`] in case the number of replicas is hard-coded to a certain value.
     ///
     /// This is the case when all `replicas` are set to [`Some<u16>`], in which case they are simply
     /// summed.

--- a/crates/stackable-operator/src/role_utils.rs
+++ b/crates/stackable-operator/src/role_utils.rs
@@ -415,12 +415,15 @@ where
     /// This is the case when all `replicas` are set to [`Some<u16>`], in which case they are simply
     /// summed.
     ///
-    /// The argument `treat_zero_as_none` is a safety mechanism, which allows the caller to decide
-    /// if an explicit replica count of `0` should be treated as [`None`]. It also means that
+    /// The argument `zero_replicas_counting` is a safety mechanism, which allows the caller to
+    /// decide if an explicit replica count of `0` should be treated as [`None`]. It also means that
     /// [`None`] is returned in case no roleGroups are configured at all.
-    pub fn fixed_replica_count(&self, treat_zero_as_none: bool) -> Option<u32> {
+    pub fn fixed_replica_count(
+        &self,
+        zero_replicas_counting: ZeroReplicasCounting,
+    ) -> Option<u32> {
         // An empty role has no fixed replica count when zeros are treated as None.
-        if treat_zero_as_none && self.role_groups.is_empty() {
+        if zero_replicas_counting == ZeroReplicasCounting::TreatAsNone && self.role_groups.is_empty() {
             return None;
         }
 
@@ -428,7 +431,7 @@ where
             .values()
             .map(|rg| match rg.replicas {
                 None => None,
-                Some(0) if treat_zero_as_none => None,
+                Some(0) if zero_replicas_counting == ZeroReplicasCounting::TreatAsNone => None,
                 // The individual replicas are [`u16`]s, so a [`u32`] sum has plenty of space.
                 Some(replicas) => Some(u32::from(replicas)),
             })
@@ -446,6 +449,15 @@ where
             .map(|rg| u32::from(rg.replicas.unwrap_or(1)))
             .sum()
     }
+}
+
+/// How explicit zero (`0`) replicas on a role group should be counted
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ZeroReplicasCounting {
+    /// Treat them as what they are: `Some(0)`.
+    TreatAsZero,
+    /// Treat them as if the user configured [`None`].
+    TreatAsNone,
 }
 
 impl<Config, ConfigOverrides, RoleConfig>
@@ -704,8 +716,8 @@ mod tests {
     fn replica_counts_with_all_replicas_set() {
         let role = construct_role_with_replicas([Some(3), Some(2), Some(5)]);
 
-        assert_eq!(role.fixed_replica_count(false), Some(10));
-        assert_eq!(role.fixed_replica_count(true), Some(10));
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(10));
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), Some(10));
         assert_eq!(role.estimated_replica_count(), 10);
     }
 
@@ -713,8 +725,8 @@ mod tests {
     fn replica_counts_with_one_replica_unset() {
         let role = construct_role_with_replicas([Some(3), None, Some(2)]);
 
-        assert_eq!(role.fixed_replica_count(false), None);
-        assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), None);
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
         assert_eq!(role.estimated_replica_count(), 6);
     }
 
@@ -722,9 +734,9 @@ mod tests {
     fn replica_counts_with_a_zero_replica() {
         let role = construct_role_with_replicas([Some(3), Some(0)]);
 
-        assert_eq!(role.fixed_replica_count(false), Some(3));
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(3));
         // With treat_zero_as_none the zero turns the whole count into None.
-        assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
         assert_eq!(role.estimated_replica_count(), 3);
     }
 
@@ -732,8 +744,8 @@ mod tests {
     fn replica_counts_with_a_single_zero_role_group() {
         let role = construct_role_with_replicas([Some(0)]);
 
-        assert_eq!(role.fixed_replica_count(false), Some(0));
-        assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(0));
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
         assert_eq!(role.estimated_replica_count(), 0);
     }
 
@@ -741,8 +753,8 @@ mod tests {
     fn replica_counts_without_role_groups() {
         let role = construct_role_with_replicas(vec![]);
 
-        assert_eq!(role.fixed_replica_count(false), Some(0));
-        assert_eq!(role.fixed_replica_count(true), None);
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsZero), Some(0));
+        assert_eq!(role.fixed_replica_count(ZeroReplicasCounting::TreatAsNone), None);
         assert_eq!(role.estimated_replica_count(), 0);
     }
 


### PR DESCRIPTION
# Description

Needed for https://github.com/stackabletech/nifi-operator/pull/953, we can then also use it in https://github.com/stackabletech/trino-operator/blob/3158402b23edde1633b2639eb50c67bb1b41889c/rust/operator-binary/src/crd/mod.rs#L918

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
