### PR TITLE
fix: Add Deployment to delete_orphaned_resources

### DIFF
--- a/crates/stackable-operator/src/cluster_resources.rs
+++ b/crates/stackable-operator/src/cluster_resources.rs
@@ -668,6 +668,7 @@ impl<'a> ClusterResources<'a> {
             self.delete_orphaned_resources_of_kind::<Service>(client),
             self.delete_orphaned_resources_of_kind::<StatefulSet>(client),
             self.delete_orphaned_resources_of_kind::<DaemonSet>(client),
+            self.delete_orphaned_resources_of_kind::<Deployment>(client),
             self.delete_orphaned_resources_of_kind::<Job>(client),
             self.delete_orphaned_resources_of_kind::<ConfigMap>(client),
             self.delete_orphaned_resources_of_kind::<Secret>(client),


### PR DESCRIPTION
Allowing OPA being a deployment, we should take care of orphaned deployment clean-ups as it will be possible to switch from `Deployment` to `DaemonSet`

Fixup of https://github.com/stackabletech/operator-rs/pull/992