### PR TITLE
chore: Release stackable-operator `0.115.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "base64 0.23.0",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.115.0] - 2026-08-04
+
 ### Changed
 
 - BREAKING: `PodSecurityContextBuilder::new` was removed in favor of `PodSecurityContextBuilder::with_stackable_defaults`

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.114.0"
+version = "0.115.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION

### Changed

- BREAKING: `PodSecurityContextBuilder::new` was removed in favor of `PodSecurityContextBuilder::with_stackable_defaults`
  (same for `SecurityContextBuilder`) ([#1205]).
  This function already sets up some defaults we want to use across the platform.
  Currently this is `runAsNonRoot: true` for `PodSecurityContextBuilder`, which might cause product Pods to crash and require changes.
- BREAKING: `PodSecurityContextBuilder::run_as_non_root` now takes a `bool` instead of assuming consumers always want to set it to `true` ([#1205]).
  This is needed to allow users setting it to `false` in case the new `with_stackable_defaults` function sets it to `true`.
- BREAKING: `SecurityContextBuilder::run_as_root` has been removed ([#1205]).
- BREAKING: Bump `kube` to `4.2.0` ([#1257]).
  - This fixes a long-standing issue, where `additionalPrinterColumns`, `categories` and `shortNames` where always included in the CRD, which lead to ArgoCD thinking the CRs where out of sync.

[#1205]: https://github.com/stackabletech/operator-rs/pull/1205
[#1257]: https://github.com/stackabletech/operator-rs/pull/1257
