### PR TITLE
fix: add raw_object_schema to JsonConfigOverrides

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add `raw_object_schema` to v2 `JsonConfigOverrides` ([#1242]).
+
+[#1242]: https://github.com/stackabletech/operator-rs/pull/1242
+
 ## [0.113.1] - 2026-07-06
 
 ### Added

--- a/crates/stackable-operator/src/v2/config_overrides.rs
+++ b/crates/stackable-operator/src/v2/config_overrides.rs
@@ -78,6 +78,7 @@ where
 pub enum JsonConfigOverrides {
     /// Can be set to arbitrary YAML content, which is converted to JSON and used as
     /// [RFC 7396](https://datatracker.ietf.org/doc/html/rfc7396) JSON merge patch.
+    #[schemars(schema_with = "raw_object_schema")]
     JsonMergePatch(serde_json::Value),
 
     /// An [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) JSON patch.
@@ -92,9 +93,11 @@ pub enum JsonConfigOverrides {
     /// or
     ///
     /// `- {"op": "add", "path": "/0/happy", "value": true}`
+    #[schemars(schema_with = "raw_object_schema")]
     JsonPatch(json_patch::Patch),
 
     /// Override the entire config file with the specified JSON value.
+    #[schemars(schema_with = "raw_object_schema")]
     UserProvided(serde_json::Value),
 
     /// Sequence of [`JsonConfigOverrides`] starting with the latest patch


### PR DESCRIPTION
# Description

- add raw_object_schema to v2 JsonConfigOverrides

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
