### PR TITLE
chore: Release stackable-operator 0.114.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.113.4"
+version = "0.114.0"
 dependencies = [
  "base64",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.114.0] - 2026-07-22
+
 ### Added
 
 - [v2] Add `EnvVarSet::with_env_var` to add a given `EnvVar` to the set ([#1249]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.113.4"
+version = "0.114.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR releases stackable-operator 0.114.0:

## [0.114.0] - 2026-07-22

### Added

- [v2] Add `EnvVarSet::with_env_var` to add a given `EnvVar` to the set ([#1249]).
- [v2] Add `rbac::build_service_account` and `rbac::build_role_binding`, the infallible variant of `commons::rbac::build_rbac_resources` based on typed names and owner references ([#1251]).

### Changed

- [v2] BREAKING: Converting an `EnvVarSet` into a `Vec<EnvVar>` takes dependencies between environment variables into account ([#1249]).

### Removed

- [v2] BREAKING: Remove dependency to product-config and the product_config_utils module ([#1252]).