### PR TITLE
chore: fix typo and drop removed --short flag in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,10 +33,10 @@ body:
     attributes:
       label: Environment
       description: |
-        What type of kubernetes cluster you are running aginst (k3s/eks/aks/gke/other) and any other information about your environment?
+        What type of kubernetes cluster you are running against (k3s/eks/aks/gke/other) and any other information about your environment?
       placeholder: |
         Examples:
-        Output of `kubectl version --short`
+        Output of `kubectl version`
 
   - type: dropdown
     attributes:


### PR DESCRIPTION
Two cosmetic fixes to the bug report issue form

- Fix typo "aginst" -> "against" in the Environment field.
- The Environment placeholder suggests `kubectl version --short`, but the `--short` flag was removed from kubectl (1.28+). Suggest plain `kubectl version`.