### PR TITLE
fix(v2): Don't require macro callers to have `std::str::FromStr` in scope

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.113.3] - 2026-07-07
-
 ### Fixed
 
 - [v2]: Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#1244]).

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.113.3] - 2026-07-07
+
 ### Fixed
 
-- [v2]: Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#XXXX]).
+- [v2]: Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#1244]).
 
-[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
+[#1244]: https://github.com/stackabletech/operator-rs/pull/1244
 
 ## [0.113.2] - 2026-07-07
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- [v2]: Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#XXXX]).
+
+[#XXXX]: https://github.com/stackabletech/operator-rs/pull/XXXX
+
 ## [0.113.2] - 2026-07-07
 
 ### Added
 
-- Add `raw_object_schema` to v2 `JsonConfigOverrides` ([#1242]).
+- [v2] Add `raw_object_schema` to `JsonConfigOverrides` ([#1242]).
 
 [#1242]: https://github.com/stackabletech/operator-rs/pull/1242
 

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- [v2]: Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#1244]).
+- [v2] Don't require the `attributed_string_type` macro caller to have `std::str::FromStr` in scope ([#1244]).
 
 [#1244]: https://github.com/stackabletech/operator-rs/pull/1244
 

--- a/crates/stackable-operator/src/v2/builder/pod/container.rs
+++ b/crates/stackable-operator/src/v2/builder/pod/container.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, btree_map},
-    str::FromStr,
-};
+use std::collections::{BTreeMap, btree_map};
 
 use snafu::Snafu;
 use strum::{EnumDiscriminants, IntoStaticStr};

--- a/crates/stackable-operator/src/v2/macros/attributed_string_type.rs
+++ b/crates/stackable-operator/src/v2/macros/attributed_string_type.rs
@@ -150,7 +150,7 @@ macro_rules! attributed_string_type {
                 D: serde::Deserializer<'de>,
             {
                 let string: String = serde::Deserialize::deserialize(deserializer)?;
-                $name::from_str(&string).map_err(|err| serde::de::Error::custom(&err))
+                <$name as std::str::FromStr>::from_str(&string).map_err(|err| serde::de::Error::custom(&err))
             }
         }
 

--- a/crates/stackable-operator/src/v2/types/kubernetes.rs
+++ b/crates/stackable-operator/src/v2/types/kubernetes.rs
@@ -1,6 +1,4 @@
 //! Kubernetes (resource) names
-use std::str::FromStr;
-
 use crate::{
     attributed_string_type,
     validation::{RFC_1123_LABEL_MAX_LENGTH, RFC_1123_SUBDOMAIN_MAX_LENGTH},

--- a/crates/stackable-operator/src/v2/types/operator.rs
+++ b/crates/stackable-operator/src/v2/types/operator.rs
@@ -1,7 +1,5 @@
 //! Names for operators
 
-use std::str::FromStr;
-
 use crate::attributed_string_type;
 
 attributed_string_type! {


### PR DESCRIPTION
# Description

Fixes

```bash
error[E0599]: no function or associated item named `from_str` found for struct `TrinoCatalogName` in the current scope
   --> rust/operator-binary/src/crd/catalog/mod.rs:136:1
    |
136 | / attributed_string_type! {
137 | |     TrinoCatalogName,
138 | |     "The name of a TrinoCluster",
139 | |     "lakehouse",
...   |
147 | |     is_valid_label_value
148 | | }
    | | ^
    | | |
    | |_function or associated item not found in `TrinoCatalogName`
    |   function or associated item `from_str` not found for this struct
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `attributed_string_type` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `FromStr` which provides `from_str` is implemented but not in scope; perhaps you want to import it
    |
  1 + use std::str::FromStr;
    |
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
