### PR TITLE
fix(operator): Add missing SecurityContextBuilder::build function

### DIFF
--- a/crates/stackable-operator/CHANGELOG.md
+++ b/crates/stackable-operator/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add missing `SecurityContextBuilder::build` associated function ([#1271]).
+
+[#1271]: https://github.com/stackabletech/operator-rs/pull/1271
+
 ## [0.117.0] - 2026-09-03
 
 ### Added

--- a/crates/stackable-operator/src/builder/pod/security.rs
+++ b/crates/stackable-operator/src/builder/pod/security.rs
@@ -9,6 +9,8 @@ pub struct SecurityContextBuilder {
     security_context: SecurityContext,
 }
 
+// FIXME (@Techassi): These associated function should take `self`` instead of `&mut self` for
+// better chainability.
 impl SecurityContextBuilder {
     /// Construct a new [`SecurityContextBuilder`] that is pre-filled with Stackable's defaults.
     ///

--- a/crates/stackable-operator/src/builder/pod/security.rs
+++ b/crates/stackable-operator/src/builder/pod/security.rs
@@ -412,6 +412,34 @@ mod tests {
 
     #[test]
     fn security_context_builder() {
+        // NOTE (@Techassi): We cannot efficiently chain functions because of the function signatures.
+        // See FIXME above.
+        let mut builder = SecurityContextBuilder::with_stackable_defaults();
+        builder
+            .allow_privilege_escalation(false)
+            .privileged(false)
+            .read_only_root_filesystem(true)
+            .run_as_non_root(true)
+            .run_as_user(1001)
+            .run_as_group(1001);
+        let context = builder.build();
+
+        assert_eq!(
+            context,
+            SecurityContext {
+                allow_privilege_escalation: Some(false),
+                privileged: Some(false),
+                read_only_root_filesystem: Some(true),
+                run_as_non_root: Some(true),
+                run_as_user: Some(1001),
+                run_as_group: Some(1001),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn pod_security_context_builder() {
         let mut builder = PodSecurityContextBuilder::with_stackable_defaults();
         let context = builder
             .fs_group(1000)

--- a/crates/stackable-operator/src/builder/pod/security.rs
+++ b/crates/stackable-operator/src/builder/pod/security.rs
@@ -9,7 +9,7 @@ pub struct SecurityContextBuilder {
     security_context: SecurityContext,
 }
 
-// FIXME (@Techassi): These associated function should take `self`` instead of `&mut self` for
+// FIXME (@Techassi): These associated functions should take `self` instead of `&mut self` for
 // better chainability.
 impl SecurityContextBuilder {
     /// Construct a new [`SecurityContextBuilder`] that is pre-filled with Stackable's defaults.

--- a/crates/stackable-operator/src/builder/pod/security.rs
+++ b/crates/stackable-operator/src/builder/pod/security.rs
@@ -143,6 +143,11 @@ impl SecurityContextBuilder {
         wo.run_as_user_name = Some(name.into());
         self
     }
+
+    /// Consumes the builder and returns the configured [`SecurityContext`].
+    pub fn build(self) -> SecurityContext {
+        self.security_context
+    }
 }
 
 /// A builder to construct a [`PodSecurityContext`].


### PR DESCRIPTION
This was discovered when I implemented <https://github.com/stackabletech/stackablectl/pull/453> and had to deal with the `SecurityContextBuilder` changes from <https://github.com/stackabletech/operator-rs/pull/1205>.
