### PR TITLE
chore: Release stackable-operator 0.116.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.115.0"
+version = "0.116.0"
 dependencies = [
  "base64 0.23.0",
  "clap",

--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.116.0] - 2026-08-14
+
 ### Added
 
 - Add the Cargo feature `kube-cel` that enables the `cel` feature on the `kube` crate ([#1259]).

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stackable-operator"
 description = "Stackable Operator Framework"
-version = "0.115.0"
+version = "0.116.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
# Description

## Added

- Add the Cargo feature `kube-cel` that enables the `cel` feature on the `kube` crate ([#1259]).
- Add `length_enforcement::ensure_max_string_length` and `Key::shortened_to_valid_length` helper functions ([#1260]).

## Changed

- BREAKING: [v2] Improve functions for recommended labels in `v2::kvp::label` ([#1261]).
- BREAKING: [v2] `env_overrides` in `v2::role_utils::CommonConfiguration` is now the new
  `v2::env_overrides::EnvOverrides` type (a `BTreeMap<EnvVarName, String>`) instead of a
  `HashMap<String, String>`, so environment variable names are validated on deserialization and
  kept in a deterministic order ([#1262]).
  `v2::role_utils` now defines its own `CommonConfiguration`, `Role` and `RoleGroup` instead of
  re-exporting them from `crate::role_utils`.