### PR TITLE
feat: Add `kube-http-proxy` and `kube-socks5` Cargo features

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add the Cargo features `kube-http-proxy` and `kube-socks5` that enable the `http-proxy` and `socks5` features on the `kube` crate ([#1269]).
+
 ### Changed
 
 - BREAKING: `ClusterResources` now warns about `objectOverrides` entries that did not match any of the objects it created.  To enable this, the signatures of `apply_deep_merge` and `ObjectOverrides::apply_to` needed to be adjusted ([#1264]).
 
 [#1264]: https://github.com/stackabletech/operator-rs/pull/1264
+[#1269]: https://github.com/stackabletech/operator-rs/pull/1269
 
 ## [0.116.0] - 2026-08-14
 

--- a/crates/stackable-operator/Cargo.toml
+++ b/crates/stackable-operator/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [features]
 default = ["crds"]
-full = ["client-feature-gates", "crds", "certs", "test-support", "time", "webhook", "kube-ws", "kube-cel"]
+full = ["client-feature-gates", "crds", "certs", "test-support", "time", "webhook", "kube-ws", "kube-cel", "kube-http-proxy", "kube-socks5"]
 
 client-feature-gates = ["dep:winnow"]
 crds = ["dep:stackable-versioned"]
@@ -19,6 +19,8 @@ time = ["stackable-shared/time"]
 webhook = ["dep:stackable-webhook"]
 kube-ws = ["kube/ws"]
 kube-cel = ["kube/cel"]
+kube-http-proxy = ["kube/http-proxy"]
+kube-socks5 = ["kube/socks5"]
 
 [dependencies]
 stackable-certs = { path = "../stackable-certs", optional = true }


### PR DESCRIPTION
# Description

The default features are unchanged.
This allows us to enable these features in stackablectl (and elsewhere). Instead of ignoring a HTTP(S)_PROXY variable kube just refuses to build a client if it sees them but not the feature.

We moved stackablectl to a direct dependency on operator-rs in March via https://github.com/stackabletech/stackablectl/pull/426
That PR unfortunately also dropped support for HTTP/SOCKS proxy. I cannot find any evidence of this being a concious choice.

When this is merged and released we can enable the feature in stackablectl.

Reported on Discord: https://discordapp.com/channels/796665978481803304/1078284084247265300/1544734994856026193

## Definition of Done Checklist

### Reviewer

- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
